### PR TITLE
Fix administration and organization creation pages

### DIFF
--- a/routes/users.js
+++ b/routes/users.js
@@ -55,7 +55,7 @@ module.exports = (pool, logger) => {
       const organizationId = req.query.organization_id || await getCurrentOrganizationId(req, pool, logger);
 
       const result = await pool.query(
-        `SELECT u.id, u.email, u.full_name, u.is_verified, uo.role, uo.approved
+        `SELECT u.id, u.email, u.full_name, u.is_verified, uo.role
          FROM users u
          JOIN user_organizations uo ON u.id = uo.user_id
          WHERE uo.organization_id = $1

--- a/spa/admin.js
+++ b/spa/admin.js
@@ -22,7 +22,20 @@ export class Admin {
         }
 
         async init() {
-                this.currentOrganizationId = await getCurrentOrganizationId();
+                this.currentOrganizationId =
+                        (await getCurrentOrganizationId()) ||
+                        this.app.organizationId ||
+                        null;
+
+                if (!this.currentOrganizationId) {
+                        this.app.showMessage(
+                                this.app.translate(
+                                        "error_loading_data",
+                                ),
+                                "error",
+                        );
+                        return;
+                }
                 await this.fetchData();
                 this.render();
                 this.initEventListeners();


### PR DESCRIPTION
## Summary
- ensure admin panel resolves organization ID before loading and handles missing context gracefully
- require a valid organization when creating new organizations and initialize forms with proper formats
- remove reference to nonexistent approved column when fetching users to stop admin API errors

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69332b0eb41483249a47b5e3a2f9b95e)