### PR TITLE
Bust participant cache to include new roles field

### DIFF
--- a/spa/api/api-endpoints.js
+++ b/spa/api/api-endpoints.js
@@ -223,7 +223,7 @@ export async function updateUserRole(userId, role) {
  */
 export async function getParticipants() {
     return API.get('v1/participants', {}, {
-        cacheKey: 'participants',
+        cacheKey: 'participants_v2', // v2: includes roles field from participant_groups
         cacheDuration: CONFIG.CACHE_DURATION.MEDIUM
     });
 }

--- a/spa/indexedDB.js
+++ b/spa/indexedDB.js
@@ -239,6 +239,7 @@ export async function clearGroupRelatedCaches() {
   const keysToDelete = [
     'groups',
     'participants',
+    'participants_v2', // Clear new versioned cache
     'manage_points_data',
     'dashboard_groups',
     'dashboard_participant_info'


### PR DESCRIPTION
- Changed cache key from 'participants' to 'participants_v2'
- Forces fresh fetch from API with updated schema including roles field
- Updated clearGroupRelatedCaches to clear both old and new cache keys
- Fixes issue where cached data didn't include roles from participant_groups