### PR TITLE
Fix cross-domain Supabase image loading in service worker

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -141,6 +141,11 @@ self.addEventListener("fetch", (event) => {
     event.request.destination === "image" ||
     staticImages.includes(url.pathname)
   ) {
+    // Don't intercept Supabase storage images - let them pass through
+    // This prevents CORS issues when different subdomains access shared images
+    if (url.hostname.includes('supabase.co')) {
+      return; // Let the browser handle Supabase images directly
+    }
     event.respondWith(handleImageRequest(event.request));
     return;
   }


### PR DESCRIPTION
Prevent service worker from intercepting Supabase storage image requests. This allows browsers on different domains (e.g., meute6a.app and meute6b.wampums.app) to properly load shared equipment images from Supabase with correct CORS handling.

The service worker was caching cross-origin Supabase images, causing CORS issues when different organization domains tried to access shared inventory images. Now Supabase images bypass the service worker entirely.