### PR TITLE
Fix broken API endpoints

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -322,7 +322,9 @@ async function fetchAndCacheInIndexedDB(request) {
 
       // Save the response data in IndexedDB for offline access
       await setCachedData(cacheKey, data, 24 * 60 * 60 * 1000); // Cache for 24 hours
-      return new Response(JSON.stringify(data)); // Return the response
+      return new Response(JSON.stringify(data), {
+        headers: { 'Content-Type': 'application/json' }
+      }); // Return the response
     }
   } catch (error) {
     console.error("Network request failed, attempting to serve from cache:", error);


### PR DESCRIPTION
The service worker's fetchAndCacheInIndexedDB function was creating a Response object without setting the Content-Type header when returning cached API data. This caused the response to default to text/plain;charset=UTF-8 instead of application/json, causing the frontend's api-core.js handleResponse function to throw an error.

Fixed by adding Content-Type: application/json header to the Response object at service-worker.js:325.

This fixes failing endpoints:
- /api/v1/participants
- /api/v1/groups
- /api/honors