### PR TITLE
Add WhatsApp as communication option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,8 +22,29 @@ JWT_SECRET_KEY=your_secret_key_here_REPLACE_WITH_RANDOM_64_BYTE_HEX
 VAPID_PRIVATE=your_vapid_private_key
 VAPID_PUBLIC=BPsOyoPVxNCN6BqsLdHwc5aaNPERFO2yq-xF3vqHJ7CdMlHRn5EBPnxcoOKGkeIO1_9zHnF5CRyD6RvLlOKPcTE
 
-# SendGrid (for email)
+# Email Configuration (Brevo - formerly Sendinblue)
+# Brevo API Key for transactional emails
+BREVO_API_KEY=your_brevo_api_key
+# Alternative environment variable name
+# BREVO_KEY=your_brevo_api_key
+
+# Brevo SMTP Configuration (fallback email sending method)
+BREVO_SMTP_KEY=your_brevo_smtp_key
+BREVO_SMTP_USER=your-smtp-login@smtp-brevo.com
+
+# Email sender configuration
+EMAIL_FROM=info@wampums.app
+EMAIL_FROM_NAME=Wampums
+
+# SendGrid (for email - alternative, not currently in use)
 SENDGRID_API_KEY=your_sendgrid_api_key
+
+# WhatsApp Integration (Twilio)
+# Get credentials from: https://console.twilio.com
+TWILIO_ACCOUNT_SID=your_twilio_account_sid
+TWILIO_AUTH_TOKEN=your_twilio_auth_token
+# Your Twilio WhatsApp-enabled phone number (format: whatsapp:+1234567890)
+TWILIO_WHATSAPP_FROM=whatsapp:+1234567890
 
 # Server Configuration
 PORT=3000

--- a/migrations/add_whatsapp_integration.sql
+++ b/migrations/add_whatsapp_integration.sql
@@ -1,0 +1,17 @@
+-- Migration: Add WhatsApp integration support
+-- Description: Adds whatsapp_phone_number column to users table to support
+-- WhatsApp as a communication channel alongside email and push notifications.
+
+-- Add WhatsApp phone number column to users table
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS whatsapp_phone_number VARCHAR(20);
+
+-- Add comment explaining the field
+COMMENT ON COLUMN users.whatsapp_phone_number IS 'User WhatsApp phone number in E.164 format (e.g., +1234567890) for WhatsApp notifications. NULL if user has not opted in to WhatsApp communications.';
+
+-- Create index for efficient filtering when sending bulk WhatsApp messages
+CREATE INDEX IF NOT EXISTS idx_users_whatsapp_phone
+  ON users (whatsapp_phone_number) WHERE whatsapp_phone_number IS NOT NULL;
+
+-- Add helpful comment about supported channels
+COMMENT ON TABLE announcement_logs IS 'Logs for announcement deliveries. Supported channels: email, push, whatsapp. Status can be: sent, failed.';

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "sib-api-v3-sdk": "^8.5.0",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
+    "twilio": "^5.3.7",
     "web-push": "^3.6.7",
     "winston": "^3.3.3"
   },


### PR DESCRIPTION
Integrate WhatsApp as a communication channel alongside email and push notifications using Twilio WhatsApp Business API.

Features:
- Send announcements via WhatsApp to users who opt-in
- User-managed WhatsApp phone numbers in account settings
- Phone number validation (E.164 format)
- Comprehensive logging in announcement_logs table
- Full integration with existing announcement system

Backend Changes:
- Add sendWhatsApp() utility function using Twilio API
- Update announcement system to dispatch WhatsApp messages
- Add API endpoint to set/update WhatsApp phone number
- Add Twilio package dependency

Database:
- Add whatsapp_phone_number column to users table
- Create index for efficient WhatsApp recipient queries
- Support 'whatsapp' as new channel in announcement_logs

Frontend:
- Add WhatsApp phone number field in account settings UI
- Client-side phone number validation
- Handle WhatsApp preference updates via API

Configuration:
- Add Twilio environment variables to .env.example
- Document Brevo email configuration
- Include WhatsApp setup instructions

See docs/WHATSAPP_INTEGRATION.md for complete setup guide and usage.