### PR TITLE
Fix parent dashboard participant documents page

### DIFF
--- a/spa/api/api-endpoints.js
+++ b/spa/api/api-endpoints.js
@@ -581,6 +581,13 @@ export async function getOrganizationFormFormats(organizationId = null) {
         return null;
     }
 
+    // Check if response.data is already an object (transformed format)
+    // This can happen if cached data is in a different format
+    if (!Array.isArray(response.data)) {
+        return response.data;
+    }
+
+    // Transform array format to object format
     const formFormats = {};
     for (const format of response.data) {
         formFormats[format.form_type] = format.form_structure;

--- a/spa/upcoming_meeting.js
+++ b/spa/upcoming_meeting.js
@@ -65,6 +65,10 @@ export class UpcomingMeeting {
                                                 const response = await getReunionPreparation(date);
                                                 if (response.success && response.preparation) {
                                                                 this.meetingDetails = response.preparation;
+                                                                // Parse the activities JSON string if it's a string
+                                                                if (typeof this.meetingDetails.activities === 'string') {
+                                                                        this.meetingDetails.activities = JSON.parse(this.meetingDetails.activities);
+                                                                }
                                                 } else {
                                                                 this.meetingDetails = null;
                                                 }


### PR DESCRIPTION
Fixed two issues in the parent dashboard:

1. Participant Documents Error: Updated getOrganizationFormFormats() to handle both array and object response formats from cache. Added check to return data directly if it's already in object format, preventing iteration error.

2. Upcoming Meeting Activities: Added JSON parsing for activities field in fetchMeetingDetails(). Activities are stored as JSON strings in the database and need to be parsed before rendering, similar to preparation_reunions.js.