### PR TITLE
Fix external revenue endpoint data loading error

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -209,7 +209,8 @@ module.exports = (pool, logger) => {
           token: token,
           user_role: user.role,
           user_full_name: user.full_name,
-          user_id: user.id
+          user_id: user.id,
+          organization_id: organizationId
         };
 
       if (guardianResult.rows.length > 0) {

--- a/spa/login.js
+++ b/spa/login.js
@@ -158,6 +158,7 @@ handleLoginSuccess(result) {
   const userId = result.user_id || (result.data && result.data.user_id);
   const userRole = result.user_role || (result.data && result.data.user_role);
   const userFullName = result.user_full_name || (result.data && result.data.user_full_name) || "User";
+  const organizationId = result.organization_id || (result.data && result.data.organization_id);
 
   // Validate required fields
   if (!token) {
@@ -185,6 +186,7 @@ handleLoginSuccess(result) {
   debugLog("User ID:", userId);
   debugLog("User Role:", userRole);
   debugLog("User Full Name:", userFullName);
+  debugLog("Organization ID:", organizationId);
 
   // Update app state
   this.app.isLoggedIn = true;
@@ -199,12 +201,11 @@ handleLoginSuccess(result) {
     userId: userId
   };
 
-  // Make sure organization ID is stored correctly
-  const orgId = getCurrentOrganizationId();
-  if (orgId) {
-    userData.currentOrganizationId = orgId;
+  // Store organization ID from login response
+  if (organizationId) {
+    userData.currentOrganizationId = organizationId;
     // Also store as organizationId for backward compatibility
-    userData.organizationId = orgId;
+    userData.organizationId = organizationId;
   }
 
   // Store guardian participants if available


### PR DESCRIPTION
… response

Root cause: The login endpoint was not returning the organization_id in the response, causing the frontend to fail when trying to load budget categories and external revenue data. The frontend tried to read the organization ID from localStorage using getCurrentOrganizationId(), but since it wasn't stored yet, API calls to /api/v1/budget/categories and /api/v1/revenue/external/* would fail due to missing organization context.

Changes:
- routes/auth.js: Added organization_id to login response
- spa/login.js: Extract and store organization_id from login response instead of trying to read it from localStorage before it's set

This ensures the organization ID is properly set in localStorage during login, allowing subsequent API calls to include the correct organization context.

Fixes: /external-revenue "Error loading Data" issue