### PR TITLE
Redesign manage_points.js interface layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1329,13 +1329,96 @@ tr:hover {
    5.17 SORTING & FILTERING
    ---------------------------------------------------------------------------- */
 
-.sort-options,
-.filter-options {
+.controls-container {
   margin-block-end: var(--space-lg);
   display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-md);
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.sort-options {
+  display: flex;
+  gap: var(--space-sm);
   align-items: center;
+  justify-content: center;
+}
+
+.sort-btn,
+.filter-toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-inline-size: 48px;
+  min-block-size: 48px;
+  padding: var(--space-sm);
+  background-color: white;
+  border: 2px solid var(--color-primary);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--transition-base);
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-medium);
+}
+
+.sort-btn:hover,
+.filter-toggle-btn:hover {
+  background-color: var(--color-primary);
+  color: white;
+  transform: translateY(-2px) scale(1.05);
+  box-shadow: var(--shadow-md);
+}
+
+.sort-btn:active,
+.filter-toggle-btn:active {
+  transform: translateY(0) scale(0.98);
+}
+
+.filter-toggle-btn {
+  background-color: var(--color-secondary);
+  border-color: var(--color-text-muted);
+}
+
+.filter-toggle-btn:hover {
+  background-color: var(--color-text-muted);
+  color: white;
+}
+
+.filter-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-md);
+  background-color: var(--color-surface);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+  max-block-size: 200px;
+  opacity: 1;
+  transition: all var(--transition-base);
+}
+
+.filter-options.hidden {
+  max-block-size: 0;
+  padding: 0;
+  opacity: 0;
+  margin: 0;
+}
+
+.filter-options label {
+  margin: 0;
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text);
+}
+
+.filter-options select {
+  flex: 1;
+  min-inline-size: 150px;
+  padding: var(--space-sm);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-base);
 }
 
 .sort-control {

--- a/spa/manage_points.js
+++ b/spa/manage_points.js
@@ -162,21 +162,24 @@ export class ManagePoints {
     const content = `
       <a href="/dashboard" class="home-icon" aria-label="${translate("back_to_dashboard")}">🏠</a>
       <h1>${translate("manage_points")}</h1>
-      <div class="sort-options">
-        <button data-sort="name">${translate("sort_by_name")}</button>
-        <button data-sort="group">${translate("sort_by_group")}</button>
-        <button data-sort="points">${translate("sort_by_points")}</button>
-      </div>
-      <div class="filter-options">
-        <label for="group-filter">${translate("filter_by_group")}:</label>
-        <select id="group-filter">
-          <option value="">${translate("all_groups")}</option>
-          ${this.groups
-            .map(
-              (group) => `<option value="${group.id}">${group.name}</option>`,
-            )
-            .join("")}
-        </select>
+      <div class="controls-container">
+        <div class="sort-options">
+          <button class="sort-btn" data-sort="name" title="${translate("sort_by_name")}">👤</button>
+          <button class="sort-btn" data-sort="group" title="${translate("sort_by_group")}">👥</button>
+          <button class="sort-btn" data-sort="points" title="${translate("sort_by_points")}">🏆</button>
+          <button class="filter-toggle-btn" id="filter-toggle" title="${translate("filter_by_group")}">⊙</button>
+        </div>
+        <div class="filter-options hidden" id="filter-container">
+          <label for="group-filter">${translate("filter_by_group")}:</label>
+          <select id="group-filter">
+            <option value="">${translate("all_groups")}</option>
+            ${this.groups
+              .map(
+                (group) => `<option value="${group.id}">${group.name}</option>`,
+              )
+              .join("")}
+          </select>
+        </div>
       </div>
       <div id="points-list"></div>
       <div class="fixed-bottom">
@@ -277,6 +280,7 @@ export class ManagePoints {
     const sortContainer = document.querySelector(".sort-options");
     const pointsList = document.getElementById("points-list");
     const filterDropdown = document.getElementById("group-filter");
+    const filterToggle = document.getElementById("filter-toggle");
     const fixedBottom = document.querySelector(".fixed-bottom"); // Ensure we target .fixed-bottom
 
     // Check if these elements exist before adding listeners
@@ -311,6 +315,13 @@ export class ManagePoints {
       // Add change listener for group filter dropdown
       filterDropdown.addEventListener("change", (event) => {
         this.filterByGroup(event.target.value);
+      });
+    }
+
+    if (filterToggle) {
+      // Add listener for filter toggle button
+      filterToggle.addEventListener("click", () => {
+        this.toggleFilter();
       });
     }
 
@@ -635,6 +646,16 @@ export class ManagePoints {
 
   sortItems(key) {
     debugLog(`Sorting by ${key}`);
+
+    // Toggle sort order if clicking same key, otherwise start with asc
+    if (this.currentSort.key === key) {
+      this.currentSort.order =
+        this.currentSort.order === "asc" ? "desc" : "asc";
+    } else {
+      this.currentSort.key = key;
+      this.currentSort.order = "asc";
+    }
+
     if (key === "group") {
       this.sortByGroup(); // Reuse the method to sort by group
     } else {
@@ -661,16 +682,14 @@ export class ManagePoints {
       // Clear the list and render only participants
       list.innerHTML = items.map((item) => item.outerHTML).join("");
 
-      // Update current sort order
-      if (this.currentSort.key === key) {
-        this.currentSort.order =
-          this.currentSort.order === "asc" ? "desc" : "asc";
-      } else {
-        this.currentSort.key = key;
-        this.currentSort.order = "asc";
-      }
-
       debugLog(`Sorted by ${key}, order: ${this.currentSort.order}`);
+    }
+  }
+
+  toggleFilter() {
+    const filterContainer = document.getElementById("filter-container");
+    if (filterContainer) {
+      filterContainer.classList.toggle("hidden");
     }
   }
 


### PR DESCRIPTION
- Replace large text sorting buttons with compact icon buttons (👤 for name, 👥 for group, 🏆 for points)
- Change sorting behavior from 3-click cycle to 2-click toggle between ascending/descending
- Hide filter dropdown by default, show/hide with new filter toggle button (⊙)
- Add smooth transitions for filter dropdown visibility
- Improve overall layout with controls-container for better organization
- Maintain the six bottom action buttons unchanged as requested