### PR TITLE
Ensure landing pages are mobile-first and redirect demo submissions

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -1,6 +1,8 @@
 <!doctype html>
 <html lang="fr">
   <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <!-- Canonical -->
     <link rel="canonical" href="https://wampums.app/" />
 

--- a/landing/landing.js
+++ b/landing/landing.js
@@ -474,53 +474,18 @@ demoForm.addEventListener("submit", async (e) => {
 			body: JSON.stringify(formData),
 		});
 
-		const data = await response.json();
+                const data = await response.json();
 
-		if (response.ok && data.success) {
-			// Show success message
-			formSuccess.classList.add("active");
-			demoForm.style.display = "none";
+                if (response.ok && data.success) {
+                        // Show success message
+                        formSuccess.classList.add("active");
+                        demoForm.style.display = "none";
 
-			// Wait 2 seconds then authenticate and redirect to demo
-			setTimeout(async () => {
-				try {
-					// Authenticate with demo credentials
-					const loginResponse = await fetch(
-						"https://demo.wampums.app/public/login",
-						{
-							method: "POST",
-							headers: {
-								"Content-Type": "application/json",
-							},
-							body: JSON.stringify({
-								email: "akela.demo@demo.com",
-								password: "Aylmer2025",
-							}),
-						},
-					);
-
-					const loginData = await loginResponse.json();
-
-					if (loginResponse.ok && loginData.success && loginData.token) {
-						// Store the token and redirect to the app
-						localStorage.setItem("token", loginData.token);
-						localStorage.setItem("user_role", loginData.user_role);
-						localStorage.setItem("user_full_name", loginData.user_full_name);
-						localStorage.setItem("user_id", loginData.user_id);
-
-						// Redirect to the main app
-						window.location.href = "https://demo.wampums.app/dashboard";
-					} else {
-						// If login fails, just redirect to login page
-						window.location.href = "https://wampums.app/";
-					}
-				} catch (error) {
-					console.error("Error authenticating:", error);
-					// On error, just redirect to login page
-					window.location.href = "https://wampums.app/";
-				}
-			}, 2000);
-		} else {
+                        // Redirect to demo experience after a brief confirmation pause
+                        setTimeout(() => {
+                                window.location.href = "https://demo.wampums.app";
+                        }, 2000);
+                } else {
 			// Show error
 			alert(
 				data.message ||


### PR DESCRIPTION
## Summary
- add charset and viewport metadata to the main landing page to enable mobile-first rendering
- simplify the demo request success flow to redirect visitors to demo.wampums.app after submission

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f60391dac8324ae49c2cfa0b1b646)