### PR TITLE
Fix fundraiser edit modal lookup

### DIFF
--- a/spa/fundraisers.js
+++ b/spa/fundraisers.js
@@ -230,9 +230,9 @@ export class Fundraisers {
                                 const unarchiveBtn = event.target.closest('.unarchive-fundraiser-btn');
 
                                 if (editBtn) {
-                                        const fundraiserId = parseInt(editBtn.dataset.id);
-                                        const fundraiser = this.fundraisers.find(f => f.id === fundraiserId) ||
-                                                           this.archivedFundraisers.find(f => f.id === fundraiserId);
+                                        const fundraiserId = editBtn.dataset.id;
+                                        const fundraiser = this.fundraisers.find(f => String(f.id) === fundraiserId) ||
+                                                           this.archivedFundraisers.find(f => String(f.id) === fundraiserId);
                                         if (fundraiser) {
                                                 this.showModal(fundraiser);
                                         }


### PR DESCRIPTION
## Summary
- ensure fundraiser edit button finds matching item by comparing string ids
- allow edit modal to open for both active and archived fundraisers when ids are not numeric

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69333007f45c8324a3b3d8e01eb6540b)