### PR TITLE
Add role-based access control to participant detail endpoint

### DIFF
--- a/spa/api/api-endpoints.js
+++ b/spa/api/api-endpoints.js
@@ -208,16 +208,28 @@ export async function getParticipants() {
 
 /**
  * Get participant by ID
+ * Uses RESTful endpoint with role-based access control
  */
 export async function getParticipant(id) {
-    return API.get(`participant/${id}`);
+    const response = await API.get(`v1/participants/${id}`);
+    // Transform response to match expected format
+    return {
+        success: response.success,
+        participant: response.data
+    };
 }
 
 /**
  * Fetch participant (alias for getParticipant)
+ * Uses RESTful endpoint with role-based access control
  */
 export async function fetchParticipant(participantId) {
-    return API.get(`participant/${participantId}`);
+    const response = await API.get(`v1/participants/${participantId}`);
+    // Transform response to match expected format
+    return {
+        success: response.success,
+        participant: response.data
+    };
 }
 
 /**


### PR DESCRIPTION
Backend changes:
- Update GET /api/v1/participants/:id with role-based filtering
- Admin and Animation roles can view ANY participant in organization
- Parent role users can only view their linked participants
- Return 404 with "access denied" message for unauthorized access
- Add form submission status flags (has_*) to response

Frontend changes:
- Update getParticipant() and fetchParticipant() to use RESTful endpoint
- Change from /api/participant/${id} to /api/v1/participants/${id}
- Transform response format to maintain compatibility with forms

This fixes the issue where forms were loading but not populating with data for Animation/Admin users viewing children in the Parent Dashboard.