### PR TITLE
Fix Points Management and Meeting Date Issues

### DIFF
--- a/spa/api/api-endpoints.js
+++ b/spa/api/api-endpoints.js
@@ -901,7 +901,10 @@ export async function getParticipantCalendar(participantId) {
  * Get reunion preparation for a date
  */
 export async function getReunionPreparation(date) {
-    return API.get('reunion-preparation', { date });
+    return API.get('reunion-preparation', { date }, {
+        cacheKey: `reunion_preparation_${date}`,
+        cacheDuration: CONFIG.CACHE_DURATION.MEDIUM
+    });
 }
 
 /**

--- a/spa/attendance.js
+++ b/spa/attendance.js
@@ -583,10 +583,13 @@ console.log(groupHeader, participantRow);
 
   async changeDate(newDate) {
     this.currentDate = newDate;
-    document.getElementById("dateSelect").value = this.currentDate;
     console.log(`Changing date to ${this.currentDate}`);
-    await this.preloadAttendanceData();
-    this.updateAttendanceUIForDate();
+    // Fetch fresh data for the new date
+    await this.fetchData();
+    // Re-render the entire view with new data
+    this.render();
+    // Re-attach event listeners
+    this.attachEventListeners();
   }
 
   async loadAttendanceForDate(date) {
@@ -604,7 +607,7 @@ console.log(groupHeader, participantRow);
 
   updateAttendanceUIForDate() {
     document.querySelectorAll(".participant-row").forEach((row) => {
-      const participantId = row.dataset.id;
+      const participantId = row.dataset.participantId;
       const statusSpan = row.querySelector(".participant-status");
       const status = this.attendanceData[participantId] || "present";
       const statusClass = status === "present" && !this.attendanceData[participantId] ? "" : status;

--- a/spa/manage_groups.js
+++ b/spa/manage_groups.js
@@ -5,6 +5,7 @@ import {
   updateGroupName,
 } from "./ajax-functions.js";
 import { translate } from "./app.js";
+import { clearGroupRelatedCaches } from "./indexedDB.js";
 
 export class ManageGroups {
   constructor(app) {
@@ -97,6 +98,8 @@ export class ManageGroups {
         const result = await addGroup(groupName);
         this.showMessage(result.message);
         if (result.status === "success") {
+          // Clear all group-related caches
+          await clearGroupRelatedCaches();
           await this.fetchGroups();
           this.render();
           this.attachEventListeners();
@@ -115,6 +118,10 @@ export class ManageGroups {
     try {
       const result = await updateGroupName(groupId, newName);
       this.showMessage(result.message);
+      if (result.status === "success") {
+        // Clear all group-related caches
+        await clearGroupRelatedCaches();
+      }
     } catch (error) {
       console.error("Error:", error);
       this.showMessage(translate("error_updating_group_name"));
@@ -128,6 +135,8 @@ export class ManageGroups {
         const result = await removeGroup(groupId);
         this.showMessage(result.message);
         if (result.status === "success") {
+          // Clear all group-related caches
+          await clearGroupRelatedCaches();
           await this.fetchGroups();
           this.render();
           this.attachEventListeners();

--- a/spa/manage_points.js
+++ b/spa/manage_points.js
@@ -638,6 +638,9 @@ export class ManagePoints {
         </div>
         <div class="group-content">
           ${this.renderParticipantsForGroup(group.id)}
+          <div class="group-points" id="group-points-${group.id}">
+            ${translate("total_points")}: ${group.total_points}
+          </div>
         </div>
       `
       )

--- a/spa/preparation_reunions.js
+++ b/spa/preparation_reunions.js
@@ -8,6 +8,7 @@ import {
         getReunionPreparation,
         fetchFromApi
 } from "./ajax-functions.js";
+import { deleteCachedData } from "./indexedDB.js";
 import { ActivityManager } from "./modules/ActivityManager.js";
 import { FormManager } from "./modules/FormManager.js";
 import { DateManager } from "./modules/DateManager.js";
@@ -390,6 +391,8 @@ export class PreparationReunions {
 
                 try {
                         await saveReunionPreparation(formData);
+                        // Clear the reunion_dates cache so upcoming_meeting page gets fresh data
+                        await deleteCachedData('reunion_dates');
                         this.app.showMessage(translate("reunion_preparation_saved"), "success");
                         await this.fetchAvailableDates();
                 } catch (error) {


### PR DESCRIPTION
- Points Management: Add group total points display to sortByGroup method
- Upcoming Meeting: Clear reunion_dates cache when saving meeting prep
- Attendance: Fix date dropdown to fetch and render fresh data for selected date
- Meeting Preparation: Add date-specific cache keys for reunion preparation
- Group Management: Clear all group-related caches when adding/updating/deleting groups
- IndexedDB: Add clearGroupRelatedCaches function to clear attendance and participant caches

Fixes issues where:
- Points management wasn't showing group totals when sorted by group
- Upcoming meeting didn't show newly saved meetings until cache cleared
- Attendance date dropdown didn't update records
- Meeting preparation date dropdown used stale cached data
- Deleted groups still appeared until browser data was cleared