### PR TITLE
Add dynamic robots.txt generation for multi-tenant hosts

### DIFF
--- a/test/api.test.js
+++ b/test/api.test.js
@@ -7,12 +7,16 @@ jest.mock('pg', () => {
     query: jest.fn(),
     release: jest.fn()
   };
+  const mPool = {
+    connect: jest.fn(() => Promise.resolve(mClient)),
+    query: jest.fn(),
+    on: jest.fn()
+  };
   return {
-    Pool: jest.fn(() => ({
-      connect: jest.fn(() => Promise.resolve(mClient))
-    })),
+    Pool: jest.fn(() => mPool),
     __esModule: true,
-    __mClient: mClient
+    __mClient: mClient,
+    __mPool: mPool
   };
 });
 
@@ -29,6 +33,15 @@ beforeAll(() => {
   process.env.DB_PORT = '5432';
 
   app = require('../api');
+});
+
+beforeEach(() => {
+  const { __mClient, __mPool } = require('pg');
+  __mClient.query.mockReset();
+  __mClient.release.mockReset();
+  __mPool.connect.mockClear();
+  __mPool.query.mockReset();
+  __mPool.query.mockResolvedValue({ rows: [] });
 });
 
 afterEach(() => {


### PR DESCRIPTION
## Summary
- generate robots.txt dynamically per host with cache headers and sensitive path exclusions
- register the legacy action-based endpoint before modular routers and scope attendance routes to avoid intercepting /api
- strengthen pg mocks for pool-level interactions used by legacy requests

## Testing
- npm test -- --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f1014017c8324a2e774982f748da7)