### PR TITLE
Align service worker version to 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wampums",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 // Version should match package.json and config.js
-const APP_VERSION = "2.0.5";
+const APP_VERSION = "2.1.0";
 const CACHE_NAME = `wampums-app-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `wampums-static-v${APP_VERSION}`;
 const API_CACHE_NAME = `wampums-api-v${APP_VERSION}`;


### PR DESCRIPTION
## Summary
- update the service worker APP_VERSION to 2.1.0 so cache naming and update prompts match the current app release
- sync package-lock metadata version with the 2.1.0 application version

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936ce57add883248d8b7f9e769a31e6)