### PR TITLE
Fix date format mismatch between app and database

### DIFF
--- a/spa/modules/FormManager.js
+++ b/spa/modules/FormManager.js
@@ -15,6 +15,21 @@ export class FormManager {
         }
 
         /**
+         * Convert ISO date string to yyyy-MM-dd format for HTML date inputs
+         */
+        formatDateForInput(dateString) {
+                if (!dateString) return '';
+
+                // If it's already in yyyy-MM-dd format, return as is
+                if (/^\d{4}-\d{2}-\d{2}$/.test(dateString)) {
+                        return dateString;
+                }
+
+                // Extract date part from ISO string (e.g., "2025-12-02T00:00:00.000Z" -> "2025-12-02")
+                return dateString.split('T')[0];
+        }
+
+        /**
          * Populate form with meeting data
          */
         async populateForm(meetingData, currentDate) {
@@ -24,7 +39,7 @@ export class FormManager {
                 }
 
                 document.getElementById("animateur-responsable").value = meetingData.animateur_responsable || '';
-                document.getElementById("date").value = meetingData.date || currentDate;
+                document.getElementById("date").value = this.formatDateForInput(meetingData.date || currentDate);
 
                 // Handle Louveteau d'honneur
                 const louveteauxDHonneur = document.getElementById("louveteau-dhonneur");
@@ -81,7 +96,7 @@ export class FormManager {
          */
         resetForm(currentDate) {
                 document.getElementById("animateur-responsable").value = '';
-                document.getElementById("date").value = currentDate;
+                document.getElementById("date").value = this.formatDateForInput(currentDate);
                 document.getElementById("louveteau-dhonneur").innerHTML = '';
                 document.getElementById("endroit").value = this.organizationSettings.organization_info?.endroit || '';
                 document.getElementById("notes").value = '';
@@ -125,7 +140,7 @@ export class FormManager {
                         const recurringReminderEl = document.getElementById('recurring-reminder');
 
                         if (reminderTextEl) reminderTextEl.value = this.reminder.reminder_text || '';
-                        if (reminderDateEl) reminderDateEl.value = this.reminder.reminder_date || '';
+                        if (reminderDateEl) reminderDateEl.value = this.formatDateForInput(this.reminder.reminder_date || '');
                         if (recurringReminderEl) recurringReminderEl.checked = this.reminder.is_recurring || false;
                 }
         }

--- a/spa/preparation_reunions.js
+++ b/spa/preparation_reunions.js
@@ -183,8 +183,22 @@ export class PreparationReunions {
                 this.attachEventListeners();
         }
 
+        /**
+         * Format date string to yyyy-MM-dd format for HTML date inputs
+         */
+        formatDateForInput(dateString) {
+                if (!dateString) return '';
+                // If it's already in yyyy-MM-dd format, return as is
+                if (/^\d{4}-\d{2}-\d{2}$/.test(dateString)) {
+                        return dateString;
+                }
+                // Extract date part from ISO string (e.g., "2025-12-02T00:00:00.000Z" -> "2025-12-02")
+                return dateString.split('T')[0];
+        }
+
         render() {
-                const nextMeetingDate = this.currentMeetingData?.date || this.dateManager.getNextMeetingDate();
+                const rawNextMeetingDate = this.currentMeetingData?.date || this.dateManager.getNextMeetingDate();
+                const nextMeetingDate = this.formatDateForInput(rawNextMeetingDate);
                 const defaultAnimateur = this.animateurs.find(a => a.full_name === this.organizationSettings.organization_info?.animateur_responsable);
                 const availableDates = this.dateManager.getAvailableDates();
 
@@ -197,7 +211,7 @@ export class PreparationReunions {
                                         <select id="date-select">
                                         <option value="">${translate("select_date")}</option>
                                                 ${availableDates.map(date =>
-                                                        `<option value="${date}" ${date === this.currentMeetingData?.date ? 'selected' : ''}>${this.dateManager.formatDate(date, this.app.lang)}</option>`
+                                                        `<option value="${date}" ${date === this.formatDateForInput(this.currentMeetingData?.date) ? 'selected' : ''}>${this.dateManager.formatDate(date, this.app.lang)}</option>`
                                                 ).join('')}
                                         </select>
                                 </div>


### PR DESCRIPTION
Fixed the date format issue where ISO 8601 dates (e.g., "2025-12-02T00:00:00.000Z") from the database were being assigned directly to HTML date inputs, which require the "yyyy-MM-dd" format.

Changes:
- Added formatDateForInput() helper method in FormManager.js to convert ISO dates to yyyy-MM-dd format
- Updated populateForm(), resetForm(), and populateReminderForm() to use the helper
- Added formatDateForInput() method in preparation_reunions.js
- Fixed nextMeetingDate formatting in the render() method
- Fixed date comparison in the date-select dropdown to ensure proper selection

This resolves the browser console warnings:
"The specified value does not conform to the required format, 'yyyy-MM-dd'"