### PR TITLE
Fix PATCH route callback error

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -24,8 +24,7 @@ const {
   validateNewPassword,
   validateToken,
   validateFullName,
-  checkValidation,
-  normalizeEmailInput
+  checkValidation
 } = require('../middleware/validation');
 
 // Import utilities
@@ -139,7 +138,7 @@ module.exports = (pool, logger) => {
       try {
         const organizationId = await getCurrentOrganizationId(req, pool, logger);
         const { email, password } = req.body;
-        const normalizedEmail = normalizeEmailInput(email);
+        const normalizedEmail = email.toString().trim().toLowerCase();
         const trimmedPassword = password.trim();
 
         const userResult = await pool.query(
@@ -275,7 +274,7 @@ module.exports = (pool, logger) => {
       try {
         const organizationId = await getCurrentOrganizationId(req, pool, logger);
         const { email, password, full_name, user_type } = req.body;
-        const normalizedEmail = normalizeEmailInput(email);
+        const normalizedEmail = email.toString().trim().toLowerCase();
         const trimmedPassword = password.trim();
         const role = mapRequestedRole(user_type);
 
@@ -363,7 +362,7 @@ module.exports = (pool, logger) => {
       try {
         const organizationId = await getCurrentOrganizationId(req, pool, logger);
         const { email, password, full_name, user_type } = req.body;
-        const normalizedEmail = normalizeEmailInput(email);
+        const normalizedEmail = email.toString().trim().toLowerCase();
         const trimmedPassword = password.trim();
         const role = mapRequestedRole(user_type);
 
@@ -448,7 +447,7 @@ module.exports = (pool, logger) => {
     async (req, res) => {
       try {
         const { email } = req.body;
-        const normalizedEmail = normalizeEmailInput(email);
+        const normalizedEmail = email.toString().trim().toLowerCase();
 
         logger.info('Password reset request received', {
           email: normalizedEmail,


### PR DESCRIPTION
normalizeEmailInput is a middleware function (req, res, next) but was being incorrectly called as a utility function with just the email string. This caused "Cannot read properties of undefined (reading 'email')" errors when trying to access req.body.email on a string parameter.

Replaced all 4 instances with inline email normalization: email.toString().trim().toLowerCase()