### PR TITLE
Remove duplicate fiche medications API export

### DIFF
--- a/spa/api/api-endpoints.js
+++ b/spa/api/api-endpoints.js
@@ -1428,26 +1428,6 @@ export async function getFicheMedications(cacheOptions = {}) {
 }
 
 /**
- * Get distinct medications from fiche_sante submissions
- */
-export async function getFicheMedications() {
-    return API.get('v1/medication/fiche-medications', {}, {
-        cacheKey: 'fiche_medications',
-        cacheDuration: CONFIG.CACHE_DURATION.SHORT
-    });
-}
-
-/**
- * Get distinct medications from fiche_sante submissions
- */
-export async function getFicheMedications() {
-    return API.get('v1/medication/fiche-medications', {}, {
-        cacheKey: 'fiche_medications',
-        cacheDuration: CONFIG.CACHE_DURATION.SHORT
-    });
-}
-
-/**
  * Create or update a medication requirement
  */
 export async function saveMedicationRequirement(payload) {


### PR DESCRIPTION
## Summary
- remove duplicate getFicheMedications exports from the medication API endpoints
- retain the cacheable implementation to prevent identifier redeclaration errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69406e0b66f48324b6220d72e267e74d)