### PR TITLE
Add bilingual landing page for weekly scout management

### DIFF
--- a/index_2.html
+++ b/index_2.html
@@ -1,0 +1,593 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Wampums - Gestion des scouts</title>
+  <style>
+    :root {
+      --color-primary: #4c65ae;
+      --color-primary-dark: #3a4f8a;
+      --color-secondary: #f4f4f4;
+      --color-text: #111827;
+      --color-text-muted: #4b5563;
+      --color-surface: #ffffff;
+      --color-border: #e5e7eb;
+      --color-highlight: #f2f6ff;
+      --shadow-card: 0 10px 25px rgb(17 24 39 / 0.08);
+      --radius-lg: 1rem;
+      --radius-md: 0.75rem;
+      --space-2xs: 0.35rem;
+      --space-xs: 0.5rem;
+      --space-sm: 0.75rem;
+      --space-md: 1rem;
+      --space-lg: 1.5rem;
+      --space-xl: 2rem;
+      --max-width: 1100px;
+      --touch-target: 44px;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+      background: #f8fafc;
+      color: var(--color-text);
+      line-height: 1.6;
+    }
+
+    a {
+      color: inherit;
+    }
+
+    .skip-link {
+      position: absolute;
+      top: -100px;
+      left: 0;
+      background: var(--color-primary);
+      color: #fff;
+      padding: var(--space-xs) var(--space-md);
+      border-radius: var(--radius-md);
+      z-index: 100;
+      transition: top 0.2s ease;
+    }
+
+    .skip-link:focus {
+      top: var(--space-xs);
+      outline: 3px solid #fff;
+    }
+
+    header {
+      background: radial-gradient(circle at 10% 20%, #e9edfb, #f8fafc 40%), linear-gradient(135deg, #fff 0%, #f0f4ff 100%);
+      padding: var(--space-lg) var(--space-md) var(--space-xl);
+      border-bottom: 1px solid var(--color-border);
+    }
+
+    .shell {
+      max-width: var(--max-width);
+      margin: 0 auto;
+      padding: 0 var(--space-md);
+    }
+
+    .top-bar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--space-sm);
+      margin-bottom: var(--space-lg);
+      flex-wrap: wrap;
+    }
+
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      gap: var(--space-xs);
+      font-weight: 700;
+      color: var(--color-primary-dark);
+      letter-spacing: 0.01em;
+    }
+
+    .brand-mark {
+      width: 2.5rem;
+      height: 2.5rem;
+      background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-dark) 100%);
+      color: #fff;
+      border-radius: 0.85rem;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 800;
+      box-shadow: var(--shadow-card);
+    }
+
+    .lang-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: var(--space-xs);
+      background: var(--color-surface);
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-full, 999px);
+      padding: var(--space-2xs) var(--space-xs);
+      box-shadow: 0 1px 4px rgb(0 0 0 / 0.05);
+    }
+
+    .lang-toggle button {
+      min-height: var(--touch-target);
+      padding: 0 var(--space-md);
+      border: none;
+      background: transparent;
+      border-radius: var(--radius-full, 999px);
+      color: var(--color-text);
+      font-weight: 600;
+      cursor: pointer;
+    }
+
+    .lang-toggle button[aria-pressed="true"] {
+      background: var(--color-primary);
+      color: #fff;
+      box-shadow: inset 0 0 0 1px #fff;
+    }
+
+    .hero {
+      display: grid;
+      gap: var(--space-lg);
+    }
+
+    .hero h1 {
+      font-size: clamp(1.8rem, 1.5rem + 2vw, 2.6rem);
+      margin: 0 0 var(--space-sm);
+      letter-spacing: -0.01em;
+    }
+
+    .hero p {
+      margin: 0;
+      color: var(--color-text-muted);
+      font-size: 1.05rem;
+    }
+
+    .badge-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--space-sm);
+      margin: var(--space-md) 0 var(--space-lg);
+    }
+
+    .pill {
+      background: var(--color-highlight);
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-full, 999px);
+      padding: var(--space-2xs) var(--space-sm);
+      font-weight: 600;
+      color: var(--color-primary-dark);
+      display: inline-flex;
+      align-items: center;
+      gap: var(--space-2xs);
+    }
+
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--space-sm);
+    }
+
+    .btn-primary, .btn-secondary {
+      min-height: var(--touch-target);
+      padding: var(--space-sm) var(--space-lg);
+      font-weight: 700;
+      border-radius: var(--radius-md);
+      border: 2px solid transparent;
+      cursor: pointer;
+      text-decoration: none;
+      text-align: center;
+    }
+
+    .btn-primary {
+      background: var(--color-primary);
+      color: #fff;
+      border-color: var(--color-primary);
+      box-shadow: 0 8px 20px rgb(76 101 174 / 0.25);
+    }
+
+    .btn-primary:focus-visible,
+    .btn-secondary:focus-visible,
+    .lang-toggle button:focus-visible,
+    .card:focus-visible {
+      outline: 3px solid #111;
+      outline-offset: 4px;
+    }
+
+    .btn-secondary {
+      background: #fff;
+      color: var(--color-primary-dark);
+      border-color: var(--color-border);
+    }
+
+    main {
+      padding: var(--space-xl) var(--space-md) var(--space-2xl);
+    }
+
+    .section {
+      max-width: var(--max-width);
+      margin: 0 auto var(--space-xl);
+    }
+
+    .section h2 {
+      margin: 0 0 var(--space-sm);
+      font-size: 1.5rem;
+      letter-spacing: -0.01em;
+    }
+
+    .section p {
+      margin: 0 0 var(--space-md);
+      color: var(--color-text-muted);
+    }
+
+    .grid {
+      display: grid;
+      gap: var(--space-md);
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    }
+
+    .card {
+      background: var(--color-surface);
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-lg);
+      padding: var(--space-lg);
+      box-shadow: var(--shadow-card);
+      display: grid;
+      gap: var(--space-sm);
+    }
+
+    .card h3 {
+      margin: 0;
+      font-size: 1.1rem;
+    }
+
+    .meta {
+      font-size: 0.95rem;
+      color: var(--color-text-muted);
+    }
+
+    .list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: grid;
+      gap: var(--space-xs);
+    }
+
+    .list li {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      align-items: start;
+      gap: var(--space-xs);
+    }
+
+    .dot {
+      width: 10px;
+      height: 10px;
+      margin-top: 0.35rem;
+      border-radius: 50%;
+      background: var(--color-primary);
+    }
+
+    .stats {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: var(--space-md);
+      margin-top: var(--space-md);
+    }
+
+    .stat {
+      background: var(--color-highlight);
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-md);
+      padding: var(--space-md);
+      display: grid;
+      gap: var(--space-2xs);
+      font-weight: 700;
+      color: var(--color-primary-dark);
+    }
+
+    footer {
+      background: #0f172a;
+      color: #e2e8f0;
+      padding: var(--space-lg) var(--space-md);
+      text-align: center;
+    }
+
+    footer p {
+      margin: 0;
+      color: #cbd5e1;
+    }
+
+    @media (min-width: 768px) {
+      .hero {
+        grid-template-columns: 1.2fr 1fr;
+        align-items: center;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        scroll-behavior: auto !important;
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+      }
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main" data-i18n="skip_link">Passer au contenu principal</a>
+  <header>
+    <div class="shell">
+      <div class="top-bar">
+        <div class="brand" aria-label="Wampums">
+          <span class="brand-mark" aria-hidden="true">W</span>
+          <span>Wampums</span>
+        </div>
+        <div class="lang-toggle" role="group" aria-label="Changer de langue">
+          <button type="button" data-lang="fr" aria-pressed="true">Français</button>
+          <button type="button" data-lang="en" aria-pressed="false">English</button>
+        </div>
+      </div>
+      <div class="hero" role="banner">
+        <div>
+          <p class="pill" data-i18n="tagline">Application web bilingue pour les scouts</p>
+          <h1 data-i18n="hero_title">Orchestrez vos réunions hebdomadaires, vos parents et vos équipes en toute sérénité.</h1>
+          <p data-i18n="hero_body">Wampums centralise l'organisation des groupes scouts : agenda des rencontres, présence, progression, communications et documents, pour que chaque réunion soit prête et sécuritaire.</p>
+          <div class="badge-row">
+            <span class="pill" data-i18n="badge1">Planification mobile-first</span>
+            <span class="pill" data-i18n="badge2">Suivi badges et présences</span>
+            <span class="pill" data-i18n="badge3">Parents connectés</span>
+          </div>
+          <div class="actions">
+            <a class="btn-primary" href="#features" data-i18n="cta_primary">Découvrir les fonctions clés</a>
+            <a class="btn-secondary" href="#weekly" data-i18n="cta_secondary">Voir la gestion des réunions</a>
+          </div>
+        </div>
+        <div class="card" aria-label="Aperçu des fonctionnalités" tabindex="0">
+          <h3 data-i18n="card_title">Tout-en-un pour votre groupe</h3>
+          <p class="meta" data-i18n="card_subtitle">Suivi des membres, activités, badges, documents et paiements.</p>
+          <div class="stats" aria-label="Indicateurs clés">
+            <div class="stat">
+              <span data-i18n="stat1_label">Réunions prêtes</span>
+              <span aria-hidden="true">✅</span>
+            </div>
+            <div class="stat">
+              <span data-i18n="stat2_label">Présences tracées</span>
+              <span aria-hidden="true">📊</span>
+            </div>
+            <div class="stat">
+              <span data-i18n="stat3_label">Parents informés</span>
+              <span aria-hidden="true">📢</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main id="main">
+    <section class="section" id="features">
+      <h2 data-i18n="features_title">Fonctions conçues pour les unités scoutes</h2>
+      <p data-i18n="features_body">Chaque module est pensé pour les réalités des équipes d'animation : préparation rapide, suivi clair et collaboration avec les parents.</p>
+      <div class="grid" role="list">
+        <article class="card" role="listitem">
+          <h3 data-i18n="feature1_title">Planification des rencontres</h3>
+          <p class="meta" data-i18n="feature1_body">Planifiez les activités hebdomadaires, matériaux et responsabilités, avec un calendrier partagé.</p>
+        </article>
+        <article class="card" role="listitem">
+          <h3 data-i18n="feature2_title">Présences et progression</h3>
+          <p class="meta" data-i18n="feature2_body">Consignez les présences, les points et l'avancement des badges ou honneurs.</p>
+        </article>
+        <article class="card" role="listitem">
+          <h3 data-i18n="feature3_title">Communication aux parents</h3>
+          <p class="meta" data-i18n="feature3_body">Envoyez des nouvelles, rappels et documents pour que les familles restent alignées.</p>
+        </article>
+        <article class="card" role="listitem">
+          <h3 data-i18n="feature4_title">Gestion des rôles</h3>
+          <p class="meta" data-i18n="feature4_body">Attribuez les rôles (admin, animation, parents) et sécurisez l'accès aux données.</p>
+        </article>
+        <article class="card" role="listitem">
+          <h3 data-i18n="feature5_title">Documents et consentements</h3>
+          <p class="meta" data-i18n="feature5_body">Stockez fiches santé, autorisations et rapports pour des activités conformes.</p>
+        </article>
+        <article class="card" role="listitem">
+          <h3 data-i18n="feature6_title">Rapports et export</h3>
+          <p class="meta" data-i18n="feature6_body">Générez des rapports sur la participation, la progression et les ventes de calendriers.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section" id="weekly">
+      <h2 data-i18n="weekly_title">Prêt pour chaque réunion hebdomadaire</h2>
+      <p data-i18n="weekly_body">Un fil conducteur clair pour préparer, tenir et archiver vos rencontres avec fiabilité.</p>
+      <div class="grid">
+        <article class="card">
+          <h3 data-i18n="weekly_step1_title">Avant la réunion</h3>
+          <ul class="list">
+            <li><span class="dot" aria-hidden="true"></span><span data-i18n="weekly_step1_item1">Ajoutez l'activité, l'objectif d'apprentissage et les ressources nécessaires.</span></li>
+            <li><span class="dot" aria-hidden="true"></span><span data-i18n="weekly_step1_item2">Assignez les responsables et partagez la liste avec l'équipe.</span></li>
+            <li><span class="dot" aria-hidden="true"></span><span data-i18n="weekly_step1_item3">Envoyez un rappel aux parents avec les détails logistiques.</span></li>
+          </ul>
+        </article>
+        <article class="card">
+          <h3 data-i18n="weekly_step2_title">Pendant la réunion</h3>
+          <ul class="list">
+            <li><span class="dot" aria-hidden="true"></span><span data-i18n="weekly_step2_item1">Enregistrez les présences et les points en direct sur mobile.</span></li>
+            <li><span class="dot" aria-hidden="true"></span><span data-i18n="weekly_step2_item2">Notez les progrès de badges ou tout besoin de suivi.</span></li>
+            <li><span class="dot" aria-hidden="true"></span><span data-i18n="weekly_step2_item3">Consignez les observations pour le rapport de fin de rencontre.</span></li>
+          </ul>
+        </article>
+        <article class="card">
+          <h3 data-i18n="weekly_step3_title">Après la réunion</h3>
+          <ul class="list">
+            <li><span class="dot" aria-hidden="true"></span><span data-i18n="weekly_step3_item1">Envoyez un compte rendu aux parents et à l'équipe.</span></li>
+            <li><span class="dot" aria-hidden="true"></span><span data-i18n="weekly_step3_item2">Mettez à jour les inventaires, les paiements et les documents.</span></li>
+            <li><span class="dot" aria-hidden="true"></span><span data-i18n="weekly_step3_item3">Planifiez la prochaine rencontre à partir du modèle existant.</span></li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <section class="section" id="benefits">
+      <h2 data-i18n="benefits_title">Pourquoi Wampums aide votre communauté</h2>
+      <div class="grid">
+        <article class="card">
+          <h3 data-i18n="benefit1_title">Animation efficace</h3>
+          <p class="meta" data-i18n="benefit1_body">Moins d'administration, plus de temps sur le terrain grâce à des modèles et rappels prêts à l'emploi.</p>
+        </article>
+        <article class="card">
+          <h3 data-i18n="benefit2_title">Parents rassurés</h3>
+          <p class="meta" data-i18n="benefit2_body">Informations claires, notifications rapides et documents centralisés pour suivre l'avancement.</p>
+        </article>
+        <article class="card">
+          <h3 data-i18n="benefit3_title">Sécurité et conformité</h3>
+          <p class="meta" data-i18n="benefit3_body">Gestion des autorisations, des rôles et des dossiers pour des activités sécuritaires.</p>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <p data-i18n="footer_note">Conçu pour les groupes scouts qui se rencontrent chaque semaine — simple, bilingue et prêt à l'emploi.</p>
+  </footer>
+
+  <script>
+    const translations = {
+      fr: {
+        skip_link: "Passer au contenu principal",
+        tagline: "Application web bilingue pour les scouts",
+        hero_title: "Orchestrez vos réunions hebdomadaires, vos parents et vos équipes en toute sérénité.",
+        hero_body: "Wampums centralise l'organisation des groupes scouts : agenda des rencontres, présence, progression, communications et documents, pour que chaque réunion soit prête et sécuritaire.",
+        badge1: "Planification mobile-first",
+        badge2: "Suivi badges et présences",
+        badge3: "Parents connectés",
+        cta_primary: "Découvrir les fonctions clés",
+        cta_secondary: "Voir la gestion des réunions",
+        card_title: "Tout-en-un pour votre groupe",
+        card_subtitle: "Suivi des membres, activités, badges, documents et paiements.",
+        stat1_label: "Réunions prêtes",
+        stat2_label: "Présences tracées",
+        stat3_label: "Parents informés",
+        features_title: "Fonctions conçues pour les unités scoutes",
+        features_body: "Chaque module est pensé pour les réalités des équipes d'animation : préparation rapide, suivi clair et collaboration avec les parents.",
+        feature1_title: "Planification des rencontres",
+        feature1_body: "Planifiez les activités hebdomadaires, matériaux et responsabilités, avec un calendrier partagé.",
+        feature2_title: "Présences et progression",
+        feature2_body: "Consignez les présences, les points et l'avancement des badges ou honneurs.",
+        feature3_title: "Communication aux parents",
+        feature3_body: "Envoyez des nouvelles, rappels et documents pour que les familles restent alignées.",
+        feature4_title: "Gestion des rôles",
+        feature4_body: "Attribuez les rôles (admin, animation, parents) et sécurisez l'accès aux données.",
+        feature5_title: "Documents et consentements",
+        feature5_body: "Stockez fiches santé, autorisations et rapports pour des activités conformes.",
+        feature6_title: "Rapports et export",
+        feature6_body: "Générez des rapports sur la participation, la progression et les ventes de calendriers.",
+        weekly_title: "Prêt pour chaque réunion hebdomadaire",
+        weekly_body: "Un fil conducteur clair pour préparer, tenir et archiver vos rencontres avec fiabilité.",
+        weekly_step1_title: "Avant la réunion",
+        weekly_step1_item1: "Ajoutez l'activité, l'objectif d'apprentissage et les ressources nécessaires.",
+        weekly_step1_item2: "Assignez les responsables et partagez la liste avec l'équipe.",
+        weekly_step1_item3: "Envoyez un rappel aux parents avec les détails logistiques.",
+        weekly_step2_title: "Pendant la réunion",
+        weekly_step2_item1: "Enregistrez les présences et les points en direct sur mobile.",
+        weekly_step2_item2: "Notez les progrès de badges ou tout besoin de suivi.",
+        weekly_step2_item3: "Consignez les observations pour le rapport de fin de rencontre.",
+        weekly_step3_title: "Après la réunion",
+        weekly_step3_item1: "Envoyez un compte rendu aux parents et à l'équipe.",
+        weekly_step3_item2: "Mettez à jour les inventaires, les paiements et les documents.",
+        weekly_step3_item3: "Planifiez la prochaine rencontre à partir du modèle existant.",
+        benefits_title: "Pourquoi Wampums aide votre communauté",
+        benefit1_title: "Animation efficace",
+        benefit1_body: "Moins d'administration, plus de temps sur le terrain grâce à des modèles et rappels prêts à l'emploi.",
+        benefit2_title: "Parents rassurés",
+        benefit2_body: "Informations claires, notifications rapides et documents centralisés pour suivre l'avancement.",
+        benefit3_title: "Sécurité et conformité",
+        benefit3_body: "Gestion des autorisations, des rôles et des dossiers pour des activités sécuritaires.",
+        footer_note: "Conçu pour les groupes scouts qui se rencontrent chaque semaine — simple, bilingue et prêt à l'emploi."
+      },
+      en: {
+        skip_link: "Skip to main content",
+        tagline: "Bilingual web app for scouting groups",
+        hero_title: "Coordinate weekly meetings, parents, and crews with confidence.",
+        hero_body: "Wampums centralizes scout group operations: meeting schedules, attendance, advancement, communications, and documents so every gathering is ready and safe.",
+        badge1: "Mobile-first planning",
+        badge2: "Badge and attendance tracking",
+        badge3: "Parents stay informed",
+        cta_primary: "Explore core features",
+        cta_secondary: "See weekly meeting flow",
+        card_title: "All-in-one for your troop",
+        card_subtitle: "Track members, activities, badges, documents, and payments.",
+        stat1_label: "Meetings prepared",
+        stat2_label: "Attendance captured",
+        stat3_label: "Parents updated",
+        features_title: "Built for weekly scout units",
+        features_body: "Every module fits real-world leadership needs: quick prep, clear follow-up, and tight parent collaboration.",
+        feature1_title: "Meeting planning",
+        feature1_body: "Schedule weekly activities, materials, and responsibilities with a shared calendar.",
+        feature2_title: "Attendance & advancement",
+        feature2_body: "Record attendance, points, and badge or honor progress.",
+        feature3_title: "Parent communications",
+        feature3_body: "Send updates, reminders, and documents so families stay aligned.",
+        feature4_title: "Role management",
+        feature4_body: "Assign roles (admin, leaders, parents) and secure access to data.",
+        feature5_title: "Documents & consents",
+        feature5_body: "Store health forms, permissions, and reports to keep activities compliant.",
+        feature6_title: "Reports & export",
+        feature6_body: "Generate reports on participation, advancement, and calendar sales.",
+        weekly_title: "Ready for every weekly meeting",
+        weekly_body: "A clear guide to prepare, deliver, and archive each gathering reliably.",
+        weekly_step1_title: "Before the meeting",
+        weekly_step1_item1: "Add the activity, learning goal, and required resources.",
+        weekly_step1_item2: "Assign leaders and share the checklist with the crew.",
+        weekly_step1_item3: "Send a reminder to parents with logistics.",
+        weekly_step2_title: "During the meeting",
+        weekly_step2_item1: "Capture attendance and points live on mobile.",
+        weekly_step2_item2: "Log badge progress or any follow-up needs.",
+        weekly_step2_item3: "Record observations for the end-of-meeting report.",
+        weekly_step3_title: "After the meeting",
+        weekly_step3_item1: "Share a recap with parents and the team.",
+        weekly_step3_item2: "Update inventories, payments, and documents.",
+        weekly_step3_item3: "Plan the next gathering using the existing template.",
+        benefits_title: "How Wampums supports your community",
+        benefit1_title: "Effective leadership",
+        benefit1_body: "Less admin, more time outdoors thanks to ready-to-use templates and reminders.",
+        benefit2_title: "Confident parents",
+        benefit2_body: "Clear information, fast notifications, and centralized documents to follow progress.",
+        benefit3_title: "Safety and compliance",
+        benefit3_body: "Manage permissions, roles, and records to keep activities safe.",
+        footer_note: "Built for scout groups that meet every week — simple, bilingual, and ready to deploy."
+      }
+    };
+
+    const html = document.documentElement;
+    const buttons = document.querySelectorAll('.lang-toggle button');
+
+    function applyTranslations(lang) {
+      const copy = translations[lang];
+      if (!copy) return;
+      html.lang = lang;
+      document.title = lang === 'fr' ? 'Wampums - Gestion des scouts' : 'Wampums - Scout Management';
+      document.querySelectorAll('[data-i18n]').forEach((node) => {
+        const key = node.getAttribute('data-i18n');
+        if (copy[key]) {
+          node.textContent = copy[key];
+        }
+      });
+      buttons.forEach((btn) => btn.setAttribute('aria-pressed', btn.dataset.lang === lang ? 'true' : 'false'));
+    }
+
+    buttons.forEach((button) => {
+      button.addEventListener('click', () => applyTranslations(button.dataset.lang));
+    });
+
+    applyTranslations('fr');
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a mobile-first bilingual marketing page highlighting Wampums features for weekly scout meetings
- include accessibility features such as skip links, WCAG-friendly contrast, and focus states
- provide inline translation copy and language toggle defaulting to French

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935fbae92dc83249cb303afdd1ed0fe)