### PR TITLE
Fix service worker image handling to always return Response

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -193,11 +193,17 @@ async function handleImageRequest(request) {
       cache.put(request, networkResponse.clone());
       return networkResponse;
     }
+    // If response is not OK (4xx, 5xx), return fallback
+    debugError("Image fetch returned non-OK status:", networkResponse.status);
+    return (
+      (await caches.match("/images/fallback.png")) ||
+      new Response("Image not available", { status: 404 })
+    );
   } catch (error) {
     debugError("Error fetching image:", error);
     // Return a fallback image if available
     return (
-      caches.match("/images/fallback.png") ||
+      (await caches.match("/images/fallback.png")) ||
       new Response("Image not available", { status: 404 })
     );
   }


### PR DESCRIPTION
- Ensure handleImageRequest always returns a Response object
- Add fallback response when network fetch returns non-OK status
- Await fallback image cache lookup
- Prevents "Failed to convert value to 'Response'" error

This fixes the service worker error when fetching Supabase storage images that fail to load.