### PR TITLE
Separate permission slips and resources pages

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -319,6 +319,50 @@ a:focus-visible {
   grid-template-columns: repeat(auto-fit, minmax(min(100%, 250px), 1fr));
 }
 
+/* Summary Dashboard Grids */
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr));
+  gap: var(--space-md);
+  margin-block-end: var(--space-md);
+}
+
+.summary-tile {
+  background-color: var(--color-surface);
+  border-radius: var(--radius-md);
+  padding: var(--space-md);
+  box-shadow: var(--shadow-sm);
+  border: 1px solid var(--color-border-light);
+}
+
+.summary-label {
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-primary);
+  margin-block-end: var(--space-sm);
+  font-size: var(--font-size-lg);
+}
+
+.summary-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.summary-list li {
+  padding: var(--space-xs) 0;
+  border-bottom: 1px solid var(--color-border-light);
+  font-size: var(--font-size-base);
+}
+
+.summary-list li:last-child {
+  border-bottom: none;
+}
+
+.summary-list strong {
+  color: var(--color-primary-dark);
+  font-weight: var(--font-weight-bold);
+}
+
 /* ============================================================================
    5. COMPONENT LIBRARY
    ============================================================================ */
@@ -6310,6 +6354,11 @@ details p {
     display: block;
     overflow-x: auto;
     white-space: nowrap;
+  }
+
+  /* Stack grid-2 layout on mobile for better readability */
+  .grid-2 {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/spa/permission_slip_dashboard.js
+++ b/spa/permission_slip_dashboard.js
@@ -1,0 +1,197 @@
+import { translate } from "./app.js";
+import { debugError } from "./utils/DebugUtils.js";
+import { escapeHTML } from "./utils/SecurityUtils.js";
+import { formatDate, getTodayISO } from "./utils/DateUtils.js";
+import {
+  getPermissionSlips,
+  savePermissionSlip,
+  signPermissionSlip,
+  getResourceDashboard
+} from "./api/api-endpoints.js";
+
+export class PermissionSlipDashboard {
+  constructor(app) {
+    this.app = app;
+    this.meetingDate = getTodayISO();
+    this.permissionSlips = [];
+    this.dashboardSummary = { permission_summary: [] };
+  }
+
+  async init() {
+    try {
+      await this.refreshData();
+      this.render();
+      this.attachEventHandlers();
+    } catch (error) {
+      debugError("Error initializing permission slip dashboard:", error);
+      this.app.showMessage(translate("permission_slip_error_loading"), "error");
+    }
+  }
+
+  async refreshData() {
+    const [slipResponse, summaryResponse] = await Promise.all([
+      getPermissionSlips({ meeting_date: this.meetingDate }),
+      getResourceDashboard({ meeting_date: this.meetingDate })
+    ]);
+
+    this.permissionSlips = slipResponse?.data?.permission_slips || slipResponse?.permission_slips || [];
+    this.dashboardSummary = summaryResponse?.data || summaryResponse || { permission_summary: [] };
+  }
+
+  render() {
+    const container = document.getElementById("app");
+    if (!container) {
+      return;
+    }
+
+    const permissionSummary = this.dashboardSummary?.permission_summary || [];
+
+    container.innerHTML = `
+      <a href="/dashboard" class="home-icon" aria-label="${translate("back_to_dashboard")}">🏠</a>
+      <section class="page permission-slip-dashboard">
+        <div class="card">
+          <h1>${escapeHTML(translate("permission_slip_dashboard_title"))}</h1>
+          <p class="subtitle">${escapeHTML(translate("permission_slip_dashboard_description"))}</p>
+          <label class="stacked">
+            <span>${escapeHTML(translate("meeting_date_label"))}</span>
+            <input type="date" id="meetingDateInput" value="${escapeHTML(this.meetingDate)}" />
+          </label>
+        </div>
+
+        <div class="card">
+          <h2>${escapeHTML(translate("dashboard_summary_title"))}</h2>
+          <div class="summary-grid">
+            <div class="summary-tile">
+              <div class="summary-label">${escapeHTML(translate("permission_slip_status"))}</div>
+              <ul class="summary-list">
+                ${permissionSummary.length === 0
+                  ? `<li>${escapeHTML(translate("no_data_available"))}</li>`
+                  : permissionSummary
+                      .map((row) => `<li>${escapeHTML(row.status)}: <strong>${row.count}</strong></li>`)
+                      .join('')}
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="card">
+          <h2>${escapeHTML(translate("permission_slip_section_title"))}</h2>
+          <form id="permissionSlipForm" class="stacked">
+            <div class="grid grid-2">
+              <label class="stacked">
+                <span>${escapeHTML(translate("permission_slip_participant_id"))}</span>
+                <input type="number" name="participant_id" min="1" required />
+              </label>
+              <label class="stacked">
+                <span>${escapeHTML(translate("permission_slip_guardian_id"))}</span>
+                <input type="number" name="guardian_id" min="1" />
+              </label>
+            </div>
+            <label class="stacked">
+              <span>${escapeHTML(translate("consent_details"))}</span>
+              <textarea name="consent_payload" rows="3" placeholder="{}" maxlength="2000"></textarea>
+            </label>
+            <button type="submit" class="btn primary">${escapeHTML(translate("permission_slip_create"))}</button>
+          </form>
+          <div class="table-container">
+            <table class="data-table">
+              <thead>
+                <tr>
+                  <th>${escapeHTML(translate("permission_slip_participant_id"))}</th>
+                  <th>${escapeHTML(translate("permission_slip_guardian_id"))}</th>
+                  <th>${escapeHTML(translate("permission_slip_status"))}</th>
+                  <th>${escapeHTML(translate("permission_slip_signed_at"))}</th>
+                  <th>${escapeHTML(translate("actions"))}</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${this.permissionSlips.length === 0
+                  ? `<tr><td colspan="5">${escapeHTML(translate("no_data_available"))}</td></tr>`
+                  : this.permissionSlips
+                      .map((slip) => `
+                        <tr data-slip-id="${slip.id}">
+                          <td>${escapeHTML(String(slip.participant_id))}</td>
+                          <td>${escapeHTML(slip.guardian_id ? String(slip.guardian_id) : '-')}</td>
+                          <td>${escapeHTML(slip.status)}</td>
+                          <td>${slip.signed_at ? escapeHTML(formatDate(slip.signed_at, this.app.lang || 'en')) : '-'}</td>
+                          <td>
+                            <button class="btn link sign-slip" data-id="${slip.id}">${escapeHTML(translate("permission_slip_sign"))}</button>
+                          </td>
+                        </tr>
+                      `)
+                      .join('')}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+    `;
+  }
+
+  attachEventHandlers() {
+    const meetingDateInput = document.getElementById("meetingDateInput");
+    if (meetingDateInput) {
+      meetingDateInput.addEventListener("change", async (event) => {
+        this.meetingDate = event.target.value || getTodayISO();
+        await this.refreshData();
+        this.render();
+        this.attachEventHandlers();
+      });
+    }
+
+    const permissionSlipForm = document.getElementById("permissionSlipForm");
+    if (permissionSlipForm) {
+      permissionSlipForm.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        const formData = new FormData(permissionSlipForm);
+        const payload = Object.fromEntries(formData.entries());
+        payload.participant_id = parseInt(payload.participant_id, 10);
+        payload.guardian_id = payload.guardian_id ? parseInt(payload.guardian_id, 10) : undefined;
+        payload.meeting_date = this.meetingDate;
+
+        if (payload.consent_payload) {
+          try {
+            payload.consent_payload = JSON.parse(payload.consent_payload);
+          } catch (parseError) {
+            debugError("Invalid consent payload", parseError);
+            this.app.showMessage(translate("invalid_consent_payload"), "error");
+            return;
+          }
+        }
+
+        try {
+          await savePermissionSlip(payload);
+          this.app.showMessage(translate("permission_slip_saved"), "success");
+          await this.refreshData();
+          this.render();
+          this.attachEventHandlers();
+        } catch (error) {
+          debugError("Error saving permission slip", error);
+          this.app.showMessage(translate("permission_slip_error_loading"), "error");
+        }
+      });
+    }
+
+    document.querySelectorAll(".sign-slip").forEach((button) => {
+      button.addEventListener("click", async (event) => {
+        event.preventDefault();
+        const slipId = event.currentTarget.getAttribute("data-id");
+        const signerName = prompt(translate("permission_slip_signer"));
+        if (!signerName) {
+          return;
+        }
+
+        try {
+          await signPermissionSlip(slipId, { signed_by: signerName, signature_hash: `signed-${Date.now()}` });
+          this.app.showMessage(translate("permission_slip_signed"), "success");
+          await this.refreshData();
+          this.render();
+          this.attachEventHandlers();
+        } catch (error) {
+          debugError("Error signing permission slip", error);
+          this.app.showMessage(translate("permission_slip_error_loading"), "error");
+        }
+      });
+    });
+  }
+}

--- a/spa/router.js
+++ b/spa/router.js
@@ -44,7 +44,8 @@ const lazyModules = {
   ExternalRevenue: () => import('./external-revenue.js').then(m => m.ExternalRevenue),
   Expenses: () => import('./expenses.js').then(m => m.Expenses),
   RevenueDashboard: () => import('./revenue-dashboard.js').then(m => m.RevenueDashboard),
-  ResourceDashboard: () => import('./resource_dashboard.js').then(m => m.ResourceDashboard)
+  ResourceDashboard: () => import('./resource_dashboard.js').then(m => m.ResourceDashboard),
+  PermissionSlipDashboard: () => import('./permission_slip_dashboard.js').then(m => m.PermissionSlipDashboard)
 };
 
 // Cache for loaded modules
@@ -96,7 +97,7 @@ const routes = {
   "/expenses": "expenses",
   "/revenue-dashboard": "revenueDashboard",
   "/resources": "resourceDashboard",
-  "/permission-slips": "resourceDashboard",
+  "/permission-slips": "permissionSlipDashboard",
 
 };
 
@@ -224,6 +225,15 @@ export class Router {
             const ResourceDashboard = await this.loadModule('ResourceDashboard');
             const resourceDashboard = new ResourceDashboard(this.app);
             await resourceDashboard.init();
+          }
+          break;
+        case "permissionSlipDashboard":
+          if (this.app.userRole !== "admin" && this.app.userRole !== "animation" && this.app.userRole !== "leader") {
+            this.loadNotAuthorizedPage();
+          } else {
+            const PermissionSlipDashboard = await this.loadModule('PermissionSlipDashboard');
+            const permissionSlipDashboard = new PermissionSlipDashboard(this.app);
+            await permissionSlipDashboard.init();
           }
           break;
         case "calendars":


### PR DESCRIPTION
- Created new PermissionSlipDashboard class in permission_slip_dashboard.js
- Updated ResourceDashboard to remove permission slip functionality
- Modified router.js to handle /permission-slips and /resources as separate routes
- Added home button to both pages for easy navigation back to dashboard
- Enhanced mobile-first responsive design:
  - Added summary-grid, summary-tile, and summary-list CSS classes
  - Added responsive breakpoint for .grid-2 to stack on mobile (max-width: 768px)
  - Ensured tables are horizontally scrollable on mobile devices
- Both pages now follow UX best practices for mobile usage