### PR TITLE
CRITICAL FIX: Always show errors in production

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -14,7 +14,7 @@ const isProduction = () => {
   }
 };
 const debugLog = (...args) => { if (!isProduction()) console.log(...args); };
-const debugError = (...args) => { if (!isProduction()) console.error(...args); };
+const debugError = (...args) => { console.error(...args); }; // Always show errors, even in production
 const debugWarn = (...args) => { if (!isProduction()) console.warn(...args); };
 const debugInfo = (...args) => { if (!isProduction()) console.info(...args); };
 

--- a/spa/config.js
+++ b/spa/config.js
@@ -248,6 +248,9 @@ if (CONFIG.debugMode) {
     console.log("Version:", CONFIG.VERSION);
     console.log("Environment:", import.meta.env?.MODE || "production");
     console.log("============================");
+} else {
+    // In production, at least show the version for troubleshooting
+    console.log(`Wampums v${CONFIG.VERSION} - Production Mode`);
 }
 
 /**

--- a/spa/utils/DebugUtils.js
+++ b/spa/utils/DebugUtils.js
@@ -41,13 +41,12 @@ export function debugLog(...args) {
 }
 
 /**
- * Log an error message (only if debug mode is enabled)
+ * Log an error message (ALWAYS shown, even in production)
+ * Errors are critical and should never be suppressed
  * @param {...any} args - Arguments to log
  */
 export function debugError(...args) {
-    if (isDebugMode()) {
-        console.error('[ERROR]', ...args);
-    }
+    console.error('[ERROR]', ...args);
 }
 
 /**


### PR DESCRIPTION
- debugError() now always outputs to console, even in production
- Errors are critical and should never be suppressed
- Only debug logs (debugLog, debugWarn) are suppressed in production
- Added version log in production for basic troubleshooting

This fixes the issue where production was completely broken because all errors were being suppressed.