### PR TITLE
Fix DOM element access before rendering in FormManager

### DIFF
--- a/spa/modules/FormManager.js
+++ b/spa/modules/FormManager.js
@@ -113,10 +113,20 @@ export class FormManager {
          */
         setReminder(reminder) {
                 this.reminder = reminder;
-                if (reminder) {
-                        document.getElementById('reminder-text').value = reminder.reminder_text;
-                        document.getElementById('reminder-date').value = reminder.reminder_date;
-                        document.getElementById('recurring-reminder').checked = reminder.is_recurring;
+        }
+
+        /**
+         * Populate reminder form (to be called after DOM is rendered)
+         */
+        populateReminderForm() {
+                if (this.reminder) {
+                        const reminderTextEl = document.getElementById('reminder-text');
+                        const reminderDateEl = document.getElementById('reminder-date');
+                        const recurringReminderEl = document.getElementById('recurring-reminder');
+
+                        if (reminderTextEl) reminderTextEl.value = this.reminder.reminder_text || '';
+                        if (reminderDateEl) reminderDateEl.value = this.reminder.reminder_date || '';
+                        if (recurringReminderEl) recurringReminderEl.checked = this.reminder.is_recurring || false;
                 }
         }
 

--- a/spa/preparation_reunions.js
+++ b/spa/preparation_reunions.js
@@ -53,6 +53,9 @@ export class PreparationReunions {
                         this.currentMeetingData = currentMeeting;
                         await this.formManager.populateForm(currentMeeting, this.dateManager.getCurrentDate());
 
+                        // Populate reminder form after DOM is rendered
+                        this.formManager.populateReminderForm();
+
                         // Attach event listeners
                         this.attachEventListeners();
                 } catch (error) {
@@ -173,6 +176,7 @@ export class PreparationReunions {
                 this.currentMeetingData = newMeetingData;
                 this.render();
                 await this.formManager.populateForm(newMeetingData, this.dateManager.getCurrentDate());
+                this.formManager.populateReminderForm();
                 this.attachEventListeners();
         }
 


### PR DESCRIPTION
- Split setReminder into two methods: setReminder (stores data) and populateReminderForm (populates DOM elements)
- Call populateReminderForm after page rendering to avoid null reference errors
- Fixes TypeError: Cannot set properties of null error when loading page