### PR TITLE
Add cdn.jsdelivr.net to CSP for DOMPurify import

### DIFF
--- a/api.js
+++ b/api.js
@@ -38,8 +38,8 @@ app.use(helmet({
   contentSecurityPolicy: {
     directives: {
       defaultSrc: ["'self'"],
-      scriptSrc: ["'self'", "'unsafe-inline'", "https://*.clarity.ms", "https://www.clarity.ms"], // Note: Consider removing unsafe-inline and using nonces in production
-      scriptSrcElem: ["'self'", "'unsafe-inline'", "https://*.clarity.ms", "https://www.clarity.ms"],
+      scriptSrc: ["'self'", "'unsafe-inline'", "https://*.clarity.ms", "https://www.clarity.ms", "https://cdn.jsdelivr.net"], // Note: Consider removing unsafe-inline and using nonces in production
+      scriptSrcElem: ["'self'", "'unsafe-inline'", "https://*.clarity.ms", "https://www.clarity.ms", "https://cdn.jsdelivr.net"],
       styleSrc: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
       fontSrc: ["'self'", "https://fonts.gstatic.com"],
       imgSrc: ["'self'", "data:", "https:"],


### PR DESCRIPTION
Updated Content Security Policy to allow loading DOMPurify from cdn.jsdelivr.net. This fixes the CSP violation error:
'Loading the script https://cdn.jsdelivr.net/npm/dompurify@3.3.0/dist/purify.es.mjs violates the following Content Security Policy directive'

Added https://cdn.jsdelivr.net to both scriptSrc and scriptSrcElem directives.