### PR TITLE
Bump project version to 2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wampums",
-  "version": "2.2.5",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wampums",
-      "version": "2.2.5",
+      "version": "2.3.0",
       "dependencies": {
         "bcrypt": "^5.0.1",
         "body-parser": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wampums",
-  "version": "2.2.5",
+  "version": "2.3.0",
   "description": "Wampums project",
   "main": "api.js",
   "scripts": {

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 // Version should match package.json and config.js
-const APP_VERSION = "2.2.5";
+const APP_VERSION = "2.3.0";
 const CACHE_NAME = `wampums-app-v${APP_VERSION}`;
 const STATIC_CACHE_NAME = `wampums-static-v${APP_VERSION}`;
 const API_CACHE_NAME = `wampums-api-v${APP_VERSION}`;

--- a/spa/config.js
+++ b/spa/config.js
@@ -57,7 +57,7 @@ export const CONFIG = {
     /**
      * Application Version
      */
-    VERSION: "2.2.5",
+    VERSION: "2.3.0",
 
     /**
      * Application Name


### PR DESCRIPTION
## Summary
- bump project version to 2.3.0 across package metadata, service worker, and SPA config

## Testing
- npm test *(fails: TypeError: pool.on is not a function in api.js during Authenticated API communication tests)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938292269988324a332e1ea8d1c5bf5)