### PR TITLE
Fix budget table layout and styling

### DIFF
--- a/spa/budgets.js
+++ b/spa/budgets.js
@@ -253,7 +253,7 @@ export class Budgets {
           </button>
         </div>
 
-        <div class="tab-content">
+        <div class="tab-content active">
           ${tabContent}
         </div>
       </div>


### PR DESCRIPTION
The tab-content div was always hidden because it was missing the 'active' class. Added the 'active' class to make the budget table and all tab content visible.

Fixes: Budget table not displaying due to display:none CSS rule