### PR TITLE
Improve admin subscriber handling

### DIFF
--- a/spa/api/api-endpoints.js
+++ b/spa/api/api-endpoints.js
@@ -1297,7 +1297,14 @@ export async function getInitialData() {
  * Get push notification subscribers
  */
 export async function getSubscribers(organizationId) {
-    return API.get('push-subscribers', { organization_id: organizationId });
+    try {
+        return await API.get('push-subscribers', {
+            organization_id: organizationId
+        });
+    } catch (error) {
+        debugWarn('Push subscriber endpoint unavailable, returning empty list', error);
+        return { success: false, data: [] };
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary
- normalize admin user handling to avoid runtime errors when unexpected response shapes are returned
- guard subscriber loading so admin page keeps working even if the push subscriber endpoint is unavailable
- return an empty subscriber list when the push subscriber endpoint cannot be reached

## Testing
- npm test *(fails: npm command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69333a8273688324bdd58cb81d0468e7)