### PR TITLE
Refine parent dashboard header and remove statement button

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2182,8 +2182,7 @@ tr:hover {
 .parent-dashboard__header {
   text-align: center;
   padding: var(--space-lg) var(--space-md);
-  background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-dark) 100%);
-  color: white;
+  background: white;
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-md);
 }
@@ -2192,25 +2191,26 @@ tr:hover {
   font-size: var(--font-size-xl);
   font-weight: var(--font-weight-bold);
   margin: 0 0 var(--space-xs) 0;
+  color: var(--color-text);
 }
 
 .parent-dashboard__subtitle {
   font-size: var(--font-size-base);
   margin: 0;
-  opacity: 0.95;
   font-weight: var(--font-weight-medium);
+  color: var(--color-text-secondary);
 }
 
 .back-link {
   display: inline-block;
   margin-block-start: var(--space-md);
-  color: white;
+  color: var(--color-primary);
   text-decoration: underline;
   font-size: var(--font-size-sm);
 }
 
 .back-link:hover {
-  opacity: 0.8;
+  color: var(--color-primary-dark);
 }
 
 /* Main Actions Section */

--- a/spa/parent_dashboard.js
+++ b/spa/parent_dashboard.js
@@ -314,7 +314,6 @@ export class ParentDashboard {
                                                 ${translate("modifier")}
                                         </a>
                                 </header>
-                                ${statementLink}
                                 <div class="participant-card__forms">
                                         ${this.renderFormButtons(participant)}
                                 </div>


### PR DESCRIPTION
- Change header background from blue gradient to white for better contrast
- Update header text colors to use standard text colors instead of white
- Update back link to use primary color instead of white
- Remove intrusive "Amount due" statement button from participant cards
- Statement information still accessible via "Mes finances" page

These changes create a cleaner, less cluttered interface as requested.