### PR TITLE
Fix meeting date and schedule display

### DIFF
--- a/api.js
+++ b/api.js
@@ -2230,7 +2230,7 @@ app.get('/api', [
           `SELECT DISTINCT date::text as date
            FROM reunion_preparations
            WHERE organization_id = $1
-           ORDER BY date DESC`,
+           ORDER BY date ASC`,
           [organizationId]
         );
         jsonResponse(res, true, datesResult.rows.map(row => row.date));

--- a/api.php
+++ b/api.php
@@ -3140,7 +3140,7 @@ case 'associate_user':
 				SELECT DISTINCT date 
 				FROM reunion_preparations 
 				WHERE organization_id = :organization_id 
-				ORDER BY date DESC
+				ORDER BY date ASC
 		");
 		$stmt->execute([':organization_id' => $organizationId]);
 		$dates = $stmt->fetchAll(PDO::FETCH_COLUMN);

--- a/spa/modules/DateManager.js
+++ b/spa/modules/DateManager.js
@@ -97,7 +97,7 @@ export class DateManager {
 
                 if (!this.availableDates.includes(newDate)) {
                         this.availableDates.push(newDate);
-                        this.availableDates.sort((a, b) => new Date(b) - new Date(a));
+                        this.availableDates.sort((a, b) => new Date(a) - new Date(b));
                 }
                 this.currentDate = newDate;
                 return newDate;


### PR DESCRIPTION
Changed date sorting from DESC to ASC in:
- api.php get_reunion_dates endpoint
- api.js get_reunion_dates endpoint
- DateManager.js createNewMeetingDate method

This fixes the issue where the next meeting was showing one week too far in the future. Now the soonest/next meeting will be displayed first.