### PR TITLE
Fix reunion preparations table data structure

### DIFF
--- a/spa/modules/DateManager.js
+++ b/spa/modules/DateManager.js
@@ -64,10 +64,25 @@ export class DateManager {
         }
 
         /**
-         * Create a new meeting date
+         * Create a new meeting date (one week after the current meeting date)
          */
         createNewMeetingDate() {
-                const newDate = this.getNextMeetingDate();
+                let newDate;
+
+                if (this.currentDate) {
+                        // Add 7 days to the current meeting date
+                        const currentMeetingDate = new Date(this.currentDate);
+                        currentMeetingDate.setDate(currentMeetingDate.getDate() + 7);
+
+                        const year = currentMeetingDate.getFullYear();
+                        const month = String(currentMeetingDate.getMonth() + 1).padStart(2, '0');
+                        const day = String(currentMeetingDate.getDate()).padStart(2, '0');
+                        newDate = `${year}-${month}-${day}`;
+                } else {
+                        // If no current date, use next meeting date
+                        newDate = this.getNextMeetingDate();
+                }
+
                 if (!this.availableDates.includes(newDate)) {
                         this.availableDates.push(newDate);
                         this.availableDates.sort((a, b) => new Date(b) - new Date(a));

--- a/spa/preparation_reunions.js
+++ b/spa/preparation_reunions.js
@@ -52,7 +52,9 @@ export class PreparationReunions {
                         // Determine current meeting and populate form
                         const currentMeeting = await this.determineCurrentMeeting();
                         this.currentMeetingData = currentMeeting;
-                        await this.formManager.populateForm(currentMeeting, this.dateManager.getCurrentDate());
+                        // Set the current date in dateManager to match the meeting we're displaying
+                        this.dateManager.setCurrentDate(currentMeeting.date);
+                        await this.formManager.populateForm(currentMeeting, currentMeeting.date);
 
                         // Populate reminder form after DOM is rendered
                         this.formManager.populateReminderForm();


### PR DESCRIPTION
- Update createNewMeetingDate() to add 7 days to current meeting date instead of recalculating from today
- Ensure currentDate is properly set when determining initial meeting to display
- This fixes the "New Meeting" button to correctly set the date to one week after the current meeting