### PR TITLE
Fix Content Security Policy script violation

### DIFF
--- a/api.js
+++ b/api.js
@@ -38,11 +38,11 @@ app.use(helmet({
   contentSecurityPolicy: {
     directives: {
       defaultSrc: ["'self'"],
-      scriptSrc: ["'self'", "'unsafe-inline'"], // Note: Consider removing unsafe-inline and using nonces in production
+      scriptSrc: ["'self'", "'unsafe-inline'", "https://www.clarity.ms"], // Note: Consider removing unsafe-inline and using nonces in production
       styleSrc: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
       fontSrc: ["'self'", "https://fonts.gstatic.com"],
       imgSrc: ["'self'", "data:", "https:"],
-      connectSrc: ["'self'"],
+      connectSrc: ["'self'", "https://www.clarity.ms"],
       frameSrc: ["'none'"],
       objectSrc: ["'none'"],
       upgradeInsecureRequests: isProduction ? [] : null,


### PR DESCRIPTION
Added https://www.clarity.ms to both scriptSrc and connectSrc CSP directives to allow the Clarity analytics script to load and communicate properly.

This resolves the console error: "Loading the script 'https://www.clarity.ms/tag/...' violates the following Content Security Policy directive"

Changes:
- Added https://www.clarity.ms to scriptSrc directive in helmet CSP config
- Added https://www.clarity.ms to connectSrc directive for analytics data transmission