### PR TITLE
Fix syntax error in manage_points.js

### DIFF
--- a/spa/manage_points.js
+++ b/spa/manage_points.js
@@ -7,8 +7,8 @@ import {
   getApiUrl,
 } from "./ajax-functions.js";
 import { translate } from "./app.js";
-import {
 import { debugLog, debugError } from "./utils/DebugUtils.js";
+import {
   saveOfflineData,
   getOfflineData,
   clearOfflineData,


### PR DESCRIPTION
Fix duplicate import statement that was causing:
'Uncaught SyntaxError: Unexpected reserved word'

The debugLog import was incorrectly placed inside another import block, creating invalid syntax. Moved it to its own import statement.