### PR TITLE
Improve Font Awesome loading on dashboard

### DIFF
--- a/spa/dashboard.js
+++ b/spa/dashboard.js
@@ -28,6 +28,7 @@ export class Dashboard {
 
   async init() {
     try {
+      this.applyIconFontLoadingStrategy();
       await this.fetchOrganizationInfo();
       await this.preloadDashboardData();
       this.attachEventListeners();
@@ -37,6 +38,43 @@ export class Dashboard {
       debugError("Error initializing dashboard:", error);
       this.renderError();
     }
+  }
+
+  /**
+   * Ensure Font Awesome icons use a non-blocking loading strategy.
+   *
+   * The override adds `font-display: swap` so icons fall back to system
+   * fonts until the CDN-delivered font finishes loading. Metric overrides
+   * keep the fallback glyph dimensions close to the final font to mitigate
+   * layout shifts when the icon font swaps in.
+   */
+  applyIconFontLoadingStrategy() {
+    const existingOverride = document.getElementById(
+      "fa-font-display-override",
+    );
+
+    if (existingOverride) {
+      return;
+    }
+
+    const style = document.createElement("style");
+    style.id = "fa-font-display-override";
+    style.textContent = `
+      @font-face {
+        font-family: "Font Awesome 6 Free";
+        font-style: normal;
+        font-weight: 900;
+        font-display: swap;
+        src: url("https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/webfonts/fa-solid-900.woff2") format("woff2"),
+             url("https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/webfonts/fa-solid-900.woff") format("woff");
+        ascent-override: 90%;
+        descent-override: 22%;
+        line-gap-override: 0%;
+        size-adjust: 92%;
+      }
+    `;
+
+    document.head.appendChild(style);
   }
 
   loadPointsCollapsedState() {


### PR DESCRIPTION
## Summary
- add a font-display swap override for Font Awesome assets used by the dashboard
- include metric overrides to reduce layout shifts when the icon font loads

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f1b66ed708324b08e947f5de5232d)