### PR TITLE
Make Font Awesome stylesheet non-blocking

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,11 +62,21 @@
     <!-- Stylesheets -->
     <link rel="stylesheet" href="/css/styles.css">
     <link
-        rel="stylesheet"
+        rel="preload"
+        as="style"
         href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
         crossorigin="anonymous"
         referrerpolicy="no-referrer"
+        onload="this.rel='stylesheet'"
     >
+    <noscript>
+        <link
+            rel="stylesheet"
+            href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+            crossorigin="anonymous"
+            referrerpolicy="no-referrer"
+        >
+    </noscript>
 
     <!-- Import Map for ES Modules -->
     <script type="importmap">


### PR DESCRIPTION
## Summary
- switch Font Awesome include to preload with onload activation so it no longer blocks rendering
- add a noscript fallback stylesheet load to preserve icons without JavaScript

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f0e3de6748324bfb55eb04c2d975c)