### PR TITLE
Fix auth endpoint paths for reset and logout

### DIFF
--- a/spa/api/api-endpoints.js
+++ b/spa/api/api-endpoints.js
@@ -127,14 +127,14 @@ export async function verifyEmail(token) {
  * Request password reset
  */
 export async function requestPasswordReset(email) {
-    return API.post('request-reset', { email });
+    return API.post('auth/request-reset', { email });
 }
 
 /**
  * Reset password with token
  */
 export async function resetPassword(token, newPassword) {
-    return API.post('reset-password', { token, new_password: newPassword });
+    return API.post('auth/reset-password', { token, new_password: newPassword });
 }
 
 /**
@@ -148,7 +148,7 @@ export async function refreshToken() {
  * Logout user
  */
 export async function logout() {
-    const result = await API.post('logout');
+    const result = await API.post('auth/logout');
 
     // Clear user-specific data but keep organization JWT
     localStorage.removeItem("userRole");

--- a/spa/config.js
+++ b/spa/config.js
@@ -97,9 +97,9 @@ export const CONFIG = {
     ENDPOINTS: {
         // Auth
         LOGIN: "/public/login",
-        LOGOUT: "/api/logout",
-        REGISTER: "/api/register",
-        RESET_PASSWORD: "/api/reset-password",
+        LOGOUT: "/api/auth/logout",
+        REGISTER: "/api/auth/register",
+        RESET_PASSWORD: "/api/auth/reset-password",
 
         // Organization
         ORGANIZATION_SETTINGS: "/api/organization-settings",


### PR DESCRIPTION
## Summary
- align SPA auth API calls with backend /api/auth routes for password reset and logout
- update shared config endpoints to match corrected auth paths

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69336a4411648324abf787ed88dae3ef)