### PR TITLE
Add home icon navigation to budget page

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -4972,9 +4972,21 @@ details p {
 
 .budgets-page .page-header {
   display: flex;
+  align-items: flex-start;
+  margin-bottom: var(--space-xl);
+  gap: var(--space-md);
+}
+
+.budgets-page .page-header .home-icon {
+  flex-shrink: 0;
+  margin-top: 0.25rem;
+}
+
+.budgets-page .page-header-content {
+  flex: 1;
+  display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: var(--space-xl);
   flex-wrap: wrap;
   gap: var(--space-md);
 }

--- a/spa/budgets.js
+++ b/spa/budgets.js
@@ -117,9 +117,12 @@ export class Budgets {
     container.innerHTML = `
       <div class="page-container budgets-page">
         <div class="page-header">
-          <h1>${translate("budget_management")}</h1>
-          <div class="fiscal-year-display">
-            <span>${translate("fiscal_year")}: <strong>${escapeHTML(this.fiscalYear.label)}</strong></span>
+          <a href="/dashboard" class="home-icon" aria-label="${translate("back_to_dashboard")}">🏠</a>
+          <div class="page-header-content">
+            <h1>${translate("budget_management")}</h1>
+            <div class="fiscal-year-display">
+              <span>${translate("fiscal_year")}: <strong>${escapeHTML(this.fiscalYear.label)}</strong></span>
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
- Added home icon (🏠) to return to dashboard
- Updated header layout to accommodate home icon
- Added page-header-content wrapper for proper flexbox layout
- Mobile responsive design maintained

Matches navigation pattern used in finance page and other sections of the app for consistent user experience.