### PR TITLE
Sort fee definitions and hide finance tabs on mobile

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -4199,10 +4199,16 @@ details p {
 }
 
 .finance-tabs {
-  display: flex;
-  gap: 0.5rem;
-  overflow-x: auto;
-  padding-bottom: 0.25rem;
+  display: none;
+}
+
+@media (min-width: 768px) {
+  .finance-tabs {
+    display: flex;
+    gap: 0.5rem;
+    overflow-x: auto;
+    padding-bottom: 0.25rem;
+  }
 }
 
 .finance-tab {


### PR DESCRIPTION
## Summary
- sort fee definitions by most recent year and format ranges as year-only to avoid invalid dates
- reuse the sorted definitions when selecting memberships for consistency
- hide finance page tab switcher on mobile viewports where navigation happens via URLs

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936d1104bd083248504acba78d959b1)