### PR TITLE
Fix app updates not applying on Android devices

### DIFF
--- a/api.js
+++ b/api.js
@@ -651,6 +651,10 @@ app.get('/', (req, res) => {
   const indexPath = isProduction
     ? path.join(__dirname, 'dist', 'index.html')
     : path.join(__dirname, 'index.html');
+  // Prevent caching of index.html to ensure PWA updates work properly
+  res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
+  res.setHeader('Pragma', 'no-cache');
+  res.setHeader('Expires', '0');
   res.sendFile(indexPath);
 });
 
@@ -1837,6 +1841,10 @@ app.get('*', (req, res) => {
   const indexPath = isProduction
     ? path.join(__dirname, 'dist', 'index.html')
     : path.join(__dirname, 'index.html');
+  // Prevent caching of index.html to ensure PWA updates work properly
+  res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
+  res.setHeader('Pragma', 'no-cache');
+  res.setHeader('Expires', '0');
   res.sendFile(indexPath);
 });
 


### PR DESCRIPTION
Add Cache-Control headers to index.html responses to prevent indefinite browser caching that was blocking PWA updates on Android/Pixel devices.

The issue occurred because index.html was being cached without proper headers, causing Chrome on Android to serve stale HTML even after service worker updates. Users had to manually clear all browsing data to see updates.

Changes:
- Add no-cache headers to root route (/)
- Add no-cache headers to SPA catch-all route (*)
- Include Pragma and Expires headers for backwards compatibility

This ensures the browser always revalidates index.html with the server, allowing PWA updates to work properly on all devices.