### PR TITLE
Find missing translation keys in material management

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1557,5 +1557,9 @@
   "select_target_organization": "Select Target Organization",
   "select_organization": "Select an organization...",
   "copy": "Copy",
-  "error_organization_not_found": "Organization not found"
+  "error_organization_not_found": "Organization not found",
+  "reservation_form": "Reservation Form",
+  "existing_reservations": "Existing Reservations",
+  "organization": "Organization",
+  "date_required": "Please select reservation dates"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1594,5 +1594,9 @@
   "select_target_organization": "Sélectionner l'organisation cible",
   "select_organization": "Sélectionner une organisation...",
   "copy": "Copier",
-  "error_organization_not_found": "Organisation introuvable"
+  "error_organization_not_found": "Organisation introuvable",
+  "reservation_form": "Formulaire de réservation",
+  "existing_reservations": "Réservations existantes",
+  "organization": "Organisation",
+  "date_required": "Veuillez sélectionner les dates de réservation"
 }


### PR DESCRIPTION
Added 4 missing translation keys that were used in material_management.js but were not present in the translation files:
- reservation_form: "Reservation Form" / "Formulaire de réservation"
- existing_reservations: "Existing Reservations" / "Réservations existantes"
- organization: "Organization" / "Organisation"
- date_required: "Please select reservation dates" / "Veuillez sélectionner les dates de réservation"

All translation keys used in material_management.js are now present in both en.json and fr.json translation files.