### PR TITLE
Fix attendance dates returning as Date objects instead of strings

### DIFF
--- a/routes/attendance.js
+++ b/routes/attendance.js
@@ -78,7 +78,7 @@ module.exports = (pool) => {
     const organizationId = await getOrganizationId(req, pool);
 
     const result = await pool.query(
-      `SELECT DISTINCT date
+      `SELECT DISTINCT date::text as date
        FROM attendance
        WHERE organization_id = $1
        ORDER BY date DESC`,


### PR DESCRIPTION
The /api/v1/attendance/dates endpoint was returning dates as PostgreSQL Date objects instead of strings, which could cause issues with the frontend date validation and comparison logic.

Updated the SQL query to cast dates to text (date::text) to match the format used in other endpoints and ensure consistent string-based date handling in the frontend.

This ensures the date selector in the attendance UI displays all available attendance dates properly.