### PR TITLE
Ensure email normalization preserves formatting

### DIFF
--- a/middleware/validation.js
+++ b/middleware/validation.js
@@ -33,7 +33,7 @@ const checkValidation = (req, res, next) => {
 
 /**
  * Validate email format and length
- * Normalizes email to lowercase
+ * Normalizes email to lowercase without altering provider-specific formatting
  */
 const validateEmail = check('email')
   .trim()
@@ -44,6 +44,7 @@ const validateEmail = check('email')
     outlookdotcom_remove_subaddress: false,
     yahoo_remove_subaddress: false,
     icloud_remove_subaddress: false,
+    gmail_convert_googlemaildotcom: false,
   })
   .withMessage('Valid email is required')
   .isLength({ max: 255 })
@@ -62,10 +63,18 @@ const validateEmailOptional = check('email')
     outlookdotcom_remove_subaddress: false,
     yahoo_remove_subaddress: false,
     icloud_remove_subaddress: false,
+    gmail_convert_googlemaildotcom: false,
   })
   .withMessage('Valid email is required')
   .isLength({ max: 255 })
   .withMessage('Email too long');
+
+/**
+ * Canonicalize email without removing dots or subaddresses
+ * @param {string} email - Raw email input
+ * @returns {string} Trimmed, lowercase email preserving user formatting
+ */
+const normalizeEmailInput = (email = '') => email.toString().trim().toLowerCase();
 
 // ============================================
 // PASSWORD VALIDATIONS
@@ -325,5 +334,8 @@ module.exports = {
   validateToken,
 
   // Attendance
-  validateAttendanceStatus
+  validateAttendanceStatus,
+
+  // Helpers
+  normalizeEmailInput
 };

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -24,7 +24,8 @@ const {
   validateNewPassword,
   validateToken,
   validateFullName,
-  checkValidation
+  checkValidation,
+  normalizeEmailInput
 } = require('../middleware/validation');
 
 // Import utilities
@@ -138,7 +139,7 @@ module.exports = (pool, logger) => {
       try {
         const organizationId = await getCurrentOrganizationId(req, pool, logger);
         const { email, password } = req.body;
-        const normalizedEmail = email.toLowerCase();
+        const normalizedEmail = normalizeEmailInput(email);
         const trimmedPassword = password.trim();
 
         const userResult = await pool.query(
@@ -270,7 +271,7 @@ module.exports = (pool, logger) => {
       try {
         const organizationId = await getCurrentOrganizationId(req, pool, logger);
         const { email, password, full_name, user_type } = req.body;
-        const normalizedEmail = email.toLowerCase();
+        const normalizedEmail = normalizeEmailInput(email);
         const trimmedPassword = password.trim();
         const role = mapRequestedRole(user_type);
 
@@ -354,7 +355,7 @@ module.exports = (pool, logger) => {
       try {
         const organizationId = await getCurrentOrganizationId(req, pool, logger);
         const { email, password, full_name, user_type } = req.body;
-        const normalizedEmail = email.toLowerCase();
+        const normalizedEmail = normalizeEmailInput(email);
         const trimmedPassword = password.trim();
         const role = mapRequestedRole(user_type);
 
@@ -435,7 +436,7 @@ module.exports = (pool, logger) => {
     async (req, res) => {
       try {
         const { email } = req.body;
-        const normalizedEmail = email.trim().toLowerCase();
+        const normalizedEmail = normalizeEmailInput(email);
 
         logger.info('Password reset request received', {
           email: normalizedEmail,


### PR DESCRIPTION
## Summary
- add helper to canonicalize emails without altering provider-specific formatting
- reuse the helper across authentication flows to prevent dot removal during login/registration/password reset
- tighten email validator options to avoid hidden provider transformations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935f0e2dd448324a41ed6e915242303)