### PR TITLE
Fix Content Security Policy script errors

### DIFF
--- a/api.js
+++ b/api.js
@@ -38,11 +38,12 @@ app.use(helmet({
   contentSecurityPolicy: {
     directives: {
       defaultSrc: ["'self'"],
-      scriptSrc: ["'self'", "'unsafe-inline'", "https://*.clarity.ms"], // Note: Consider removing unsafe-inline and using nonces in production
+      scriptSrc: ["'self'", "'unsafe-inline'", "https://*.clarity.ms", "https://www.clarity.ms"], // Note: Consider removing unsafe-inline and using nonces in production
+      scriptSrcElem: ["'self'", "'unsafe-inline'", "https://*.clarity.ms", "https://www.clarity.ms"],
       styleSrc: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
       fontSrc: ["'self'", "https://fonts.gstatic.com"],
       imgSrc: ["'self'", "data:", "https:"],
-      connectSrc: ["'self'", "https://*.clarity.ms", "https://c.bing.com"],
+      connectSrc: ["'self'", "https://*.clarity.ms", "https://c.bing.com", "https://www.clarity.ms"],
       frameSrc: ["'none'"],
       objectSrc: ["'none'"],
       upgradeInsecureRequests: isProduction ? [] : null,

--- a/index.html
+++ b/index.html
@@ -12,7 +12,6 @@
     <meta name="mobile-web-app-capable" content="yes">
 
     <!-- iOS PWA Support -->
-    <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="apple-mobile-web-app-title" content="Wampums">
 

--- a/routes/badges.js
+++ b/routes/badges.js
@@ -58,7 +58,7 @@ module.exports = (pool, logger) => {
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
       // Verify user belongs to this organization
-      const authCheck = await verifyOrganizationMembership(decoded.user_id, organizationId, pool);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId);
       if (!authCheck.authorized) {
         return res.status(403).json({ success: false, message: authCheck.message });
       }
@@ -112,7 +112,7 @@ module.exports = (pool, logger) => {
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
       // Verify user belongs to this organization with admin or leader role
-      const authCheck = await verifyOrganizationMembership(decoded.user_id, organizationId, pool, ['admin', 'leader']);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId, ['admin', 'leader']);
       if (!authCheck.authorized) {
         return res.status(403).json({ success: false, message: authCheck.message });
       }
@@ -189,7 +189,7 @@ module.exports = (pool, logger) => {
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
       // Verify user belongs to this organization
-      const authCheck = await verifyOrganizationMembership(decoded.user_id, organizationId, pool);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId);
       if (!authCheck.authorized) {
         return res.status(403).json({ success: false, message: authCheck.message });
       }
@@ -271,7 +271,7 @@ module.exports = (pool, logger) => {
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
       // Verify user belongs to this organization with admin or leader role
-      const authCheck = await verifyOrganizationMembership(decoded.user_id, organizationId, pool, ['admin', 'leader']);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId, ['admin', 'leader']);
       if (!authCheck.authorized) {
         return res.status(403).json({ success: false, message: authCheck.message });
       }
@@ -385,7 +385,7 @@ module.exports = (pool, logger) => {
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
       // Verify user belongs to this organization with admin or leader role
-      const authCheck = await verifyOrganizationMembership(decoded.user_id, organizationId, pool, ['admin', 'leader']);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId, ['admin', 'leader']);
       if (!authCheck.authorized) {
         return res.status(403).json({ success: false, message: authCheck.message });
       }
@@ -443,7 +443,7 @@ module.exports = (pool, logger) => {
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
       // Verify user belongs to this organization
-      const authCheck = await verifyOrganizationMembership(decoded.user_id, organizationId, pool);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId);
       if (!authCheck.authorized) {
         return res.status(403).json({ success: false, message: authCheck.message });
       }
@@ -500,7 +500,7 @@ module.exports = (pool, logger) => {
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
       // Verify user belongs to this organization
-      const authCheck = await verifyOrganizationMembership(decoded.user_id, organizationId, pool);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId);
       if (!authCheck.authorized) {
         return res.status(403).json({ success: false, message: authCheck.message });
       }
@@ -561,7 +561,7 @@ module.exports = (pool, logger) => {
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
       // Verify user belongs to this organization
-      const authCheck = await verifyOrganizationMembership(decoded.user_id, organizationId, pool);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId);
       if (!authCheck.authorized) {
         return res.status(403).json({ success: false, message: authCheck.message });
       }
@@ -613,7 +613,7 @@ module.exports = (pool, logger) => {
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
       // Verify user belongs to this organization
-      const authCheck = await verifyOrganizationMembership(decoded.user_id, organizationId, pool);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId);
       if (!authCheck.authorized) {
         return res.status(403).json({ success: false, message: authCheck.message });
       }
@@ -707,7 +707,7 @@ module.exports = (pool, logger) => {
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
       // Verify user belongs to this organization with admin or leader role
-      const authCheck = await verifyOrganizationMembership(decoded.userId, organizationId, pool, ['admin', 'leader']);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.userId, organizationId, ['admin', 'leader']);
       if (!authCheck.authorized) {
         return res.status(403).json({ success: false, message: authCheck.message });
       }

--- a/routes/calendars.js
+++ b/routes/calendars.js
@@ -125,7 +125,7 @@ module.exports = (pool, logger) => {
 
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
-      const authCheck = await verifyOrganizationMembership(decoded.user_id, organizationId, pool);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId);
       if (!authCheck.authorized || !['admin', 'animation'].includes(authCheck.role)) {
         return res.status(403).json({ success: false, message: 'Insufficient permissions' });
       }
@@ -207,7 +207,7 @@ module.exports = (pool, logger) => {
 
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
-      const authCheck = await verifyOrganizationMembership(decoded.user_id, organizationId, pool);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId);
       if (!authCheck.authorized || !['admin', 'animation'].includes(authCheck.role)) {
         return res.status(403).json({ success: false, message: 'Insufficient permissions' });
       }

--- a/routes/dashboards.js
+++ b/routes/dashboards.js
@@ -193,7 +193,7 @@ document.addEventListener("DOMContentLoaded", function() {
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
       // Verify user belongs to this organization
-      const authCheck = await verifyOrganizationMembership(decoded.user_id, organizationId, pool);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId);
       if (!authCheck.authorized) {
         return res.status(403).json({ success: false, message: authCheck.message });
       }

--- a/routes/forms.js
+++ b/routes/forms.js
@@ -64,7 +64,7 @@ module.exports = (pool, logger) => {
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
       // Verify user belongs to this organization
-      const authCheck = await verifyOrganizationMembership(decoded.user_id, organizationId, pool);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId);
       if (!authCheck.authorized) {
         return res.status(403).json({ success: false, message: authCheck.message });
       }
@@ -201,7 +201,7 @@ module.exports = (pool, logger) => {
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
       // Verify user belongs to this organization
-      const authCheck = await verifyOrganizationMembership(decoded.user_id, organizationId, pool);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId);
       if (!authCheck.authorized) {
         return res.status(403).json({ success: false, message: authCheck.message });
       }
@@ -286,7 +286,7 @@ module.exports = (pool, logger) => {
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
       // Verify user belongs to this organization
-      const authCheck = await verifyOrganizationMembership(decoded.user_id, organizationId, pool);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId);
       if (!authCheck.authorized) {
         return res.status(403).json({ success: false, message: authCheck.message });
       }

--- a/routes/guardians.js
+++ b/routes/guardians.js
@@ -60,7 +60,7 @@ module.exports = (pool, logger) => {
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
       // Verify user belongs to this organization
-      const authCheck = await verifyOrganizationMembership(decoded.user_id, organizationId, pool);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId);
       if (!authCheck.authorized) {
         return res.status(403).json({ success: false, message: authCheck.message });
       }
@@ -166,7 +166,7 @@ module.exports = (pool, logger) => {
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
       // Verify user belongs to this organization
-      const authCheck = await verifyOrganizationMembership(decoded.user_id, organizationId, pool);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId);
       if (!authCheck.authorized) {
         return res.status(403).json({ success: false, message: authCheck.message });
       }
@@ -308,7 +308,7 @@ module.exports = (pool, logger) => {
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
       // Verify user belongs to this organization
-      const authCheck = await verifyOrganizationMembership(decoded.user_id, organizationId, pool);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId);
       if (!authCheck.authorized) {
         return res.status(403).json({ success: false, message: authCheck.message });
       }

--- a/routes/notifications.js
+++ b/routes/notifications.js
@@ -124,7 +124,7 @@ module.exports = (pool, logger) => {
 
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
-      const authCheck = await verifyOrganizationMembership(decoded.user_id, organizationId, pool);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId);
       if (!authCheck.authorized || authCheck.role !== 'admin') {
         return res.status(403).json({ success: false, message: 'Insufficient permissions' });
       }

--- a/routes/reports.js
+++ b/routes/reports.js
@@ -103,7 +103,7 @@ module.exports = (pool, logger) => {
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
       // Verify user belongs to this organization with admin or animation role
-      const authCheck = await verifyOrganizationMembership(decoded.user_id, organizationId, pool, ['admin', 'animation', 'leader']);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId, ['admin', 'animation', 'leader']);
       if (!authCheck.authorized) {
         return res.status(403).json({ success: false, message: authCheck.message });
       }
@@ -213,7 +213,7 @@ module.exports = (pool, logger) => {
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
       // Verify user belongs to this organization with admin or animation role
-      const authCheck = await verifyOrganizationMembership(decoded.user_id, organizationId, pool, ['admin', 'animation', 'leader']);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId, ['admin', 'animation', 'leader']);
       if (!authCheck.authorized) {
         return res.status(403).json({ success: false, message: authCheck.message });
       }
@@ -329,7 +329,7 @@ module.exports = (pool, logger) => {
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
       // Verify user belongs to this organization with admin or animation role
-      const authCheck = await verifyOrganizationMembership(decoded.user_id, organizationId, pool, ['admin', 'animation', 'leader']);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId, ['admin', 'animation', 'leader']);
       if (!authCheck.authorized) {
         return res.status(403).json({ success: false, message: authCheck.message });
       }
@@ -422,7 +422,7 @@ module.exports = (pool, logger) => {
 
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
-      const authCheck = await verifyOrganizationMembership(decoded.user_id, organizationId, pool);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId);
       if (!authCheck.authorized || !['admin', 'animation'].includes(authCheck.role)) {
         return res.status(403).json({ success: false, message: 'Insufficient permissions' });
       }
@@ -476,7 +476,7 @@ module.exports = (pool, logger) => {
 
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
-      const authCheck = await verifyOrganizationMembership(decoded.user_id, organizationId, pool);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId);
       if (!authCheck.authorized || !['admin', 'animation'].includes(authCheck.role)) {
         return res.status(403).json({ success: false, message: 'Insufficient permissions' });
       }
@@ -529,7 +529,7 @@ module.exports = (pool, logger) => {
 
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
-      const authCheck = await verifyOrganizationMembership(decoded.user_id, organizationId, pool);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId);
       if (!authCheck.authorized || !['admin', 'animation'].includes(authCheck.role)) {
         return res.status(403).json({ success: false, message: 'Insufficient permissions' });
       }
@@ -582,7 +582,7 @@ module.exports = (pool, logger) => {
 
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
-      const authCheck = await verifyOrganizationMembership(decoded.user_id, organizationId, pool);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId);
       if (!authCheck.authorized || !['admin', 'animation'].includes(authCheck.role)) {
         return res.status(403).json({ success: false, message: 'Insufficient permissions' });
       }
@@ -634,7 +634,7 @@ module.exports = (pool, logger) => {
 
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
-      const authCheck = await verifyOrganizationMembership(decoded.user_id, organizationId, pool);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId);
       if (!authCheck.authorized || !['admin', 'animation'].includes(authCheck.role)) {
         return res.status(403).json({ success: false, message: 'Insufficient permissions' });
       }
@@ -685,7 +685,7 @@ module.exports = (pool, logger) => {
 
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
-      const authCheck = await verifyOrganizationMembership(decoded.user_id, organizationId, pool);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId);
       if (!authCheck.authorized || !['admin', 'animation'].includes(authCheck.role)) {
         return res.status(403).json({ success: false, message: 'Insufficient permissions' });
       }
@@ -736,7 +736,7 @@ module.exports = (pool, logger) => {
 
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
-      const authCheck = await verifyOrganizationMembership(decoded.user_id, organizationId, pool);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId);
       if (!authCheck.authorized || !['admin', 'animation'].includes(authCheck.role)) {
         return res.status(403).json({ success: false, message: 'Insufficient permissions' });
       }
@@ -788,7 +788,7 @@ module.exports = (pool, logger) => {
 
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
-      const authCheck = await verifyOrganizationMembership(decoded.user_id, organizationId, pool);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId);
       if (!authCheck.authorized || !['admin', 'animation'].includes(authCheck.role)) {
         return res.status(403).json({ success: false, message: 'Insufficient permissions' });
       }


### PR DESCRIPTION
- Fix CSP violation for Microsoft Clarity by adding scriptSrcElem directive
- Remove deprecated apple-mobile-web-app-capable meta tag
- Fix 403 authorization errors by correcting verifyOrganizationMembership parameter order across all route files
- Password autocomplete attributes were already present in login form

Issues resolved:
1. CSP script-src error for Clarity analytics
2. Deprecated meta tag warning
3. 403 authorization check failures in API endpoints