### PR TITLE
Add roles field to Assign Groups page

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -949,6 +949,8 @@
     "risques_inherents_activites_texte": "<p>By signing this document, I acknowledge having been informed of the inherent risks of scouting and its activities, both current and future, regardless of the level of supervision or my ability and experience. Furthermore, there are no factors or conditions I should disclose to the organizers that would make my participation in scouting activities dangerous. I also acknowledge that it is my duty to follow the rules, instructions, and procedures applicable to the activities in which I participate.</p>",
     "role": "Role",
     "role_updated_successfully": "Role updated successfully",
+    "roles": "Roles",
+    "additional_roles": "Additional Roles",
     "s": "s",
     "salons": "Shows",
     "salons_label": "Exhibitions",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -949,6 +949,8 @@
     "risques_inherents_activites_texte": "<p>En signant le présent document, je reconnais avoir été informé(e) sur les risques inhérents du scoutisme et de ses activités, en cours ou futures, peu importe le niveau de supervision ainsi que du niveau de mon habileté et de mon expérience. De plus, il n’y a aucun facteur ou condition que je devrais dévoiler aux organisateurs qui rendrait dangereuse ma participation aux activités de scoutisme. Je reconnais également qu’il est de mon devoir de respecter les règles, les consignes et les façons de faire applicable aux activités à laquelle je participe.</p>",
     "role": "Rôle",
     "role_updated_successfully": "Rôle mis à jour avec succès",
+    "roles": "Rôles",
+    "additional_roles": "Rôles additionnels",
     "s": "s",
     "salons": "Salons",
     "salons_label": "Salons",

--- a/spa/api/api-endpoints.js
+++ b/spa/api/api-endpoints.js
@@ -514,12 +514,13 @@ export async function updateGroupName(groupId, newName) {
 /**
  * Update participant's group
  */
-export async function updateParticipantGroup(participantId, groupId, isLeader = false, isSecondLeader = false) {
+export async function updateParticipantGroup(participantId, groupId, isLeader = false, isSecondLeader = false, roles = null) {
     return API.post('update-participant-group', {
         participant_id: participantId,
         group_id: groupId,
         is_leader: isLeader,
-        is_second_leader: isSecondLeader
+        is_second_leader: isSecondLeader,
+        roles: roles
     });
 }
 


### PR DESCRIPTION
- Updated participant_groups backend queries to include roles field
- Added roles field to update endpoint in routes/participants.js
- Enhanced manage_participants UI with roles input field
- Added mobile-first responsive design with CSS
- Updated API endpoint to send/receive roles parameter
- Added translations for "roles" and "additional_roles" in EN/FR
- Now displays pisteur/second_pisteur roles correctly