### PR TITLE
Add roles fields to v1 participants endpoint SELECT query

### DIFF
--- a/routes/participants.js
+++ b/routes/participants.js
@@ -50,7 +50,7 @@ module.exports = (pool) => {
     // If user is admin or animation, show ALL participants
     if (userRole === 'admin' || userRole === 'animation') {
       query = `
-        SELECT p.*, pg.group_id, g.name as group_name,
+        SELECT p.*, pg.group_id, g.name as group_name, pg.is_leader, pg.is_second_leader, pg.roles,
                COALESCE(
                  (SELECT json_agg(json_build_object('form_type', form_type, 'updated_at', updated_at))
                   FROM form_submissions
@@ -89,7 +89,7 @@ module.exports = (pool) => {
     } else {
       // For parents, only show participants linked to them
       query = `
-        SELECT p.*, pg.group_id, g.name as group_name,
+        SELECT p.*, pg.group_id, g.name as group_name, pg.is_leader, pg.is_second_leader, pg.roles,
                COALESCE(
                  (SELECT json_agg(json_build_object('form_type', form_type, 'updated_at', updated_at))
                   FROM form_submissions


### PR DESCRIPTION
- Added pg.is_leader, pg.is_second_leader, pg.roles to admin query
- Added same fields to parent user query
- Fixes issue where v1 endpoint didn't return role data
- Now participants data includes all group membership fields
- Enables proper display and editing of roles in UI