### PR TITLE
Fix dropdown selection, new meeting date calculation, and reminder save

### DIFF
--- a/spa/modules/DateManager.js
+++ b/spa/modules/DateManager.js
@@ -64,19 +64,31 @@ export class DateManager {
         }
 
         /**
-         * Create a new meeting date (one week after the current meeting date)
+         * Create a new meeting date (next occurrence of the meeting day after current date)
          */
         createNewMeetingDate() {
                 let newDate;
 
                 if (this.currentDate) {
-                        // Add 7 days to the current meeting date
+                        // Calculate the next occurrence of the meeting day AFTER the current date
                         const currentMeetingDate = new Date(this.currentDate);
-                        currentMeetingDate.setDate(currentMeetingDate.getDate() + 7);
+                        const meetingDay = this.organizationSettings.organization_info?.meeting_day || 'Tuesday';
+                        const daysOfWeek = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+                        const meetingDayIndex = daysOfWeek.indexOf(meetingDay);
+                        const currentDayIndex = currentMeetingDate.getDay();
 
-                        const year = currentMeetingDate.getFullYear();
-                        const month = String(currentMeetingDate.getMonth() + 1).padStart(2, '0');
-                        const day = String(currentMeetingDate.getDate()).padStart(2, '0');
+                        // Calculate days until next meeting day (always at least 7 days from current)
+                        let daysUntilNextMeeting = (meetingDayIndex - currentDayIndex + 7) % 7;
+                        if (daysUntilNextMeeting === 0) {
+                                daysUntilNextMeeting = 7; // If current date is the meeting day, go to next week
+                        }
+
+                        const nextMeeting = new Date(currentMeetingDate);
+                        nextMeeting.setDate(currentMeetingDate.getDate() + daysUntilNextMeeting);
+
+                        const year = nextMeeting.getFullYear();
+                        const month = String(nextMeeting.getMonth() + 1).padStart(2, '0');
+                        const day = String(nextMeeting.getDate()).padStart(2, '0');
                         newDate = `${year}-${month}-${day}`;
                 } else {
                         // If no current date, use next meeting date

--- a/spa/preparation_reunions.js
+++ b/spa/preparation_reunions.js
@@ -5,9 +5,9 @@ import {
         getRecentHonors,
         saveReunionPreparation,
         getReunionDates,
-        getReunionPreparation,
-        fetchFromApi
+        getReunionPreparation
 } from "./ajax-functions.js";
+import { saveReminder, getReminder } from "./api/api-endpoints.js";
 import { deleteCachedData } from "./indexedDB.js";
 import { ActivityManager } from "./modules/ActivityManager.js";
 import { FormManager } from "./modules/FormManager.js";
@@ -46,14 +46,14 @@ export class PreparationReunions {
                         const reminder = await this.fetchReminder();
                         this.formManager.setReminder(reminder);
 
-                        // Render the page
-                        this.render();
-
-                        // Determine current meeting and populate form
+                        // Determine current meeting BEFORE rendering
                         const currentMeeting = await this.determineCurrentMeeting();
                         this.currentMeetingData = currentMeeting;
                         // Set the current date in dateManager to match the meeting we're displaying
                         this.dateManager.setCurrentDate(currentMeeting.date);
+
+                        // Render the page now that we have the meeting data
+                        this.render();
                         await this.formManager.populateForm(currentMeeting, currentMeeting.date);
 
                         // Populate reminder form after DOM is rendered
@@ -95,7 +95,7 @@ export class PreparationReunions {
 
         async fetchReminder() {
                 try {
-                        const data = await fetchFromApi(`get_reminder`);
+                        const data = await getReminder();
                         return data.success ? data.reminder : null;
                 } catch (error) {
                         console.error("Error fetching reminder:", error);
@@ -392,7 +392,7 @@ export class PreparationReunions {
                 const reminderData = this.formManager.getReminderData();
 
                 try {
-                        await fetchFromApi('save_reminder', 'POST', reminderData);
+                        await saveReminder(reminderData);
                         this.app.showMessage(translate("reminder_saved_successfully"), "success");
                 } catch (error) {
                         this.app.showMessage(translate("error_saving_reminder"), "error");


### PR DESCRIPTION
Fixed three issues in the reunion preparation page:

1. **Dropdown selection on page load**: Moved render() to happen AFTER determineCurrentMeeting() so the dropdown has the correct date selected when the page loads. Previously, render() was called before we knew which meeting data to display, causing the dropdown to not select the current meeting date.

2. **New meeting date calculation**: Updated DateManager.createNewMeetingDate() to calculate the next occurrence of the organization's meeting day (from settings) instead of just adding 7 days. Now properly respects the configured meeting day (e.g., Tuesday) when creating new meetings.

3. **Reminder save functionality**: Fixed reminder saving by importing and using saveReminder() from api-endpoints.js instead of fetchFromApi(), which was incorrectly aliased to API.get and couldn't perform POST requests.

Changes:
- spa/preparation_reunions.js: Reordered initialization, updated imports
- spa/modules/DateManager.js: Fixed createNewMeetingDate() logic