### PR TITLE
Fix parent finance route and modal display

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -3164,6 +3164,11 @@ details p {
   z-index: var(--z-modal);
 }
 
+.modal-screen .modal {
+  display: block;
+  position: relative;
+}
+
 .statement-summary {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));

--- a/spa/router.js
+++ b/spa/router.js
@@ -189,6 +189,13 @@ export class Router {
         case "parentDashboard":
           await this.loadParentDashboard();
           break;
+        case "parentFinance":
+          if (this.app.userRole !== "parent") {
+            this.loadNotAuthorizedPage();
+          } else {
+            await this.loadParentFinance();
+          }
+          break;
         case "login":
           if (this.app.isLoggedIn) {
             // Redirect to appropriate dashboard if already logged in
@@ -366,6 +373,12 @@ export class Router {
     const ParentDashboard = await this.loadModule('ParentDashboard');
     const parentDashboard = new ParentDashboard(this.app);
     await parentDashboard.init();
+  }
+
+  async loadParentFinance() {
+    const ParentFinance = await this.loadModule('ParentFinance');
+    const parentFinance = new ParentFinance(this.app);
+    await parentFinance.init();
   }
 
   async loadManagePoints() {


### PR DESCRIPTION
## Summary
- add router handling for the parent finance page and gate it to parent users
- ensure parent finance module is loaded via a new helper
- make parent dashboard finance modal visible by overriding the modal display within the backdrop

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936fb5234ec832481d1a2017f95b539)