### PR TITLE
Fix points data responses and rendering

### DIFF
--- a/api.js
+++ b/api.js
@@ -681,13 +681,13 @@ app.get('/api/points-data', async (req, res) => {
 
     // Fetch all participants with their associated group and total points
     const participantsResult = await pool.query(
-      `SELECT part.id, part.first_name, pg.group_id, COALESCE(SUM(p.value), 0) AS total_points
+      `SELECT part.id, part.first_name, part.last_name, pg.group_id, COALESCE(SUM(p.value), 0) AS total_points
        FROM participants part
        JOIN participant_organizations po ON part.id = po.participant_id
        LEFT JOIN participant_groups pg ON part.id = pg.participant_id AND pg.organization_id = $1
        LEFT JOIN points p ON part.id = p.participant_id AND p.organization_id = $1
        WHERE po.organization_id = $1
-       GROUP BY part.id, part.first_name, pg.group_id
+       GROUP BY part.id, part.first_name, part.last_name, pg.group_id
        ORDER BY part.first_name`,
       [organizationId]
     );
@@ -695,7 +695,7 @@ app.get('/api/points-data', async (req, res) => {
     res.json({
       success: true,
       groups: groupsResult.rows,
-      names: participantsResult.rows
+      participants: participantsResult.rows
     });
   } catch (error) {
     logger.error('Error fetching points data:', error);

--- a/spa/manage_points.js
+++ b/spa/manage_points.js
@@ -768,6 +768,35 @@ export class ManagePoints {
   async updatePointsDisplay(data) {
     debugLog("Updating points display with data:", data);
 
+    // Normalize and update internal data structures when fresh data is provided
+    if (data) {
+      const participantsFromData = data.participants || data.names;
+      if (Array.isArray(participantsFromData)) {
+        this.participants = participantsFromData.map((participant) => ({
+          total_points: 0,
+          ...participant,
+          total_points: participant.total_points ?? 0,
+        }));
+      }
+
+      if (Array.isArray(data.groups)) {
+        this.groups = data.groups.map((group) => ({
+          total_points: 0,
+          ...group,
+          total_points: group.total_points ?? 0,
+        }));
+      }
+
+      // Rebuild grouping to ensure render helpers can use fresh data
+      this.organizeParticipants();
+
+      // If the DOM has not yet been rendered, bail out after re-rendering the lists
+      const pointsList = document.getElementById("points-list");
+      if (pointsList) {
+        this.sortByGroup();
+      }
+    }
+
     // Update points for all participants
     this.participants.forEach(participant => {
       const participantElement = document.querySelector(


### PR DESCRIPTION
## Summary
- include participant last names and totals in /api/points-data responses
- normalize manage points refresh to use server totals and rebuild UI from fetched data

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e4f3dec44832486cbb25c960d149a)