### PR TITLE
Use RESTful v1 endpoint for updating participant groups

### DIFF
--- a/spa/api/api-endpoints.js
+++ b/spa/api/api-endpoints.js
@@ -512,11 +512,10 @@ export async function updateGroupName(groupId, newName) {
 }
 
 /**
- * Update participant's group
+ * Update participant's group membership (RESTful v1 endpoint)
  */
 export async function updateParticipantGroup(participantId, groupId, isLeader = false, isSecondLeader = false, roles = null) {
-    return API.post('update-participant-group', {
-        participant_id: participantId,
+    return API.patch(`v1/participants/${participantId}/group-membership`, {
         group_id: groupId,
         is_leader: isLeader,
         is_second_leader: isSecondLeader,

--- a/spa/manage_participants.js
+++ b/spa/manage_participants.js
@@ -245,7 +245,7 @@ export class ManageParticipants {
               requestData.roles
           );
 
-          if (result.status === "success") {
+          if (result.success) {
               roleSelect.disabled = !groupId;
               rolesInput.disabled = !groupId;
               if (!groupId) {
@@ -298,7 +298,7 @@ export class ManageParticipants {
     try {
       const result = await updateParticipantGroup(participantId, groupId, isLeader, isSecondLeader, roles);
 
-      if (result.status === "success") {
+      if (result.success) {
         await this.fetchData()
         this.app.showMessage(translate("role_updated_successfully"), "success");
       } else {
@@ -342,7 +342,7 @@ export class ManageParticipants {
     try {
       const result = await updateParticipantGroup(participantId, groupId, isLeader, isSecondLeader, roles);
 
-      if (result.status === "success") {
+      if (result.success) {
         await this.fetchData()
         this.app.showMessage(translate("role_updated_successfully"), "success");
       } else {


### PR DESCRIPTION
- Created new PATCH /api/v1/participants/:id/group-membership endpoint
- Updated frontend to use v1 endpoint instead of old /api/ endpoint
- Changed response handling from result.status to result.success
- Now properly updates group membership and roles fields
- Fixes update error caused by using non-RESTful endpoint