### PR TITLE
Fix edit button and add cache invalidation for fundraisers

### DIFF
--- a/spa/calendars.js
+++ b/spa/calendars.js
@@ -1,6 +1,7 @@
 import { getCalendarsForFundraiser, getFundraiser, updateCalendarEntry, updateCalendarPayment } from './ajax-functions.js';
 import { debugLog, debugError, debugWarn, debugInfo } from "./utils/DebugUtils.js";
 import { translate } from "./app.js";
+import { clearFundraiserRelatedCaches } from './indexedDB.js';
 
 export class Calendars {
 	constructor(app) {
@@ -269,6 +270,8 @@ export class Calendars {
 				if (calendar) {
 					calendar.calendar_amount = parseInt(amount) || 0;
 				}
+				// Invalidate fundraisers cache so totals are updated
+				await clearFundraiserRelatedCaches();
 				this.app.showMessage('calendar_amount_updated', 'success');
 			}
 		} catch (error) {
@@ -291,6 +294,8 @@ export class Calendars {
 						calendar.paid = response.data.paid;
 					}
 				}
+				// Invalidate fundraisers cache so totals are updated
+				await clearFundraiserRelatedCaches();
 				this.app.showMessage('calendar_amount_paid_updated', 'success');
 				this.updateTableOnly();
 			}
@@ -310,6 +315,8 @@ export class Calendars {
 				if (calendar) {
 					calendar.paid = paid;
 				}
+				// Invalidate fundraisers cache so totals are updated
+				await clearFundraiserRelatedCaches();
 				this.app.showMessage('calendar_paid_status_updated', 'success');
 			}
 		} catch (error) {

--- a/spa/fundraisers.js
+++ b/spa/fundraisers.js
@@ -1,6 +1,7 @@
 import { getFundraisers, createFundraiser, updateFundraiser, archiveFundraiser } from './ajax-functions.js';
 import { debugLog, debugError } from "./utils/DebugUtils.js";
 import { translate } from "./app.js";
+import { clearFundraiserRelatedCaches } from './indexedDB.js';
 
 export class Fundraisers {
 	constructor(app) {
@@ -220,7 +221,9 @@ export class Fundraisers {
 		document.querySelectorAll('.edit-fundraiser-btn').forEach(btn => {
 			btn.addEventListener('click', (e) => {
 				const fundraiserId = parseInt(e.target.dataset.id);
-				const fundraiser = this.fundraisers.find(f => f.id === fundraiserId);
+				// Search in both active and archived fundraisers
+				const fundraiser = this.fundraisers.find(f => f.id === fundraiserId) ||
+				                   this.archivedFundraisers.find(f => f.id === fundraiserId);
 				if (fundraiser) {
 					this.showModal(fundraiser);
 				}
@@ -318,6 +321,8 @@ export class Fundraisers {
 					'success'
 				);
 				this.hideModal();
+				// Invalidate cache before refetching
+				await clearFundraiserRelatedCaches();
 				await this.fetchFundraisers();
 				this.render();
 				this.initEventListeners();
@@ -335,6 +340,8 @@ export class Fundraisers {
 			const response = await archiveFundraiser(fundraiserId, true);
 			if (response.success) {
 				this.app.showMessage('fundraiser_archived', 'success');
+				// Invalidate cache before refetching
+				await clearFundraiserRelatedCaches();
 				await this.fetchFundraisers();
 				this.render();
 				this.initEventListeners();
@@ -352,6 +359,8 @@ export class Fundraisers {
 			const response = await archiveFundraiser(fundraiserId, false);
 			if (response.success) {
 				this.app.showMessage('fundraiser_unarchived', 'success');
+				// Invalidate cache before refetching
+				await clearFundraiserRelatedCaches();
 				await this.fetchFundraisers();
 				this.render();
 				this.initEventListeners();

--- a/spa/indexedDB.js
+++ b/spa/indexedDB.js
@@ -267,6 +267,23 @@ export async function clearBadgeRelatedCaches() {
   }
 }
 
+export async function clearFundraiserRelatedCaches() {
+  const keysToDelete = [
+    'fundraisers',           // API-level cache used by getFundraisers()
+    'calendars'              // API-level cache used by getCalendarsForFundraiser()
+  ];
+
+  debugLog("Clearing fundraiser-related caches:", keysToDelete);
+
+  for (const key of keysToDelete) {
+    try {
+      await deleteCachedData(key);
+    } catch (error) {
+      debugWarn(`Failed to delete cache for ${key}:`, error);
+    }
+  }
+}
+
 // Function to sync offline data with retry mechanism
 export async function syncOfflineData() {
   if (!navigator.onLine) {


### PR DESCRIPTION
Fixed Issues:
1. Edit button now works for both active and archived fundraisers
   - Previously only searched in active fundraisers
   - Now searches both this.fundraisers and this.archivedFundraisers

2. Added cache invalidation system for fundraisers
   - Created clearFundraiserRelatedCaches() function in indexedDB.js
   - Invalidates 'fundraisers' and 'calendars' cache keys
   - Called after create, update, and archive operations

3. Cache invalidation in fundraisers.js:
   - After creating a fundraiser
   - After updating a fundraiser
   - After archiving/unarchiving a fundraiser

4. Cache invalidation in calendars.js:
   - After updating calendar amounts
   - After updating amounts paid
   - After updating paid status
   - Ensures fundraiser totals are refreshed

This fixes the issue where changes wouldn't show until clearing site data.