### PR TITLE
Fix MS Clarity integration issues

### DIFF
--- a/api.js
+++ b/api.js
@@ -38,11 +38,11 @@ app.use(helmet({
   contentSecurityPolicy: {
     directives: {
       defaultSrc: ["'self'"],
-      scriptSrc: ["'self'", "'unsafe-inline'", "https://www.clarity.ms", "https://scripts.clarity.ms"], // Note: Consider removing unsafe-inline and using nonces in production
+      scriptSrc: ["'self'", "'unsafe-inline'", "https://*.clarity.ms"], // Note: Consider removing unsafe-inline and using nonces in production
       styleSrc: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
       fontSrc: ["'self'", "https://fonts.gstatic.com"],
       imgSrc: ["'self'", "data:", "https:"],
-      connectSrc: ["'self'", "https://www.clarity.ms"],
+      connectSrc: ["'self'", "https://*.clarity.ms", "https://c.bing.com"],
       frameSrc: ["'none'"],
       objectSrc: ["'none'"],
       upgradeInsecureRequests: isProduction ? [] : null,


### PR DESCRIPTION
Updated Content Security Policy directives to include all required Clarity domains according to official Microsoft documentation:
- Changed script-src to use wildcard: https://*.clarity.ms
- Updated connect-src to include: https://*.clarity.ms and https://c.bing.com

This resolves CSP violations preventing Clarity from connecting to q.clarity.ms and other load-balanced subdomains.

Refs: https://learn.microsoft.com/en-us/clarity/setup-and-installation/clarity-csp