### PR TITLE
Fix form types loading error in reports

### DIFF
--- a/spa/reports.js
+++ b/spa/reports.js
@@ -272,12 +272,16 @@ case 'participant-age':
 
 					const response = await getFormSubmissions(null, formType); // Fetch submissions for all participants for the selected form type
 
-					if (!response) {
+					if (!response || !response.data) {
 							throw new Error('No form submissions found');
 					}
 
-					const formStructure = await getFormStructure(formType); // Get the form structure based on the selected form type
-					const missingFieldsReport = this.generateMissingFieldsReport(response, formStructure, formType);
+					const formStructure = await getFormStructure(); // Get all form structures
+					if (!formStructure || !formStructure.data) {
+							throw new Error('No form structure found');
+					}
+
+					const missingFieldsReport = this.generateMissingFieldsReport(response.data, formStructure.data, formType);
 
 					return missingFieldsReport;
 			} catch (error) {


### PR DESCRIPTION
- Add missing /api/form-submissions endpoint as alias for /api/form-submissions-list
- Modify /api/organization-form-formats to return data structured by form_type for easier lookup
- Fix reports.js to properly extract data from API responses using .data property
- Add proper error handling for missing form submissions and structures

This resolves the "erreur de chargement des types de formulaire" and "Endpoint not found" errors on the /reports page.