### PR TITLE
Fix attendance dates endpoint response format

### DIFF
--- a/api.js
+++ b/api.js
@@ -1594,11 +1594,9 @@ app.get('/api/attendance-dates', async (req, res) => {
       `SELECT DISTINCT date::text as date FROM attendance WHERE organization_id = $1 ORDER BY date DESC`,
       [organizationId]
     );
-    
-    res.json({
-      success: true,
-      dates: result.rows.map(row => row.date)
-    });
+
+    const dates = result.rows.map(row => row.date);
+    return success(res, dates);
   } catch (error) {
     logger.error('Error fetching attendance dates:', error);
     res.status(500).json({ success: false, message: error.message });

--- a/spa/attendance.js
+++ b/spa/attendance.js
@@ -76,9 +76,9 @@ export class Attendance {
   async fetchAttendanceDates() {
     try {
       const response = await getAttendanceDates(); // Call the API
-      if (response.success && response.dates) {
+      if (response.success && response.data) {
         // Filter out null, undefined, and invalid dates
-        this.availableDates = response.dates.filter(date => {
+        this.availableDates = response.data.filter(date => {
           return isValidDate(date);
         });
       } else {


### PR DESCRIPTION
The attendance-dates endpoint was returning dates in a non-standard format {success: true, dates: [...]}, but the cached data was using the standardized response format {success: true, data: [...]}.

This mismatch caused the frontend to fail when checking for response.dates when the cache contained response.data.

Changes:
- Updated /api/attendance-dates endpoint to use the success() helper which returns data in the standardized format
- Updated spa/attendance.js to check for response.data instead of response.dates

This ensures consistency with the rest of the API endpoints and fixes the attendance page loading issue.