### PR TITLE
Fix fundraiser caching and editing modal

### DIFF
--- a/spa/api/api-endpoints.js
+++ b/spa/api/api-endpoints.js
@@ -963,7 +963,12 @@ export async function getParticipantCalendar(participantId) {
  * Get all fundraisers
  */
 export async function getFundraisers(includeArchived = false) {
-    return API.get('fundraisers', { include_archived: includeArchived });
+    const cacheKey = `fundraisers_${includeArchived ? 'all' : 'active'}_${getCurrentOrganizationId() || 'org'}`;
+
+    return API.get('fundraisers', { include_archived: includeArchived }, {
+        cacheKey,
+        cacheDuration: CONFIG.CACHE_DURATION.MEDIUM
+    });
 }
 
 /**
@@ -998,7 +1003,12 @@ export async function archiveFundraiser(fundraiserId, archived) {
  * Get calendars for a specific fundraiser
  */
 export async function getCalendarsForFundraiser(fundraiserId) {
-    return API.get('calendars', { fundraiser_id: fundraiserId });
+    const cacheKey = `calendars_${fundraiserId}_${getCurrentOrganizationId() || 'org'}`;
+
+    return API.get('calendars', { fundraiser_id: fundraiserId }, {
+        cacheKey,
+        cacheDuration: CONFIG.CACHE_DURATION.MEDIUM
+    });
 }
 
 /**

--- a/spa/calendars.js
+++ b/spa/calendars.js
@@ -271,7 +271,7 @@ export class Calendars {
 					calendar.calendar_amount = parseInt(amount) || 0;
 				}
 				// Invalidate fundraisers cache so totals are updated
-				await clearFundraiserRelatedCaches();
+                                await clearFundraiserRelatedCaches(this.fundraiserId);
 				this.app.showMessage('calendar_amount_updated', 'success');
 			}
 		} catch (error) {
@@ -295,7 +295,7 @@ export class Calendars {
 					}
 				}
 				// Invalidate fundraisers cache so totals are updated
-				await clearFundraiserRelatedCaches();
+                                await clearFundraiserRelatedCaches(this.fundraiserId);
 				this.app.showMessage('calendar_amount_paid_updated', 'success');
 				this.updateTableOnly();
 			}
@@ -316,7 +316,7 @@ export class Calendars {
 					calendar.paid = paid;
 				}
 				// Invalidate fundraisers cache so totals are updated
-				await clearFundraiserRelatedCaches();
+                                await clearFundraiserRelatedCaches(this.fundraiserId);
 				this.app.showMessage('calendar_paid_status_updated', 'success');
 			}
 		} catch (error) {


### PR DESCRIPTION
## Summary
- cache fundraiser calendars per campaign and organization to prevent stale participant data
- clear fundraiser-related caches by prefix and support targeted calendar invalidation
- make fundraiser edit buttons reliably open a prefilled modal

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69332854879c8324bbc13dae88e18f54)