### PR TITLE
fix: Remove double JSON encoding in WhatsApp phone update

### DIFF
--- a/spa/modules/account-info.js
+++ b/spa/modules/account-info.js
@@ -492,7 +492,7 @@ export class AccountInfoModule {
 
       const response = await makeApiRequest("v1/users/me/whatsapp-phone", {
         method: "PATCH",
-        body: JSON.stringify({ whatsappPhoneNumber: whatsappPhoneNumber || null }),
+        body: { whatsappPhoneNumber: whatsappPhoneNumber || null },
       });
 
       if (response.success) {


### PR DESCRIPTION
The request body was being stringified twice:
1. Once in account-info.js when calling makeApiRequest
2. Again in api-core.js before sending the fetch request

This caused the server to receive an invalid JSON string like: ""{\"whatsapp...}" instead of {"whatsapp...}

Fixed by passing the object directly to makeApiRequest, which handles the JSON.stringify internally.

This resolves the 500 error when updating WhatsApp phone numbers.