### PR TITLE
Fix WhatsApp connection authentication issue

### DIFF
--- a/services/whatsapp-baileys.js
+++ b/services/whatsapp-baileys.js
@@ -27,13 +27,17 @@ const fs = require('fs').promises;
 
 // Configure logger
 const logger = winston.createLogger({
-  level: 'info',
+  level: 'debug', // Set to debug to capture trace-level logs from Baileys
   format: winston.format.json(),
   transports: [
     new winston.transports.File({ filename: 'whatsapp-baileys.log' }),
     new winston.transports.Console({ format: winston.format.simple() })
   ],
 });
+
+// Add trace method for Baileys compatibility
+// Baileys expects logger.trace() but Winston doesn't have it by default
+logger.trace = (...args) => logger.debug(...args);
 
 /**
  * WhatsApp Baileys Service Class
@@ -92,7 +96,6 @@ class WhatsAppBaileysService {
           creds: state.creds,
           keys: makeCacheableSignalKeyStore(state.keys, logger),
         },
-        printQRInTerminal: true, // Also print in terminal for debugging
         logger: logger,
         browser: ['Wampums', 'Chrome', '10.0'], // Custom browser name
         getMessage: async (key) => {


### PR DESCRIPTION
This commit addresses two critical issues preventing WhatsApp connection:

1. **Logger compatibility fix**: Added logger.trace() method to Winston logger
   - Baileys library expects trace() but Winston doesn't provide it by default
   - Mapped trace() to debug() for compatibility
   - Changed log level to 'debug' to capture trace-level logs
   - Removed deprecated printQRInTerminal option

2. **Organization ID resolution fix**: Improved PATCH /users/me/whatsapp-phone endpoint
   - Now properly resolves organization ID from headers or JWT token
   - Uses getOrganizationId() helper for consistent org ID resolution
   - Added graceful handling when organization ID is not available
   - Prevents 500 errors from undefined organizationId

These fixes should eliminate the "logger.trace is not a function" fatal errors and allow WhatsApp QR code generation and phone number updates to work correctly.