### PR TITLE
Use storage secret for Supabase S3 connection

### DIFF
--- a/routes/resources.js
+++ b/routes/resources.js
@@ -360,7 +360,11 @@ module.exports = (pool) => {
       try {
         // Check if storage is configured
         if (!isStorageConfigured()) {
-          return error(res, 'Photo storage is not configured. Please set SUPABASE_URL and SUPABASE_SERVICE_KEY.', 503);
+          return error(
+            res,
+            'Photo storage is not configured. Please set SUPABASE_URL, SUPABASE_STORAGE_SECRET_KEY, and SUPABASE_STORAGE_BUCKET.',
+            503
+          );
         }
 
         const organizationId = await getOrganizationId(req, pool);

--- a/utils/supabase-storage.js
+++ b/utils/supabase-storage.js
@@ -22,16 +22,16 @@ let supabaseClient = null;
 function getSupabaseClient() {
   if (!supabaseClient) {
     const supabaseUrl = process.env.SUPABASE_URL;
-    const supabaseKey = process.env.SUPABASE_SERVICE_KEY;
     const supabaseSecretKey = process.env.SUPABASE_STORAGE_SECRET_KEY;
 
-    if (!supabaseUrl || !supabaseKey) {
+    if (!supabaseUrl || !supabaseSecretKey) {
       throw new Error(
-        "Supabase configuration missing. Set SUPABASE_URL, SUPABASE_SERVICE_KEY and SUPABASE_STORAGE_SECRET_KEY environment variables.",
+        "Supabase configuration missing. Set SUPABASE_URL and SUPABASE_STORAGE_SECRET_KEY environment variables.",
       );
     }
 
-    supabaseClient = createClient(supabaseUrl, supabaseKey);
+    // Use the storage-specific secret key to authenticate S3-compatible storage operations
+    supabaseClient = createClient(supabaseUrl, supabaseSecretKey);
   }
   return supabaseClient;
 }
@@ -173,7 +173,9 @@ function extractPathFromUrl(publicUrl) {
  * @returns {boolean}
  */
 function isStorageConfigured() {
-  return !!(process.env.SUPABASE_URL && process.env.SUPABASE_SERVICE_KEY);
+  return !!(
+    process.env.SUPABASE_URL && process.env.SUPABASE_STORAGE_SECRET_KEY && process.env.SUPABASE_STORAGE_BUCKET
+  );
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- ensure Supabase storage client uses the S3 storage secret key when connecting
- update storage configuration checks to require the storage bucket and secret key
- refresh storage configuration error message to reference the correct environment variables

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d9dc514d883249d76f0b6c8292b10)