### PR TITLE
Fix page title and cache for language and groups

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -601,5 +601,6 @@
     "error_linking_participants": "Error occurred while linking participants",
     "no_participants_selected": "No participants selected",
     "new_animator_registration_subject": "New Animator Registration for {orgName}",
-    "new_animator_registration_body": "\r\n  Dear Admin,\r\n\r\n  A new user has registered as an animator for {orgName} and requires verification:\r\n\r\n  Name: {animatorName}\r\n  Email: {animatorEmail}\r\n\r\n  Please log in to the admin dashboard to verify this user.\r\n\r\n  Best regards,\r\n  The System\r\n  "
+    "new_animator_registration_body": "\r\n  Dear Admin,\r\n\r\n  A new user has registered as an animator for {orgName} and requires verification:\r\n\r\n  Name: {animatorName}\r\n  Email: {animatorEmail}\r\n\r\n  Please log in to the admin dashboard to verify this user.\r\n\r\n  Best regards,\r\n  The System\r\n  ",
+    "app_title": "Scouts at your fingertips"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -646,5 +646,6 @@
     "group_attendance_updated": "La présence du groupe a été mise à jour.",
     "error_updating_group_attendance": "Erreur lors de la mise à jour de la présence du groupe.",
     "no_participants_to_update": "Aucun participant à mettre à jour.",
-    "no_selection": "Aucune sélection."
+    "no_selection": "Aucune sélection.",
+    "app_title": "Scouts au bout des doigts"
 }

--- a/spa/app.js
+++ b/spa/app.js
@@ -485,10 +485,18 @@ export const app = {
                 setStorage('lang', lang);
 
                 this.loadTranslations().then(() => {
+                        // Update page title
+                        this.updatePageTitle();
+
                         if (this.router && this.initCompleted) {
                                 this.router.reloadCurrentRoute();
                         }
                 });
+        },
+
+        updatePageTitle() {
+                const title = this.translate('app_title');
+                document.title = `${title} - Wampums`;
         },
 
         initLanguageToggle() {

--- a/spa/indexedDB.js
+++ b/spa/indexedDB.js
@@ -210,6 +210,7 @@ export async function clearPointsRelatedCaches() {
 
 export async function clearGroupRelatedCaches() {
   const keysToDelete = [
+    'groups',
     'participants',
     'manage_points_data',
     'dashboard_groups',


### PR DESCRIPTION
- Add i18n support for page title (EN: "Scouts at your fingertips", FR: "Scouts au bout des doigts")
- Update app.js to dynamically change page title based on language selection
- Fix cache invalidation in manage-groups by adding 'groups' cache key to clearGroupRelatedCaches
- Groups are now immediately reflected when added/removed without page refresh

Fixes two issues:
1. Page title now changes between French and English
2. Group cache properly invalidated when groups are added/removed in /manage-groups