### PR TITLE
Add PATCH method to API core

### DIFF
--- a/spa/api/api-core.js
+++ b/spa/api/api-core.js
@@ -223,6 +223,17 @@ export const API = {
     },
 
     /**
+     * PATCH request
+     */
+    async patch(endpoint, body = {}, params = {}) {
+        return makeApiRequest(endpoint, {
+            method: 'PATCH',
+            body,
+            params
+        });
+    },
+
+    /**
      * DELETE request
      */
     async delete(endpoint, params = {}) {


### PR DESCRIPTION
- Added missing patch() method to API object
- Fixes "API.patch is not a function" error
- Enables RESTful PATCH requests for partial updates