### PR TITLE
Fix Wampums configuration in formulaire-inscription

### DIFF
--- a/spa/api/api-endpoints.js
+++ b/spa/api/api-endpoints.js
@@ -581,17 +581,22 @@ export async function getOrganizationFormFormats(organizationId = null) {
         return null;
     }
 
-    // Check if response.data is already an object (transformed format)
-    // This can happen if cached data is in a different format
-    if (!Array.isArray(response.data)) {
-        return response.data;
+    const formFormats = {};
+
+    // Check if response.data is an array
+    if (Array.isArray(response.data)) {
+        // Transform array format to object format
+        for (const format of response.data) {
+            formFormats[format.form_type] = format.form_structure;
+        }
+    } else {
+        // response.data is an object, extract form_structure from each form type
+        for (const [formType, formatData] of Object.entries(response.data)) {
+            // If formatData has a form_structure property, use it; otherwise use formatData directly
+            formFormats[formType] = formatData.form_structure || formatData;
+        }
     }
 
-    // Transform array format to object format
-    const formFormats = {};
-    for (const format of response.data) {
-        formFormats[format.form_type] = format.form_structure;
-    }
     return formFormats;
 }
 


### PR DESCRIPTION
The getOrganizationFormFormats function was returning full database records when the API response was in object format, instead of extracting the form_structure property. This caused "Invalid form structure" errors in formulaire-inscription and view-participant-documents.

Changes:
- Modified getOrganizationFormFormats to properly extract form_structure from both array and object response formats
- Added fallback to use formatData directly if form_structure doesn't exist
- This fixes TypeError: Cannot read properties of undefined (reading 'forEach') in dynamicFormHandler.js line 212

Fixes issues in:
- /formulaire-inscription (form not rendering)
- /view-participant-documents (only showing participant names, no data)