### PR TITLE
Add clear error messages for duplicate accounts

### DIFF
--- a/spa/register.js
+++ b/spa/register.js
@@ -76,19 +76,24 @@ export class Register {
       }
     } catch (error) {
       debugError("Registration error:", error);
-      this.showError(translate("error_creating_account"));
+      // Display the specific error message if available, otherwise show generic error
+      this.showError(error.message || translate("error_creating_account"));
     }
   }
 
   showError(message) {
     const errorElement = document.getElementById("error-message");
+    const successElement = document.getElementById("success-message");
     errorElement.textContent = message;
     errorElement.style.display = "block";
+    successElement.style.display = "none";
   }
 
   showSuccess(message) {
     const successElement = document.getElementById("success-message");
+    const errorElement = document.getElementById("error-message");
     successElement.textContent = message;
     successElement.style.display = "block";
+    errorElement.style.display = "none";
   }
 }


### PR DESCRIPTION
- Add /public/register endpoint to handle frontend registration requests
- Implement proper error handling for duplicate email addresses in both /public/register and /api/auth/register
- Return clear, user-friendly error message when email already exists: "An account with this email address already exists. Please use a different email or try logging in."
- Normalize email addresses to lowercase before insertion to prevent case-sensitive duplicates
- Update frontend to display specific error messages from the backend instead of generic error
- Improve UX by hiding success messages when showing errors and vice versa

Fixes issue where users attempting to register with an existing email received unclear error messages.