### PR TITLE
Bump version to 2.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wampums",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wampums",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "dependencies": {
         "bcrypt": "^5.0.1",
         "body-parser": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wampums",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Wampums project",
   "main": "api.js",
   "scripts": {

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 // Version should match package.json and config.js
-const APP_VERSION = "2.2.2";
+const APP_VERSION = "2.2.3";
 const CACHE_NAME = `wampums-app-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `wampums-static-v${APP_VERSION}`;
 const API_CACHE_NAME = `wampums-api-v${APP_VERSION}`;

--- a/spa/config.js
+++ b/spa/config.js
@@ -57,7 +57,7 @@ export const CONFIG = {
     /**
      * Application Version
      */
-    VERSION: "2.2.2",
+    VERSION: "2.2.3",
 
     /**
      * Application Name


### PR DESCRIPTION
## Summary
- bump project version to 2.2.3 for the latest bug fix release
- align service worker and client configuration versions with the package metadata

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693735a0d0408324b4a0c1d0b386f6c1)