### PR TITLE
Clear client data on logout (v2.2.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wampums",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wampums",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "dependencies": {
         "bcrypt": "^5.0.1",
         "body-parser": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wampums",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Wampums project",
   "main": "api.js",
   "scripts": {

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 // Version should match package.json and config.js
-const APP_VERSION = "2.2.0";
+const APP_VERSION = "2.2.1";
 const CACHE_NAME = `wampums-app-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `wampums-static-v${APP_VERSION}`;
 const API_CACHE_NAME = `wampums-api-v${APP_VERSION}`;

--- a/spa/config.js
+++ b/spa/config.js
@@ -57,7 +57,7 @@ export const CONFIG = {
     /**
      * Application Version
      */
-    VERSION: "2.2.0",
+    VERSION: "2.2.1",
 
     /**
      * Application Name

--- a/spa/indexedDB.js
+++ b/spa/indexedDB.js
@@ -4,6 +4,31 @@ const DB_NAME = "WampumsAppDB";
 const DB_VERSION = 12;
 const STORE_NAME = "offlineData";
 
+/**
+ * Delete the IndexedDB database for the application.
+ * Used on logout to ensure no cached data remains available across accounts.
+ * @returns {Promise<void>} Resolves when the database is deleted
+ */
+export function deleteIndexedDB() {
+  return new Promise((resolve, reject) => {
+    const deleteRequest = indexedDB.deleteDatabase(DB_NAME);
+
+    deleteRequest.onsuccess = () => {
+      debugLog("IndexedDB deleted successfully");
+      resolve();
+    };
+
+    deleteRequest.onerror = () => {
+      debugError("Error deleting IndexedDB:", deleteRequest.error);
+      reject(deleteRequest.error);
+    };
+
+    deleteRequest.onblocked = () => {
+      debugWarn("IndexedDB deletion blocked. Close other tabs using the app to complete cleanup.");
+    };
+  });
+}
+
 export function openDB() {
   return new Promise((resolve, reject) => {
     const request = indexedDB.open(DB_NAME, DB_VERSION);

--- a/spa/login.js
+++ b/spa/login.js
@@ -1,7 +1,8 @@
 import { translate } from "./app.js";
 import { debugLog, debugError, debugWarn, debugInfo } from "./utils/DebugUtils.js";
 import {login, getApiUrl, getCurrentOrganizationId} from "./ajax-functions.js";
-import { setStorage, getStorage, removeStorage, setStorageMultiple, removeStorageMultiple } from "./utils/StorageUtils.js";
+import { setStorage, getStorage, removeStorage, setStorageMultiple } from "./utils/StorageUtils.js";
+import { clearAllClientData } from "./utils/ClientCleanupUtils.js";
 
 export class Login {
   constructor(app) {
@@ -296,10 +297,12 @@ handleLoginSuccess(result) {
       // Continue with client-side logout even if server logout fails
     }
 
-    // Clear user data from localStorage using StorageUtils
-    removeStorageMultiple(["jwtToken", "userRole", "userFullName", "userId", "guardianParticipants"]);
-
-    debugLog("Local storage cleared, redirecting to login page");
+    try {
+      await clearAllClientData();
+      debugLog("Client data cleared, redirecting to login page");
+    } catch (cleanupError) {
+      debugWarn("Error during client cleanup:", cleanupError);
+    }
 
     // Redirect to login page
     window.location.href = "/login";

--- a/spa/utils/ClientCleanupUtils.js
+++ b/spa/utils/ClientCleanupUtils.js
@@ -1,0 +1,41 @@
+import { debugLog, debugWarn, debugError } from './DebugUtils.js';
+import { clearStorage } from './StorageUtils.js';
+import { deleteIndexedDB } from '../indexedDB.js';
+
+/**
+ * Remove all Cache Storage entries for the current origin.
+ * @returns {Promise<void>} Resolves after cache deletion attempts complete
+ */
+async function clearAllCaches() {
+  if (!('caches' in window)) {
+    debugWarn('CacheStorage API not available; skipping cache cleanup.');
+    return;
+  }
+
+  try {
+    const cacheNames = await caches.keys();
+    await Promise.all(cacheNames.map((cacheName) => caches.delete(cacheName)));
+    debugLog('Cache storage cleared:', cacheNames);
+  } catch (error) {
+    debugError('Error clearing caches:', error);
+  }
+}
+
+/**
+ * Clear all client-side storage, caches, and IndexedDB data.
+ * Intended for logout flows to prevent cross-account data leakage.
+ * @returns {Promise<void>} Resolves when cleanup tasks finish
+ */
+export async function clearAllClientData() {
+  debugLog('Clearing client data (localStorage, sessionStorage, caches, IndexedDB)');
+
+  // Clear Web Storage synchronously to remove tokens immediately
+  clearStorage(false);
+  clearStorage(true);
+
+  // Clear Cache Storage and IndexedDB
+  await Promise.all([
+    clearAllCaches(),
+    deleteIndexedDB().catch((error) => debugError('IndexedDB cleanup failed:', error))
+  ]);
+}


### PR DESCRIPTION
## Summary
- add a reusable client cleanup utility that wipes Web Storage, caches, and IndexedDB data
- hook the logout flow to clear all client-side data before redirecting to the login page
- expose a helper to delete the app IndexedDB database for complete cleanup
- bump the application version to 2.2.1 so clients pick up the logout data purge changes

## Testing
- npm test -- --runInBand *(fails: api.js pool.on is not a function when running tests)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69371b0c023c832496780999d910b495)