### PR TITLE
Allow district users to access parent tools and full participant lists

### DIFF
--- a/spa/router.js
+++ b/spa/router.js
@@ -17,6 +17,7 @@ import {
   canManagePoints,
   canManageRoles,
   canSendCommunications,
+  canAccessParentTools,
   canViewActivities,
   canViewAttendance,
   canViewBadges,
@@ -336,13 +337,13 @@ export class Router {
           await createOrganization.init();
           break;
         case "parentDashboard":
-          if (!guard(isParent())) {
+          if (!guard(canAccessParentTools())) {
             break;
           }
           await this.loadParentDashboard();
           break;
         case "parentFinance":
-          if (!guard(isParent())) {
+          if (!guard(canAccessParentTools())) {
             break;
           }
           await this.loadParentFinance();

--- a/spa/utils/PermissionUtils.js
+++ b/spa/utils/PermissionUtils.js
@@ -154,6 +154,29 @@ export function isParent() {
 }
 
 /**
+ * Determine if the current user can access parent-facing tools
+ * Allows staff with participant visibility to use parent dashboards
+ *
+ * @returns {boolean} True when user is a parent or has participant view access
+ */
+export function canAccessParentTools() {
+  const parentFriendlyStaffRoles = [
+    'district',
+    'unitadmin',
+    'leader',
+    'admin',
+    'animation',
+    'demoadmin'
+  ];
+
+  if (isParent()) {
+    return true;
+  }
+
+  return hasAnyRole(...parentFriendlyStaffRoles) && canViewParticipants();
+}
+
+/**
  * Check if user is an admin (district or unitadmin)
  *
  * @returns {boolean} True if user is an admin


### PR DESCRIPTION
## Summary
- allow staff roles with participant visibility to access parent-facing routes in the SPA
- return all organization participants on parent dashboard and participant APIs when the user has non-parent roles
- add shared helper for determining parent tool access to keep routing consistent
- block finance, equipment, and administration-only users from participant access outside reports while allowing parent/staff mixes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945f54026f4832499b5f323318cc679)