### PR TITLE
Bump application version to 2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wampums",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wampums",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "dependencies": {
         "bcrypt": "^5.0.1",
         "body-parser": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wampums",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Wampums project",
   "main": "api.js",
   "scripts": {

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 // Version should match package.json and config.js
-const APP_VERSION = "2.1.0";
+const APP_VERSION = "2.2.0";
 const CACHE_NAME = `wampums-app-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `wampums-static-v${APP_VERSION}`;
 const API_CACHE_NAME = `wampums-api-v${APP_VERSION}`;

--- a/spa/config.js
+++ b/spa/config.js
@@ -57,7 +57,7 @@ export const CONFIG = {
     /**
      * Application Version
      */
-    VERSION: "2.1.0",
+    VERSION: "2.2.0",
 
     /**
      * Application Name


### PR DESCRIPTION
## Summary
- bump the project version metadata to 2.2.0
- update service worker and SPA config to use the new version constant

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693706dd8f7483248369415b8950e736)