### PR TITLE
Fix console errors in login functionality

### DIFF
--- a/api.js
+++ b/api.js
@@ -43,7 +43,7 @@ app.use(helmet({
       styleSrc: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
       fontSrc: ["'self'", "https://fonts.gstatic.com"],
       imgSrc: ["'self'", "data:", "https:"],
-      connectSrc: ["'self'", "https://*.clarity.ms", "https://c.bing.com", "https://www.clarity.ms"],
+      connectSrc: ["'self'", "https://*.clarity.ms", "https://c.bing.com", "https://www.clarity.ms", "https://cdn.jsdelivr.net"],
       frameSrc: ["'none'"],
       objectSrc: ["'none'"],
       upgradeInsecureRequests: isProduction ? [] : null,

--- a/spa/calendars.js
+++ b/spa/calendars.js
@@ -15,7 +15,8 @@ export class Calendars {
 
 	async fetchCalendars() {
 		try {
-			this.calendars = await getCalendars();
+			const response = await getCalendars();
+			this.calendars = response.calendars || [];
 			this.calendars.sort((a, b) => a.first_name.localeCompare(b.first_name));
 		} catch (error) {
 			console.error('Error fetching calendars:', error);


### PR DESCRIPTION
Fixed two critical console errors:
1. Added cdn.jsdelivr.net to CSP connect-src directive to allow DOMPurify loading
2. Fixed calendars.js to properly extract calendars array from API response

These fixes resolve:
- CSP violation blocking DOMPurify from CDN
- Module loading failures for attendance.js and manage_participants.js
- TypeError in calendars page (calendars.sort/map is not a function)