### PR TITLE
fix: Remove authDir reference from connection object

### DIFF
--- a/services/whatsapp-baileys.js
+++ b/services/whatsapp-baileys.js
@@ -104,7 +104,6 @@ class WhatsAppBaileysService {
         isConnected: false,
         organizationId,
         userId,
-        authDir,
         qrCode: null,
       });
 


### PR DESCRIPTION
Removed leftover authDir reference that was causing 'authDir is not defined' error when trying to connect WhatsApp. This was missed during the migration from file-based to database storage.