### PR TITLE
Fix Supabase upload with proper S3 protocol

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,8 +31,13 @@ NODE_ENV=development
 
 # Supabase Storage Configuration
 # Used for equipment inventory photo uploads
+# SUPABASE_URL can be either:
+#   - Base URL: https://your-project.supabase.co
+#   - S3 endpoint: https://your-project.storage.supabase.co/storage/v1/s3
 SUPABASE_URL=https://your-project.supabase.co
+# Use either SUPABASE_SERVICE_KEY or SUPABASE_STORAGE_SECRET_KEY (they can be the same)
 SUPABASE_SERVICE_KEY=your_supabase_service_role_key
+SUPABASE_STORAGE_SECRET_KEY=your_supabase_service_role_key
 SUPABASE_STORAGE_BUCKET=inventory
 
 # Frontend Environment Variables (prefixed with VITE_)

--- a/routes/resources.js
+++ b/routes/resources.js
@@ -362,7 +362,7 @@ module.exports = (pool) => {
         if (!isStorageConfigured()) {
           return error(
             res,
-            'Photo storage is not configured. Please set SUPABASE_URL, SUPABASE_STORAGE_SECRET_KEY, and SUPABASE_STORAGE_BUCKET.',
+            'Photo storage is not configured. Please set SUPABASE_URL, SUPABASE_STORAGE_SECRET_KEY (or SUPABASE_SERVICE_KEY), and SUPABASE_STORAGE_BUCKET.',
             503
           );
         }


### PR DESCRIPTION
- Support both SUPABASE_URL formats (base URL and S3 endpoint)
- Auto-convert S3 endpoint URL to base Supabase URL
- Support both SUPABASE_SERVICE_KEY and SUPABASE_STORAGE_SECRET_KEY
- Update .env.example with clearer documentation
- Update error messages to reflect both env var options

This fixes the upload issue where SUPABASE_URL was set to the S3 endpoint (https://xxx.storage.supabase.co/storage/v1/s3) but the Supabase JS client expected the base URL (https://xxx.supabase.co).