### PR TITLE
Fix SQL column name for guardian email

### DIFF
--- a/routes/resources.js
+++ b/routes/resources.js
@@ -496,7 +496,7 @@ module.exports = (pool) => {
         // Build query to find permission slips
         let query = `
           SELECT ps.*, p.first_name, p.last_name,
-                 g.prenom AS guardian_first_name, g.nom AS guardian_last_name, g.email AS guardian_email,
+                 g.prenom AS guardian_first_name, g.nom AS guardian_last_name, g.courriel AS guardian_email,
                  u.email AS parent_email
           FROM permission_slips ps
           JOIN participants p ON p.id = ps.participant_id
@@ -616,7 +616,7 @@ module.exports = (pool) => {
         // Build query to find unsigned permission slips
         let query = `
           SELECT ps.*, p.first_name, p.last_name,
-                 g.prenom AS guardian_first_name, g.nom AS guardian_last_name, g.email AS guardian_email,
+                 g.prenom AS guardian_first_name, g.nom AS guardian_last_name, g.courriel AS guardian_email,
                  u.email AS parent_email
           FROM permission_slips ps
           JOIN participants p ON p.id = ps.participant_id


### PR DESCRIPTION
- Change g.email to g.courriel in permission slip email queries
- The parents_guardians table uses 'courriel' not 'email'
- Fixes both send-emails and send-reminders endpoints