### PR TITLE
Fix badges dashboard cache not refreshing on save

### DIFF
--- a/spa/approve_badges.js
+++ b/spa/approve_badges.js
@@ -1,6 +1,7 @@
 import { getPendingBadges, updateBadgeStatus } from "./ajax-functions.js";
 import { debugLog, debugError, debugWarn, debugInfo } from "./utils/DebugUtils.js";
 import { translate } from "./app.js";
+import { clearBadgeRelatedCaches } from "./indexedDB.js";
 
 export class ApproveBadges {
   constructor(app) {
@@ -87,6 +88,8 @@ export class ApproveBadges {
     try {
       const result = await updateBadgeStatus(badgeId, action);
       if (result.success) {
+        // Clear badge-related caches to ensure fresh data on next load
+        await clearBadgeRelatedCaches();
         this.showMessage(translate("badge_status_updated"));
         await this.fetchPendingBadges();
         this.render();

--- a/spa/indexedDB.js
+++ b/spa/indexedDB.js
@@ -251,7 +251,9 @@ export async function clearBadgeRelatedCaches() {
   const keysToDelete = [
     'badge_dashboard_badges',
     'badge_dashboard_participants',
-    'badge_dashboard_groups'
+    'badge_dashboard_groups',
+    'badge_summary',         // API-level cache used by getBadgeSummary()
+    'participants'           // API-level cache used by getParticipants()
   ];
 
   debugLog("Clearing badge-related caches:", keysToDelete);


### PR DESCRIPTION
The badge dashboard was showing stale data after saves/updates due to incomplete cache invalidation. The clearBadgeRelatedCaches() function was only clearing dashboard-level caches but not the API-level caches used by getBadgeSummary() and getParticipants().

Changes:
- Updated clearBadgeRelatedCaches() to also clear 'badge_summary' and 'participants' API-level cache keys
- Added cache clearing to approve_badges.js after badge status updates to ensure consistent behavior across all badge modifications

This ensures that when the dashboard reloads, fresh data is fetched instead of returning cached stale data.

Fixes issue where changes disappeared on reload but appeared after clearing all site data.