### PR TITLE
Fix password recognition after logout cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wampums",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wampums",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "dependencies": {
         "bcrypt": "^5.0.1",
         "body-parser": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wampums",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Wampums project",
   "main": "api.js",
   "scripts": {

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 // Version should match package.json and config.js
-const APP_VERSION = "2.2.1";
+const APP_VERSION = "2.2.2";
 const CACHE_NAME = `wampums-app-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `wampums-static-v${APP_VERSION}`;
 const API_CACHE_NAME = `wampums-api-v${APP_VERSION}`;

--- a/spa/config.js
+++ b/spa/config.js
@@ -57,7 +57,7 @@ export const CONFIG = {
     /**
      * Application Version
      */
-    VERSION: "2.2.1",
+    VERSION: "2.2.2",
 
     /**
      * Application Name

--- a/spa/utils/ClientCleanupUtils.js
+++ b/spa/utils/ClientCleanupUtils.js
@@ -3,7 +3,9 @@ import { clearStorage } from './StorageUtils.js';
 import { deleteIndexedDB } from '../indexedDB.js';
 
 /**
- * Remove all Cache Storage entries for the current origin.
+ * Remove user-specific Cache Storage entries while preserving static assets.
+ * This ensures the app remains functional after logout by keeping critical
+ * JavaScript, CSS, and HTML files cached.
  * @returns {Promise<void>} Resolves after cache deletion attempts complete
  */
 async function clearAllCaches() {
@@ -14,8 +16,18 @@ async function clearAllCaches() {
 
   try {
     const cacheNames = await caches.keys();
-    await Promise.all(cacheNames.map((cacheName) => caches.delete(cacheName)));
-    debugLog('Cache storage cleared:', cacheNames);
+
+    // Filter out static asset caches to preserve app functionality
+    // Only clear API and dynamic data caches
+    const cachesToClear = cacheNames.filter(cacheName => {
+      // Keep static caches (contains JS, CSS, HTML)
+      // Keep image caches (contains app icons and images)
+      return !cacheName.includes('-static-') && !cacheName.includes('-images-');
+    });
+
+    await Promise.all(cachesToClear.map((cacheName) => caches.delete(cacheName)));
+    debugLog('User data caches cleared:', cachesToClear);
+    debugLog('Static caches preserved:', cacheNames.filter(name => !cachesToClear.includes(name)));
   } catch (error) {
     debugError('Error clearing caches:', error);
   }


### PR DESCRIPTION
The logout cleanup was clearing ALL browser caches including the service worker's static asset caches (JS, CSS, HTML). This caused the login page to break after logout as critical JavaScript files were removed from cache.

Changes:
- Modified clearAllCaches() to preserve static and image caches
- Only clears API and user-specific data caches during logout
- Bumped version to 2.2.2

This ensures the app remains functional after logout while still preventing cross-account data leakage.