### PR TITLE
Fix admin dashboard subscriber fetch and user rendering

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -581,6 +581,7 @@
   "no_report_data_available": "No report data available. Please refresh when online.",
   "no_results_found": "No results found",
   "no_reunion_preparation_found": "No reunion preparation found for this date",
+  "no_users_found": "No users found",
   "no_selection": "No selection",
   "no_submission_data_found": "No submission data found",
   "no_submission_or_participant": "No submission or participant found",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -581,6 +581,7 @@
   "no_report_data_available": "Aucune donnée de rapport disponible. Veuillez actualiser lorsque vous êtes en ligne.",
   "no_results_found": "Aucun résultat trouvé",
   "no_reunion_preparation_found": "Aucune préparation de réunion trouvée pour cette date",
+  "no_users_found": "Aucun utilisateur trouvé",
   "no_selection": "Aucune sélection.",
   "no_submission_data_found": "Aucune donnée de soumission trouvée",
   "no_submission_or_participant": "Aucune soumission ou participant trouvé",

--- a/lang/update_translations.js
+++ b/lang/update_translations.js
@@ -205,6 +205,7 @@ const newTranslations = {
 
     // Backend: Not found messages
     "no_reunion_preparation_found": "No reunion preparation found for this date",
+    "no_users_found": "No users found",
     "no_subscribers_found": "No subscribers found",
     "participant_not_found": "Participant not found",
     "participant_duplicate": "A participant with this name and date of birth already exists",
@@ -380,6 +381,7 @@ const newTranslations = {
 
     // Backend: Not found messages
     "no_reunion_preparation_found": "Aucune préparation de réunion trouvée pour cette date",
+    "no_users_found": "Aucun utilisateur trouvé",
     "no_subscribers_found": "Aucun abonné trouvé",
     "participant_not_found": "Participant non trouvé",
     "participant_duplicate": "Un participant avec ce nom et cette date de naissance existe déjà",

--- a/spa/api/api-endpoints.js
+++ b/spa/api/api-endpoints.js
@@ -1294,10 +1294,10 @@ export async function getInitialData() {
 }
 
 /**
- * Get subscribers
+ * Get push notification subscribers
  */
 export async function getSubscribers(organizationId) {
-    return API.get('subscribers', { organization_id: organizationId });
+    return API.get('push-subscribers', { organization_id: organizationId });
 }
 
 /**


### PR DESCRIPTION
## Summary
- update admin dashboard data fetching to handle users/subscribers safely and use the push-subscribers API
- sanitize rendered emails/names and add empty-state messaging for users and subscribers
- add translations for new empty-state text in both languages

## Testing
- npm test -- --runInBand *(fails: npm command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69333955b8348324b0b7a538bce27823)