### PR TITLE
Fix PWA infinite update loop issue

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -498,7 +498,7 @@ async function invalidateRelatedCaches(request) {
 
 // Handle messages from clients
 self.addEventListener("message", (event) => {
-  if (event.data === "skipWaiting") {
+  if (event.data === "skipWaiting" || event.data.type === "SKIP_WAITING") {
     self.skipWaiting(); // Immediately activate new service worker
   } else if (event.data.type === "GET_VERSION") {
     // Send current version back to client

--- a/spa/pwa-update-manager.js
+++ b/spa/pwa-update-manager.js
@@ -435,6 +435,14 @@ class PWAUpdateManager {
             </div>
         `;
         document.body.appendChild(loader);
+
+        // Safety timeout: if update doesn't complete in 5 seconds, reload anyway
+        setTimeout(() => {
+            const loaderElement = document.getElementById('pwa-update-loader');
+            if (loaderElement) {
+                window.location.reload();
+            }
+        }, 5000);
     }
 
     /**


### PR DESCRIPTION
- Service worker now handles both SKIP_WAITING message formats
- Added 5-second safety timeout to prevent infinite loading
- Ensures PWA updates complete properly after clearing site data

The issue was a message format mismatch: PWA update manager was sending {type: 'SKIP_WAITING'} but service worker only checked for string "skipWaiting". This caused updates to hang indefinitely.