### PR TITLE
Fix API response handling and cache management

### DIFF
--- a/spa/api/api-endpoints.js
+++ b/spa/api/api-endpoints.js
@@ -794,7 +794,11 @@ export async function getAvailableDates() {
  */
 export async function getAttendance(date = null) {
     const params = date ? { date } : {};
-    return API.get('attendance', params);
+    const cacheKey = date ? `attendance_api_${date}` : 'attendance_api';
+    return API.get('attendance', params, {
+        cacheKey,
+        cacheDuration: CONFIG.CACHE_DURATION.SHORT
+    });
 }
 
 /**
@@ -917,10 +921,11 @@ export async function saveReunionPreparation(data) {
 /**
  * Get reunion dates
  */
-export async function getReunionDates() {
+export async function getReunionDates(forceRefresh = false) {
     return API.get('reunion-dates', {}, {
         cacheKey: 'reunion_dates',
-        cacheDuration: CONFIG.CACHE_DURATION.MEDIUM
+        cacheDuration: CONFIG.CACHE_DURATION.MEDIUM,
+        forceRefresh
     });
 }
 

--- a/spa/manage_points.js
+++ b/spa/manage_points.js
@@ -87,7 +87,10 @@ export class ManagePoints {
       ]);
 
       // Handle groups first
-      if (groupsResponse.success && Array.isArray(groupsResponse.groups)) {
+      if (groupsResponse.success && Array.isArray(groupsResponse.data)) {
+        this.groups = groupsResponse.data;
+      } else if (groupsResponse.success && Array.isArray(groupsResponse.groups)) {
+        // Backward compatibility
         this.groups = groupsResponse.groups;
       } else {
         console.error("Unexpected groups data structure:", groupsResponse);

--- a/spa/preparation_reunions.js
+++ b/spa/preparation_reunions.js
@@ -84,8 +84,8 @@ export class PreparationReunions {
                 this.organizationSettings = appSettings || {};
         }
 
-        async fetchAvailableDates() {
-                const response = await getReunionDates();
+        async fetchAvailableDates(forceRefresh = false) {
+                const response = await getReunionDates(forceRefresh);
                 // Handle both array response and object response with dates property
                 const dates = Array.isArray(response) ? response : (response?.dates || []);
                 this.dateManager.setAvailableDates(dates);
@@ -394,7 +394,8 @@ export class PreparationReunions {
                         // Clear the reunion_dates cache so upcoming_meeting page gets fresh data
                         await deleteCachedData('reunion_dates');
                         this.app.showMessage(translate("reunion_preparation_saved"), "success");
-                        await this.fetchAvailableDates();
+                        // Force refresh to get fresh dates from server
+                        await this.fetchAvailableDates(true);
                 } catch (error) {
                         console.error("Error saving reunion preparation:", error);
                         this.app.showMessage(translate("error_saving_reunion_preparation"), "error");


### PR DESCRIPTION
- Points Management: Fix groups data extraction from API response (data vs groups property)
- Attendance: Add date-specific cache keys to getAttendance API call
- Meeting Preparation: Add forceRefresh parameter to getReunionDates and use after saving

Fixes:
- Groups now properly display in points management (was checking wrong property)
- Attendance date dropdown now fetches date-specific data (was using same cache for all dates)
- Saved meeting preparations now immediately appear in upcoming meetings (force refresh after save)