### PR TITLE
Fix payment amount updates and caching

### DIFF
--- a/lang/translation.json
+++ b/lang/translation.json
@@ -647,5 +647,15 @@
     "error_linking_participants": "Error occurred while linking participants",
     "no_participants_selected": "No participants selected",
     "new_animator_registration_subject": "New Animator Registration for {orgName}",
-    "new_animator_registration_body": "\n  Dear Admin,\n\n  A new user has registered as an animator for {orgName} and requires verification:\n\n  Name: {animatorName}\n  Email: {animatorEmail}\n\n  Please log in to the admin dashboard to verify this user.\n\n  Best regards,\n  The System\n  "
+    "new_animator_registration_body": "\n  Dear Admin,\n\n  A new user has registered as an animator for {orgName} and requires verification:\n\n  Name: {animatorName}\n  Email: {animatorEmail}\n\n  Please log in to the admin dashboard to verify this user.\n\n  Best regards,\n  The System\n  ",
+    "amount_due": "Amount Due",
+    "by_participant": "By Participant",
+    "consolidated_balance": "Consolidated Balance",
+    "error_loading_data": "Error loading data",
+    "my_finances": "My Finances",
+    "outstanding_balance": "Outstanding Balance",
+    "status": "Status",
+    "total_billed": "Total Billed",
+    "total_paid": "Total Paid",
+    "view_your_financial_summary": "View your financial summary and payment history"
 }

--- a/spa/parent_dashboard.js
+++ b/spa/parent_dashboard.js
@@ -226,6 +226,7 @@ export class ParentDashboard {
                                 <nav>
                                         <ul class="dashboard-menu">
                                                 <li><a href="/formulaire-inscription" class="dashboard-button">${translate("ajouter_participant")}</a></li>
+                                                <li><a href="/parent-finance" class="dashboard-button">${translate("my_finances")}</a></li>
                                                 ${this.renderParticipantsList()}
                                                 ${notificationButton}
                                                 ${installButton}

--- a/spa/parent_finance.js
+++ b/spa/parent_finance.js
@@ -1,0 +1,290 @@
+import {
+  getCurrentOrganizationId,
+  fetchParticipants,
+  getParticipantStatement
+} from "./ajax-functions.js";
+import { debugLog, debugError } from "./utils/DebugUtils.js";
+import { translate } from "./app.js";
+import { CONFIG } from './config.js';
+import { escapeHTML } from "./utils/SecurityUtils.js";
+import { formatDateShort } from "./utils/DateUtils.js";
+
+export class ParentFinance {
+  constructor(app) {
+    this.app = app;
+    this.participants = [];
+    this.participantStatements = new Map();
+    this.consolidatedTotals = {
+      total_billed: 0,
+      total_paid: 0,
+      total_outstanding: 0
+    };
+  }
+
+  async init() {
+    try {
+      await this.fetchParticipants();
+      await this.fetchAllStatements();
+      this.calculateConsolidatedTotals();
+      this.render();
+      this.attachEventListeners();
+    } catch (error) {
+      debugError("Error initializing parent finance page:", error);
+      this.app.showMessage(translate("error_loading_data"), "error");
+    }
+  }
+
+  async fetchParticipants() {
+    try {
+      const response = await fetchParticipants(getCurrentOrganizationId());
+      const uniqueParticipants = new Map();
+
+      response.forEach(participant => {
+        if (!uniqueParticipants.has(participant.id)) {
+          uniqueParticipants.set(participant.id, participant);
+        }
+      });
+
+      this.participants = Array.from(uniqueParticipants.values());
+      debugLog("Fetched participants for finance:", this.participants);
+    } catch (error) {
+      debugError("Error fetching participants:", error);
+      throw error;
+    }
+  }
+
+  async fetchAllStatements() {
+    try {
+      const statementPromises = this.participants.map(participant =>
+        getParticipantStatement(participant.id)
+          .then(response => ({
+            participantId: participant.id,
+            statement: response?.data || response
+          }))
+          .catch(error => {
+            debugError(`Error fetching statement for participant ${participant.id}:`, error);
+            return {
+              participantId: participant.id,
+              statement: null
+            };
+          })
+      );
+
+      const statements = await Promise.all(statementPromises);
+      statements.forEach(({ participantId, statement }) => {
+        if (statement) {
+          this.participantStatements.set(participantId, statement);
+        }
+      });
+
+      debugLog("Fetched all statements:", this.participantStatements);
+    } catch (error) {
+      debugError("Error fetching participant statements:", error);
+      throw error;
+    }
+  }
+
+  calculateConsolidatedTotals() {
+    this.consolidatedTotals = {
+      total_billed: 0,
+      total_paid: 0,
+      total_outstanding: 0
+    };
+
+    this.participantStatements.forEach(statement => {
+      const totals = statement?.totals || {};
+      this.consolidatedTotals.total_billed += Number(totals.total_billed) || 0;
+      this.consolidatedTotals.total_paid += Number(totals.total_paid) || 0;
+      this.consolidatedTotals.total_outstanding += Number(totals.total_outstanding) || 0;
+    });
+
+    debugLog("Consolidated totals:", this.consolidatedTotals);
+  }
+
+  formatCurrency(amount = 0) {
+    const numericValue = Number.parseFloat(amount);
+    if (!Number.isFinite(numericValue)) {
+      return this.formatCurrency(0);
+    }
+
+    const locale = this.app?.language || CONFIG.DEFAULT_LANG || 'en';
+    const currency = CONFIG.DEFAULT_CURRENCY || 'CAD';
+
+    return new Intl.NumberFormat(locale, {
+      style: 'currency',
+      currency,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(numericValue);
+  }
+
+  render() {
+    const backLink = this.app.userRole === "admin" || this.app.userRole === "animation"
+      ? `<a href="/dashboard" class="back-link">${translate("back_to_dashboard")}</a>`
+      : `<a href="/parent-dashboard" class="back-link">${translate("back_to_dashboard")}</a>`;
+
+    const content = `
+      <section class="parent-finance-page">
+        <header class="finance-header">
+          <a href="/parent-dashboard" class="home-icon" aria-label="${translate("back_to_dashboard")}">🏠</a>
+          <div>
+            <h1>${translate("my_finances")}</h1>
+            <p class="finance-subtitle">${translate("view_your_financial_summary")}</p>
+          </div>
+        </header>
+
+        ${this.renderConsolidatedSummary()}
+
+        <div class="finance-section">
+          <h2>${translate("by_participant")}</h2>
+          ${this.renderParticipantStatements()}
+        </div>
+      </section>
+    `;
+
+    document.getElementById("app").innerHTML = content;
+  }
+
+  renderConsolidatedSummary() {
+    if (this.participants.length === 0) {
+      return `<p class="finance-helper">${translate("no_participants")}</p>`;
+    }
+
+    return `
+      <article class="finance-card finance-card--highlight">
+        <h2>${translate("consolidated_balance")}</h2>
+        <div class="finance-stats">
+          <div>
+            <p class="finance-stat__label">${translate("total_billed")}</p>
+            <p class="finance-stat__value">${this.formatCurrency(this.consolidatedTotals.total_billed)}</p>
+          </div>
+          <div>
+            <p class="finance-stat__label">${translate("total_paid")}</p>
+            <p class="finance-stat__value">${this.formatCurrency(this.consolidatedTotals.total_paid)}</p>
+          </div>
+          <div>
+            <p class="finance-stat__label">${translate("outstanding_balance")}</p>
+            <p class="finance-stat__value finance-stat__value--alert">${this.formatCurrency(this.consolidatedTotals.total_outstanding)}</p>
+          </div>
+        </div>
+      </article>
+    `;
+  }
+
+  renderParticipantStatements() {
+    if (this.participants.length === 0) {
+      return `<p class="finance-helper">${translate("no_participants")}</p>`;
+    }
+
+    return this.participants
+      .map(participant => {
+        const statement = this.participantStatements.get(participant.id);
+        const totals = statement?.totals || {
+          total_billed: 0,
+          total_paid: 0,
+          total_outstanding: 0
+        };
+
+        const participantName = escapeHTML(`${participant.first_name} ${participant.last_name}`);
+        const fees = statement?.fees || [];
+
+        return `
+          <article class="finance-card" data-participant-id="${participant.id}">
+            <div class="finance-card__header">
+              <h3>${participantName}</h3>
+              ${totals.total_outstanding > 0
+                ? `<span class="finance-pill finance-pill--warning">${translate("amount_due")}</span>`
+                : `<span class="finance-pill finance-pill--success">${translate("paid")}</span>`
+              }
+            </div>
+
+            <div class="finance-amounts">
+              <div>
+                <p class="finance-stat__label">${translate("total_billed")}</p>
+                <p class="finance-stat__value">${this.formatCurrency(totals.total_billed)}</p>
+              </div>
+              <div>
+                <p class="finance-stat__label">${translate("total_paid")}</p>
+                <p class="finance-stat__value">${this.formatCurrency(totals.total_paid)}</p>
+              </div>
+              <div>
+                <p class="finance-stat__label">${translate("outstanding_balance")}</p>
+                <p class="finance-stat__value finance-stat__value--alert">${this.formatCurrency(totals.total_outstanding)}</p>
+              </div>
+            </div>
+
+            ${fees.length > 0 ? `
+              <details class="finance-details">
+                <summary class="finance-details__summary">${translate("view_details")}</summary>
+                <div class="finance-details__content">
+                  ${this.renderFeeDetails(fees)}
+                </div>
+              </details>
+            ` : ''}
+          </article>
+        `;
+      })
+      .join("");
+  }
+
+  renderFeeDetails(fees) {
+    return fees
+      .map(fee => {
+        const yearRange = this.formatYearRange(fee.year_start, fee.year_end);
+        const statusLabel = translate(fee.status) || fee.status;
+
+        return `
+          <div class="finance-list__row">
+            <div>
+              <p class="finance-meta"><strong>${yearRange}</strong></p>
+              <p class="finance-meta">${translate("status")}: ${statusLabel}</p>
+            </div>
+            <div class="finance-row-values">
+              <div>
+                <p class="finance-meta">${translate("total_billed")}</p>
+                <span>${this.formatCurrency(fee.total_amount)}</span>
+              </div>
+              <div>
+                <p class="finance-meta">${translate("total_paid")}</p>
+                <span>${this.formatCurrency(fee.total_paid)}</span>
+              </div>
+              <div>
+                <p class="finance-meta">${translate("outstanding_balance")}</p>
+                <span class="finance-stat__value--alert">${this.formatCurrency(fee.outstanding)}</span>
+              </div>
+            </div>
+          </div>
+        `;
+      })
+      .join("");
+  }
+
+  formatYearRange(start, end) {
+    const startYear = this.extractYear(start);
+    const endYear = this.extractYear(end);
+
+    if (startYear && endYear) {
+      return `${startYear} - ${endYear}`;
+    }
+    if (startYear || endYear) {
+      return String(startYear || endYear);
+    }
+    return translate("unknown");
+  }
+
+  extractYear(dateValue) {
+    if (!dateValue) return null;
+    const parsedDate = new Date(dateValue);
+    if (!Number.isNaN(parsedDate.getTime())) {
+      return parsedDate.getFullYear();
+    }
+
+    const match = String(dateValue).match(/\d{4}/);
+    return match ? Number(match[0]) : null;
+  }
+
+  attachEventListeners() {
+    // Add any interactive elements here if needed
+    debugLog("Parent finance event listeners attached");
+  }
+}

--- a/spa/router.js
+++ b/spa/router.js
@@ -10,6 +10,7 @@ import { debugLog, debugError, debugWarn, isDebugMode } from "./utils/DebugUtils
 // These will be dynamically imported when the route is accessed
 const lazyModules = {
   ParentDashboard: () => import('./parent_dashboard.js').then(m => m.ParentDashboard),
+  ParentFinance: () => import('./parent_finance.js').then(m => m.ParentFinance),
   FormulaireInscription: () => import('./formulaire_inscription.js').then(m => m.FormulaireInscription),
   ManagePoints: () => import('./manage_points.js').then(m => m.ManagePoints),
   TimeSinceRegistration: () => import('./time_since_registration.js').then(m => m.TimeSinceRegistration),
@@ -54,6 +55,7 @@ const routes = {
   "/login": "login",
   "/logout": "logout",
   "/parent-dashboard": "parentDashboard",
+  "/parent-finance": "parentFinance",
   "/formulaire-inscription": "formulaireInscription",
   "/formulaire-inscription/:id": "formulaireInscription",
   "/attendance": "attendance",


### PR DESCRIPTION
Finance.js improvements:
- Add optimistic updates for payment amounts with automatic cache invalidation
- Cache last entered payment amounts and pre-fill them on next payment entry
- Fix date display to use fee definition year range instead of showing "Invalid Date"
- Ensure payment plans created inline are properly saved and displayed in modal
- Add clearFinanceRelatedCaches calls after all payment and plan operations
- Import clearFinanceRelatedCaches from indexedDB.js

IndexedDB improvements:
- Add clearFinanceRelatedCaches() function to invalidate finance-related caches
- Clears participant_fees, finance_report, and payment-specific caches
- Ensures data freshness after any finance operation

Parent Finance page (NEW):
- Create dedicated parent_finance.js page for parents to view their balances
- Display consolidated balance across all participants
- Show individual balances per participant with expandable details
- Use existing secure API endpoint (getParticipantStatement)
- Parents can only view their own linked participants

Router updates:
- Add ParentFinance lazy module import
- Add /parent-finance route

Parent Dashboard updates:
- Add "My Finances" link to parent dashboard navigation

Translation updates:
- Add missing finance-related translation keys:
  * amount_due, by_participant, consolidated_balance
  * error_loading_data, my_finances, outstanding_balance
  * status, total_billed, total_paid, view_your_financial_summary