### PR TITLE
Fix update loop showing same version repeatedly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wampums",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Wampums project",
   "main": "api.js",
   "scripts": {

--- a/spa/config.js
+++ b/spa/config.js
@@ -52,7 +52,7 @@ export const CONFIG = {
     /**
      * Application Version
      */
-    VERSION: '2.0.0',
+    VERSION: '2.0.1',
 
     /**
      * Application Name


### PR DESCRIPTION
The update loop was caused by a version mismatch between:
- service-worker.js: 2.0.1
- package.json: 2.0.0
- spa/config.js: 2.0.0

The PWA update manager compares these versions every 60 seconds, and when they don't match, it continuously shows the update prompt even though no real update is available.

This fix syncs all versions to 2.0.1, resolving the infinite loop.