### PR TITLE
Fix push subscription routing and cleanup

### DIFF
--- a/routes/notifications.js
+++ b/routes/notifications.js
@@ -62,7 +62,8 @@ module.exports = (pool, logger) => {
    *       401:
    *         description: Unauthorized
    */
-  router.post('/push-subscription',
+  // Accept both legacy and versioned paths to avoid 404s during rollout
+  router.post(['/push-subscription', '/v1/push-subscription'],
     check('endpoint').notEmpty().withMessage('endpoint is required').isURL().withMessage('endpoint must be a valid URL'),
     check('keys.p256dh').notEmpty().withMessage('keys.p256dh is required'),
     check('keys.auth').notEmpty().withMessage('keys.auth is required'),
@@ -112,6 +113,11 @@ module.exports = (pool, logger) => {
       logger.error('Error initiating subscription save:', error);
       res.status(500).json({ error: 'Failed to save subscription' });
     }
+  });
+
+  // Lightweight health check to prevent expensive 404 handling on accidental GET requests
+  router.get(['/push-subscription', '/v1/push-subscription'], (req, res) => {
+    res.status(405).json({ success: false, message: 'Method not allowed. Use POST to register push subscriptions.' });
   });
 
   /**

--- a/spa/app.js
+++ b/spa/app.js
@@ -80,7 +80,7 @@ async function sendSubscriptionToServer(subscription) {
                         throw new Error('No token available');
                 }
 
-                const response = await fetch('/api/push-subscription', {
+                const response = await fetch('/api/v1/push-subscription', {
                         method: 'POST',
                         headers: {
                                 'Content-Type': 'application/json',

--- a/spa/parent_dashboard.js
+++ b/spa/parent_dashboard.js
@@ -9,7 +9,7 @@ import {
 import { getPermissionSlips, signPermissionSlip } from "./api/api-endpoints.js";
 import { debugLog, debugError, debugWarn, debugInfo } from "./utils/DebugUtils.js";
 import { translate } from "./app.js";
-import { urlBase64ToUint8Array, hexStringToUint8Array, base64UrlEncode } from './functions.js';
+import { hexStringToUint8Array, base64UrlEncode } from './functions.js';
 import { CONFIG } from './config.js';
 import { escapeHTML } from "./utils/SecurityUtils.js";
 
@@ -717,32 +717,6 @@ renderFormButtons(participant) {
                 }
 
   }
-
-         async registerPushSubscription() {
-                        if ('serviceWorker' in navigator && 'PushManager' in window) {
-                                try {
-                                        const registration = await navigator.serviceWorker.ready;
-                                        const applicationServerKey = urlBase64ToUint8Array(CONFIG.PUSH_NOTIFICATIONS.VAPID_PUBLIC_KEY);
-                                        const subscription = await registration.pushManager.subscribe({
-                                                userVisibleOnly: true,
-                                                applicationServerKey: applicationServerKey,
-                                        });
-
-                                        debugLog('Push subscription:', subscription);
-
-                                        // Send subscription to your server to save it
-                                        await fetch('/save-subscription', {
-                                                method: 'POST',
-                                                headers: {
-                                                        'Content-Type': 'application/json',
-                                                },
-                                                body: JSON.stringify(subscription),
-                                        });
-                                } catch (error) {
-                                        debugError('Error registering for push notifications:', error);
-                                }
-                        }
-                }
 
                 renderError() {
                         const errorMessage = `


### PR DESCRIPTION
## Summary
- Accept both legacy and versioned push-subscription routes and add a lightweight GET handler to avoid 404 responses
- Update SPA push subscription requests to use the versioned API path
- Remove unused parent dashboard push subscription stub that hit a nonexistent endpoint

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f665266d08324ba65eff7129f528f)