### PR TITLE
Define group hierarchy and naming structure

### DIFF
--- a/migrations/add_program_section_to_organizations.sql
+++ b/migrations/add_program_section_to_organizations.sql
@@ -1,0 +1,87 @@
+BEGIN;
+
+-- Add program_section (age group) to organizations table
+-- This is the correct location for age group designation since one organization
+-- represents one age group (e.g., "1st Cubs", "2nd Scouts")
+-- Groups within an organization are subdivisions (e.g., Tannières, Patrouilles)
+
+-- Ensure the organization_program_sections table exists (should already exist from previous migration)
+CREATE TABLE IF NOT EXISTS organization_program_sections (
+  organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  section_key TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  CONSTRAINT organization_program_sections_pkey PRIMARY KEY (organization_id, section_key),
+  CONSTRAINT organization_program_sections_key_not_empty CHECK (length(btrim(section_key)) > 0),
+  CONSTRAINT organization_program_sections_label_not_empty CHECK (length(btrim(display_name)) > 0)
+);
+
+-- Seed default sections for all organizations if not already present
+WITH default_sections AS (
+  SELECT * FROM (
+    VALUES
+      ('general', 'General'),
+      ('beavers', 'Beavers'),
+      ('cubs', 'Cubs'),
+      ('scouts', 'Scouts'),
+      ('pioneers', 'Venturers'),
+      ('rovers', 'Rovers')
+  ) AS s(section_key, display_name)
+)
+INSERT INTO organization_program_sections (organization_id, section_key, display_name)
+SELECT org.id, ds.section_key, ds.display_name
+FROM organizations org
+CROSS JOIN default_sections ds
+ON CONFLICT (organization_id, section_key) DO NOTHING;
+
+-- Ensure organization settings expose the available sections for clients
+WITH default_sections AS (
+  SELECT * FROM (
+    VALUES
+      ('general', 'General'),
+      ('beavers', 'Beavers'),
+      ('cubs', 'Cubs'),
+      ('scouts', 'Scouts'),
+      ('pioneers', 'Venturers'),
+      ('rovers', 'Rovers')
+  ) AS s(section_key, display_name)
+),
+section_payload AS (
+  SELECT json_agg(json_build_object('key', section_key, 'label', display_name) ORDER BY section_key) AS value
+  FROM default_sections
+)
+INSERT INTO organization_settings (organization_id, setting_key, setting_value)
+SELECT org.id, 'program_sections', section_payload.value::text
+FROM organizations org
+CROSS JOIN section_payload
+WHERE NOT EXISTS (
+  SELECT 1 FROM organization_settings s
+  WHERE s.organization_id = org.id AND s.setting_key = 'program_sections'
+);
+
+-- Add program_section to organizations table with default to 'general'
+ALTER TABLE organizations
+  ADD COLUMN IF NOT EXISTS program_section TEXT DEFAULT 'general';
+
+-- Set all existing organizations to 'general' if NULL
+UPDATE organizations
+SET program_section = 'general'
+WHERE program_section IS NULL;
+
+-- Make it NOT NULL
+ALTER TABLE organizations
+  ALTER COLUMN program_section SET NOT NULL;
+
+-- Add foreign key constraint to ensure valid program section
+ALTER TABLE organizations
+  ADD CONSTRAINT organizations_program_section_fk
+    FOREIGN KEY (id, program_section)
+    REFERENCES organization_program_sections (organization_id, section_key)
+    ON DELETE RESTRICT;
+
+-- Add index for better query performance
+CREATE INDEX IF NOT EXISTS idx_organizations_program_section
+  ON organizations(program_section);
+
+COMMIT;

--- a/migrations/rollback_program_section_from_groups.sql
+++ b/migrations/rollback_program_section_from_groups.sql
@@ -1,0 +1,27 @@
+BEGIN;
+
+-- This migration rolls back the incorrect assignment of program_section to groups
+-- Program sections (age groups like Beavers, Cubs, Scouts) should be at the organization level,
+-- not at the group level. Groups are subdivisions within an age group (e.g., Tannières).
+
+-- Remove foreign key constraints
+ALTER TABLE participant_groups
+  DROP CONSTRAINT IF EXISTS participant_groups_group_section_fk;
+
+ALTER TABLE participant_groups
+  DROP CONSTRAINT IF EXISTS participant_groups_program_section_fk;
+
+ALTER TABLE groups
+  DROP CONSTRAINT IF EXISTS groups_org_section_unique;
+
+ALTER TABLE groups
+  DROP CONSTRAINT IF EXISTS groups_program_section_fk;
+
+-- Remove program_section columns
+ALTER TABLE participant_groups
+  DROP COLUMN IF EXISTS program_section;
+
+ALTER TABLE groups
+  DROP COLUMN IF EXISTS program_section;
+
+COMMIT;

--- a/spa/api/api-endpoints.js
+++ b/spa/api/api-endpoints.js
@@ -680,8 +680,8 @@ export async function getGroups() {
 /**
  * Add new group
  */
-export async function addGroup(groupName, programSection) {
-    return API.post('v1/groups', { name: groupName, program_section: programSection });
+export async function addGroup(groupName) {
+    return API.post('v1/groups', { name: groupName });
 }
 
 /**
@@ -694,15 +694,11 @@ export async function removeGroup(groupId) {
 /**
  * Update group name
  */
-export async function updateGroupName(groupId, newName, programSection = undefined) {
+export async function updateGroupName(groupId, newName) {
     const payload = {};
 
     if (newName !== undefined) {
         payload.name = newName;
-    }
-
-    if (programSection !== undefined) {
-        payload.program_section = programSection;
     }
 
     return API.put(`v1/groups/${groupId}`, payload);


### PR DESCRIPTION
Problem:
- Groups were incorrectly assigned age groups (program sections)
- This broke attendances and points modules
- Groups (Tannières, Patrouilles) are subdivisions within an age group
- Age group should be an organization property, not a group property

Solution:
- Created rollback migration to remove program_section from groups and participant_groups
- Created new migration to add program_section to organizations table
- Updated all backend routes (groups.js, participants.js) to remove program_section logic
- Updated frontend (manage_groups.js) to remove program_section UI
- Updated API endpoints to remove program_section parameters

Database changes:
- Removed: groups.program_section column
- Removed: participant_groups.program_section column
- Added: organizations.program_section column
- Kept: organization_program_sections table for available sections

This fixes the confusion where groups like "Tannière des Loups" were each assigned an age group, when in reality one organization represents one age group and contains multiple themed subgroups.