### PR TITLE
Prevent repeated PWA update prompts after version bumps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wampums",
-  "version": "2.3.4",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wampums",
-      "version": "2.3.4",
+      "version": "2.4.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.87.1",
         "bcrypt": "^5.0.1",


### PR DESCRIPTION
## Summary
- prevent repeated PWA update prompts by remembering the last service worker version surfaced to users
- ensure service worker update checks only trigger when encountering a new version
- align package-lock.json version metadata with the 2.4.0 release

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693efc4666c48324bc58fcf3b64e0b79)