### PR TITLE
Fix version bump reverting to previous version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wampums",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Wampums project",
   "main": "api.js",
   "scripts": {

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 // Version should match package.json and config.js
-const APP_VERSION = "2.2.4";
+const APP_VERSION = "2.2.5";
 const CACHE_NAME = `wampums-app-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `wampums-static-v${APP_VERSION}`;
 const API_CACHE_NAME = `wampums-api-v${APP_VERSION}`;
@@ -33,7 +33,7 @@ const staticAssets = [
   "/spa/api/api-core.js",
   "/spa/api/api-endpoints.js",
   "/spa/api/api-helpers.js",
-  "/spa/config.js",
+  // Note: config.js is NOT cached here - it should always be network-first to get latest version
   "/manifest.json",
 ];
 

--- a/spa/config.js
+++ b/spa/config.js
@@ -57,7 +57,7 @@ export const CONFIG = {
     /**
      * Application Version
      */
-    VERSION: "2.2.4",
+    VERSION: "2.2.5",
 
     /**
      * Application Name

--- a/spa/pwa-update-manager.js
+++ b/spa/pwa-update-manager.js
@@ -224,7 +224,6 @@ class PWAUpdateManager {
                 <div class="pwa-update-text">
                     <h3>${msg.title}</h3>
                     <p>${msg.message}</p>
-                    <p class="pwa-update-version">Version ${CONFIG.VERSION}</p>
                 </div>
                 <div class="pwa-update-actions">
                     <button class="pwa-update-btn pwa-update-btn-primary" id="pwa-update-now">
@@ -308,12 +307,6 @@ class PWAUpdateManager {
                 color: #666;
                 font-size: 14px;
                 line-height: 1.5;
-            }
-
-            .pwa-update-version {
-                color: #4c65ae;
-                font-weight: 500;
-                font-size: 13px !important;
             }
 
             .pwa-update-actions {


### PR DESCRIPTION
This fixes the issue where the PWA update prompt would show the wrong (cached) version number after deploying a new version.

Changes:
- Remove config.js from service worker's static cache to ensure it's always fetched fresh (network-first strategy)
- Remove version number display from update prompt to avoid showing potentially stale cached version
- Bump version to 2.2.5 in package.json, service-worker.js, and config.js

The root cause was that config.js was cached with a cache-first strategy, so when checking for updates, the old cached config.js would be loaded instead of the new one, causing the update prompt to display the previous version number instead of the new one.