### PR TITLE
Fix form data extraction in view_participant_documents

### DIFF
--- a/spa/view_participant_documents.js
+++ b/spa/view_participant_documents.js
@@ -142,8 +142,8 @@ export class ViewParticipantDocuments {
     console.log(`Fetching form submission for participantId: ${participantId}, formType: ${formType}`);
 
     try {
-      const formData = await getFormSubmission(participantId, formType);
-      console.log("Fetched form data:", formData);
+      const response = await getFormSubmission(participantId, formType);
+      console.log("Fetched form data:", response);
 
       if (!this.formRenderers[formType]) {
         console.error(`No form renderer found for formType: ${formType}`);
@@ -151,8 +151,12 @@ export class ViewParticipantDocuments {
         return;
       }
 
-      // Pass formData explicitly to render
-      const formContent = this.formRenderers[formType].render(formData);
+      // Extract the submission_data from the response
+      const submissionData = response.data?.submission_data || response.submission_data || {};
+      console.log("Extracted submission data:", submissionData);
+
+      // Pass submission_data to render
+      const formContent = this.formRenderers[formType].render(submissionData);
       document.getElementById('form-content').innerHTML = formContent;
       document.getElementById('form-view-modal').style.display = "block";
     } catch (error) {


### PR DESCRIPTION
The handleViewForm method was passing the entire API response object to the form renderer instead of extracting the submission_data. This caused forms to render empty because the renderer received:
  { success: true, data: { submission_data: {...} } }
instead of just:
  { field1: value1, field2: value2, ... }

Changes:
- Extract submission_data from response.data.submission_data
- Add fallback to response.submission_data for different API formats
- Add console.log to show extracted submission data for debugging

Fixes: Forms displaying structure but no data in view-participant-documents