### PR TITLE
Restructure badge system: each star is one database entry

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2810,11 +2810,6 @@ details p {
   transition: width 0.3s;
 }
 
-.badge-add-inline {
-  color: var(--color-primary);
-  font-size: var(--font-size-sm);
-}
-
 /* Legacy badge chip (keep for compatibility) */
 .badge-chip {
   background: #f4f6fb;

--- a/migrations/badge_progress_star_structure.sql
+++ b/migrations/badge_progress_star_structure.sql
@@ -1,0 +1,19 @@
+-- Migration: Change badge_progress structure so each star is one entry
+-- Date: 2025-12-04
+-- Description: Changes etoiles from quantity to star number, adds unique constraint
+
+-- Step 1: Add unique constraint to prevent duplicate star numbers
+-- This ensures each participant can only have one entry per badge per star number
+ALTER TABLE badge_progress
+ADD CONSTRAINT unique_badge_progress UNIQUE (participant_id, territoire_chasse, etoiles);
+
+-- Step 2: Add comment to clarify the new structure
+COMMENT ON COLUMN badge_progress.etoiles IS 'Star number/index (1, 2, 3, etc.) not quantity. Each star is a separate row.';
+
+-- Step 3: Create index for faster lookups when finding the next star number
+CREATE INDEX IF NOT EXISTS idx_badge_progress_lookup
+ON badge_progress(participant_id, territoire_chasse, etoiles);
+
+-- Note: Existing data may need manual cleanup if you have entries with etoiles > 1
+-- Run this query to see which entries need to be split:
+-- SELECT * FROM badge_progress WHERE etoiles > 1;

--- a/scripts/migrate-badge-data.sql
+++ b/scripts/migrate-badge-data.sql
@@ -1,0 +1,48 @@
+-- Data Migration: Split existing multi-star entries into individual star entries
+-- Run this AFTER the structure migration if you have existing data
+
+-- This is a helper script to migrate existing data
+-- WARNING: Review your data first before running!
+
+-- Example migration (customize based on your data):
+-- For each entry with etoiles > 1, create separate entries for each star
+-- This is just a template - adjust based on your actual data needs
+
+DO $$
+DECLARE
+    badge_record RECORD;
+    star_num INTEGER;
+BEGIN
+    -- Find all badges with multiple stars
+    FOR badge_record IN 
+        SELECT * FROM badge_progress WHERE etoiles > 1
+    LOOP
+        -- Create individual entries for each star (2 through etoiles)
+        FOR star_num IN 2..badge_record.etoiles LOOP
+            INSERT INTO badge_progress (
+                participant_id, territoire_chasse, objectif, description,
+                fierte, raison, date_obtention, etoiles,
+                created_at, status, approved_by, approval_date, organization_id
+            ) VALUES (
+                badge_record.participant_id,
+                badge_record.territoire_chasse,
+                badge_record.objectif,
+                badge_record.description,
+                badge_record.fierte,
+                badge_record.raison,
+                badge_record.date_obtention,
+                star_num, -- Individual star number
+                badge_record.created_at,
+                badge_record.status,
+                badge_record.approved_by,
+                badge_record.approval_date,
+                badge_record.organization_id
+            );
+        END LOOP;
+        
+        -- Update original entry to be star 1
+        UPDATE badge_progress 
+        SET etoiles = 1 
+        WHERE id = badge_record.id;
+    END LOOP;
+END $$;

--- a/spa/badge_dashboard.js
+++ b/spa/badge_dashboard.js
@@ -553,23 +553,17 @@ export class BadgeDashboard {
 
             <form id="badge-edit-form" data-participant-id="${participantId}" data-badge-name="${badge?.name || ''}">
               <div class="form-group-compact">
-                <label for="badge-entry-select">${translate("badge_select_entry") || "Entry"}</label>
+                <label for="badge-entry-select">${translate("badge_select_entry") || "Entry"} (Star #${defaultEntry?.etoiles || ""})</label>
                 <select id="badge-entry-select" name="entry">
                   ${entries.map((entry) => `
-                    <option value="${entry.id}">${this.formatReadableDate(entry.date_obtention)} · ${entry.etoiles}⭐</option>
+                    <option value="${entry.id}">⭐${entry.etoiles} · ${this.formatReadableDate(entry.date_obtention)}</option>
                   `).join("")}
                 </select>
               </div>
 
-              <div class="form-row">
-                <div class="form-group-compact">
-                  <label for="badge-stars">⭐ ${translate("badge_stars_label") || "Stars"}</label>
-                  <input id="badge-stars" name="etoiles" type="number" min="0" inputmode="numeric" required value="${defaultEntry?.etoiles || 0}" />
-                </div>
-                <div class="form-group-compact">
-                  <label for="badge-date">${translate("badge_date_label") || "Date"}</label>
-                  <input id="badge-date" name="date_obtention" type="date" value="${formattedDefaultDate}" />
-                </div>
+              <div class="form-group-compact">
+                <label for="badge-date">${translate("badge_date_label") || "Date"}</label>
+                <input id="badge-date" name="date_obtention" type="date" value="${formattedDefaultDate}" />
               </div>
 
               <div class="form-group-compact">
@@ -610,15 +604,9 @@ export class BadgeDashboard {
                 </select>
               </div>
 
-              <div class="form-row">
-                <div class="form-group-compact">
-                  <label for="badge-stars-new">⭐ ${translate("badge_stars_label") || "Stars"}</label>
-                  <input id="badge-stars-new" name="etoiles" type="number" min="1" inputmode="numeric" required value="1" />
-                </div>
-                <div class="form-group-compact">
-                  <label for="badge-date-new">${translate("badge_date_label") || "Date"}</label>
-                  <input id="badge-date-new" name="date_obtention" type="date" />
-                </div>
+              <div class="form-group-compact">
+                <label for="badge-date-new">${translate("badge_date_label") || "Date"}</label>
+                <input id="badge-date-new" name="date_obtention" type="date" />
               </div>
 
               <div class="form-group-compact">
@@ -632,7 +620,7 @@ export class BadgeDashboard {
               </div>
 
               <div class="form-actions">
-                <button type="submit" class="primary-button">${translate("badge_add_button") || "Add Badge"}</button>
+                <button type="submit" class="primary-button">${translate("badge_add_button") || "Add Star"}</button>
               </div>
               <div id="badge-add-feedback" role="status" aria-live="polite"></div>
             </form>
@@ -664,7 +652,6 @@ export class BadgeDashboard {
 
     // Edit form handlers
     const entrySelect = modal.querySelector("#badge-entry-select");
-    const starInput = modal.querySelector("#badge-stars");
     const dateInput = modal.querySelector("#badge-date");
     const objectiveInput = modal.querySelector("#badge-objective");
     const descriptionInput = modal.querySelector("#badge-description");
@@ -680,10 +667,15 @@ export class BadgeDashboard {
       const entryId = parseInt(event.target.value, 10);
       const selected = entries.find((item) => item.id === entryId) || defaultEntry;
       if (!selected) return;
-      starInput.value = selected.etoiles || 0;
       dateInput.value = this.formatDateInput(selected.date_obtention);
       objectiveInput.value = selected.objectif || "";
       descriptionInput.value = selected.description || "";
+
+      // Update the label to show which star is being edited
+      const label = modal.querySelector('label[for="badge-entry-select"]');
+      if (label) {
+        label.textContent = `${translate("badge_select_entry") || "Entry"} (Star #${selected.etoiles})`;
+      }
     });
 
     modal.querySelector("#badge-edit-form")?.addEventListener("submit", async (event) => {
@@ -693,7 +685,6 @@ export class BadgeDashboard {
       const feedback = form.querySelector("#badge-edit-feedback");
 
       const payload = {
-        etoiles: parseInt(form.querySelector("#badge-stars").value, 10) || 0,
         date_obtention: form.querySelector("#badge-date").value || null,
         objectif: form.querySelector("#badge-objective").value?.trim() || null,
         description: form.querySelector("#badge-description").value?.trim() || null
@@ -727,7 +718,6 @@ export class BadgeDashboard {
       const payload = {
         participant_id: participantId,
         territoire_chasse: form.territoire_chasse.value,
-        etoiles: parseInt(form.etoiles.value, 10) || 1,
         date_obtention: form.date_obtention.value || null,
         objectif: form.objectif.value?.trim() || null,
         description: form.description.value?.trim() || null


### PR DESCRIPTION
Database changes:
- Added unique constraint on (participant_id, territoire_chasse, etoiles)
- Etoiles field now represents star number (1, 2, 3) not quantity
- Created migration script and data migration helper
- Stars auto-increment when adding new badge entries

Backend changes:
- save-badge-progress now auto-calculates next star number
- Removed etoiles from request body (auto-assigned)
- Prevents duplicate star numbers per participant/badge

Frontend changes:
- Removed "Add Badge" inline button - use edit icon only
- Removed star number inputs from Add and Edit forms
- Stars are auto-assigned by backend
- Entry selector shows star number (⭐1, ⭐2, etc.)
- Label updates dynamically to show which star is being edited
- Button text changed to "Add Star" for clarity
- Fixed badge-chip flex height (1 1 auto instead of 220px)

This allows participants to have multiple entries (stars) for the same badge, each with its own objective, description, and approval status.