### PR TITLE
Configure logging output directory and dev watch ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,9 @@ composer.phar
 /tmp/tests/*
 !/tmp/tests/empty
 
-/logs/*
-!/logs/empty
+# Application logs
+/logs/
+logs/
 *.log
 
 # CakePHP 2

--- a/vite.config.js
+++ b/vite.config.js
@@ -108,6 +108,9 @@ export default defineConfig({
 
   server: {
     port: 5173,
+    watch: {
+      ignored: ['**/logs/**', '**/*.log']
+    },
     proxy: {
       '/api': {
         target: 'http://localhost:5000',


### PR DESCRIPTION
## Summary
- configure Winston logs to write under process.cwd()/logs with directory creation
- update Vite dev server watch settings to ignore log files and folders
- reinforce .gitignore entries for the logs directory to prevent accidental commits

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69446dbc4e1083248909a10d8ede741d)