### PR TITLE
Fix report modal visibility

### DIFF
--- a/spa/reports.js
+++ b/spa/reports.js
@@ -224,7 +224,7 @@ export class Reports {
 		document.addEventListener("keydown", (e) => {
 			if (e.key === "Escape") {
 				const modal = document.getElementById("report-modal");
-				if (modal && modal.style.display !== "none") {
+				if (modal && !modal.classList.contains("hidden")) {
 					this.closeReportModal();
 				}
 			}
@@ -239,14 +239,25 @@ export class Reports {
 		const modal = document.getElementById("report-modal");
 		const modalTitle = document.getElementById("report-modal-title");
 
+		if (!modal || !modalTitle) {
+			debugWarn("Report modal elements missing");
+			return;
+		}
+
 		modalTitle.textContent = title;
-		modal.style.display = "block";
+		modal.classList.remove("hidden");
+		modal.setAttribute("aria-hidden", "false");
 		document.body.style.overflow = "hidden"; // Prevent background scrolling
 	}
 
 	closeReportModal() {
 		const modal = document.getElementById("report-modal");
-		modal.style.display = "none";
+		if (!modal) {
+			return;
+		}
+
+		modal.classList.add("hidden");
+		modal.setAttribute("aria-hidden", "true");
 		document.body.style.overflow = ""; // Restore scrolling
 	}
 


### PR DESCRIPTION
## Summary
- ensure the reports modal removes the hidden state and updates aria flags when opened
- restore the hidden state and aria attributes when closing the modal
- align Escape key handling with the hidden class so the modal closes reliably

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942fa1f7ac08324a887b04805d18ced)