### PR TITLE
Add quick carpool access and activity creation to animation dashboard

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1767,4 +1767,7 @@
   "error_occurred": "An error occurred"
 ,
   "select_activity_for_carpool": "Select an activity to coordinate carpools"
+,
+  "quick_create_activity": "Quick Create Activity",
+  "creating": "Creating"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1805,4 +1805,7 @@
   "error_occurred": "Une erreur s'est produite"
 ,
   "select_activity_for_carpool": "Sélectionnez une activité pour coordonner les covoiturages"
+,
+  "quick_create_activity": "Création rapide d'activité",
+  "creating": "Création en cours"
 }


### PR DESCRIPTION
Features:
- Add "Carpool Coordination" link directly in Preparation section
- Clicking shows modal with all upcoming activities
- Each activity shows vehicle count and participant assignments
- "Quick Create Activity" button for easy testing
- Simplified activity creation form with sensible defaults
- After creating, redirects directly to carpool coordination
- Mobile-friendly modal design
- Hover effects on activity cards

This makes it easy for animation staff to:
1. Access carpooling without going through activities calendar
2. Quickly create test activities for carpooling
3. See overview of all carpool arrangements at a glance

Added translations:
- quick_create_activity: "Quick Create Activity" / "Création rapide d'activité"
- creating: "Creating" / "Création en cours"