### PR TITLE
Implement WhatsApp reconnect logic for error 515

### DIFF
--- a/WHATSAPP_RECONNECT_LOGIC.md
+++ b/WHATSAPP_RECONNECT_LOGIC.md
@@ -1,0 +1,173 @@
+# WhatsApp Reconnect Logic Implementation
+
+## 🎯 Problem Solved
+
+**Error 515 (Stream Errored)** was being treated as a permanent credential rejection, causing the service to delete authentication keys and require QR code re-scanning. However, Error 515 is often **temporary** and can occur when:
+- Multiple instances try to connect with the same session (zombie processes)
+- WhatsApp temporarily disconnects the connection
+- Network issues cause temporary stream errors
+
+## ✅ Solution Implemented
+
+### 1. Error 515 Now Treated as Temporary
+
+**Before:**
+```javascript
+const credentialRejection = statusCode === 515 || statusCode === 401;
+// Would clear auth state and delete keys
+```
+
+**After:**
+```javascript
+const isTemporaryError = statusCode === 515;
+const credentialRejection = statusCode === 401; // Only 401 is credential rejection
+
+// Error 515 triggers reconnection WITHOUT deleting keys
+const shouldReconnect = ... || isTemporaryError;
+```
+
+### 2. Zombie Process Detection
+
+Added checks to prevent multiple instances from connecting simultaneously:
+
+```javascript
+// Check if socket exists and is still open
+if (existingConnection.sock && !existingConnection.sock.ws?.isClosed) {
+  logger.info(`Connection already in progress, preventing zombie process`);
+  return true;
+}
+
+// Clean up stale/closed connections
+if (existingConnection.sock) {
+  existingConnection.sock.end();
+}
+this.connections.delete(organizationId);
+```
+
+### 3. Exponential Backoff for Reconnection
+
+Implements smart retry logic with exponential backoff:
+
+- **Attempt 1:** Wait 3 seconds
+- **Attempt 2:** Wait 6 seconds
+- **Attempt 3:** Wait 12 seconds
+- **Attempt 4:** Wait 24 seconds
+- **Attempt 5+:** Wait 48 seconds (max)
+
+**Counter auto-resets** if more than 5 minutes pass since last attempt.
+
+```javascript
+const reconnectInfo = this.reconnectAttempts.get(organizationId) || { count: 0, lastAttempt: 0 };
+
+// Reset counter if it's been more than 5 minutes
+if (now - reconnectInfo.lastAttempt > 5 * 60 * 1000) {
+  reconnectInfo.count = 0;
+}
+
+const backoffDelay = Math.min(baseDelay * Math.pow(2, reconnectInfo.count - 1), maxDelay);
+```
+
+### 4. Successful Connection Cleanup
+
+When connection succeeds, reconnect attempts are cleared:
+
+```javascript
+if (connection === 'open') {
+  // Reset reconnect attempts on successful connection
+  this.reconnectAttempts.delete(organizationId);
+  // ...
+}
+```
+
+## 🔄 Connection Flow
+
+### Temporary Error (515)
+```
+1. Connection closes with Error 515
+2. Service recognizes it as temporary
+3. Keeps authentication keys intact
+4. Waits with exponential backoff
+5. Reconnects with existing credentials
+6. Connection succeeds ✅
+```
+
+### Permanent Error (401, logout, bad session)
+```
+1. Connection closes with permanent error
+2. Service clears authentication state
+3. Deletes credentials from database
+4. Emits disconnection event
+5. Generates fresh QR code if needed
+```
+
+## 🛡️ Zombie Process Prevention
+
+The service now prevents multiple simultaneous connections:
+
+1. **Check existing connection** before creating new one
+2. **Verify socket is closed** before replacing
+3. **Clean up stale connections** properly
+4. **Log warnings** when preventing duplicate connections
+
+## 📊 Reconnection Tracking
+
+New `reconnectAttempts` Map tracks:
+- **count**: Number of reconnection attempts
+- **lastAttempt**: Timestamp of last attempt
+
+This enables:
+- Smart exponential backoff
+- Auto-reset after 5 minutes of inactivity
+- Clear logging of reconnection attempts
+
+## 🔧 Configuration
+
+No configuration changes needed! The reconnection logic works automatically:
+
+- **Temporary errors (515)**: Auto-reconnect with backoff
+- **Permanent errors (401, logout)**: Clear credentials
+- **Zombie processes**: Automatically detected and prevented
+- **Exponential backoff**: 3s → 6s → 12s → 24s → 48s (max)
+
+## 📝 Logging
+
+Enhanced logging shows reconnection status:
+
+```
+Connection closed for org 123. Reconnect: true. Status: 515 (temporary error - will reconnect)
+Reconnecting org 123 (attempt 2) in 6000ms
+Connection already in progress, preventing zombie process
+WhatsApp connected successfully for organization 123
+```
+
+## 🎯 Key Benefits
+
+1. ✅ **No more repeated QR scans** for temporary errors
+2. ✅ **Automatic reconnection** with smart backoff
+3. ✅ **Prevents zombie processes** from competing connections
+4. ✅ **Preserves credentials** during temporary disconnections
+5. ✅ **Clear logging** for debugging connection issues
+6. ✅ **Production-ready** with proven retry patterns
+
+## 🚀 Testing
+
+To test the new reconnection logic:
+
+1. **Connect WhatsApp** normally via QR code
+2. **Simulate Error 515** by restarting server or killing process
+3. **Observe automatic reconnection** in logs
+4. **Verify credentials persist** without requiring new QR scan
+
+Expected behavior:
+- Service automatically reconnects with exponential backoff
+- No QR code required for temporary errors
+- Connection restores successfully
+
+## 📚 Related Files
+
+- `services/whatsapp-baileys.js` - Main service with reconnection logic
+- `services/whatsapp-database-auth.js` - Credential storage and management
+
+## 🎉 Result
+
+WhatsApp connections now handle temporary disconnections gracefully, reconnecting automatically without user intervention while preventing duplicate connection attempts!


### PR DESCRIPTION
- Treat Error 515 as temporary error instead of credential rejection
- Error 515 now triggers reconnection WITHOUT deleting auth keys
- Implement exponential backoff for reconnection attempts (3s → 48s max)
- Add zombie process detection to prevent multiple simultaneous connections
- Reset reconnect counter on successful connection or after 5 minutes
- Only Error 401, logout, and bad session clear credentials
- Enhanced logging for reconnection attempts and status

This fixes the issue where Error 515 would unnecessarily clear credentials and require QR code re-scanning. Now the service automatically reconnects with existing credentials using smart retry logic.