### PR TITLE
Refactor membership checks to permission keys

### DIFF
--- a/routes/announcements.js
+++ b/routes/announcements.js
@@ -394,6 +394,7 @@ module.exports = (pool, logger, whatsappService = null, googleChatService = null
 
   /**
    * Create a new announcement
+   * Permission: communications.send
    */
   router.post(
     '/v1/announcements',
@@ -416,7 +417,9 @@ module.exports = (pool, logger, whatsappService = null, googleChatService = null
         }
 
         const organizationId = await getCurrentOrganizationId(req, pool, logger);
-        const membership = await verifyOrganizationMembership(pool, payload.user_id, organizationId, ['admin', 'animation']);
+        const membership = await verifyOrganizationMembership(pool, payload.user_id, organizationId, {
+          requiredPermissions: ['communications.send'],
+        });
         if (!membership.authorized) {
           return res.status(403).json({ success: false, message: membership.message });
         }
@@ -480,7 +483,9 @@ module.exports = (pool, logger, whatsappService = null, googleChatService = null
       }
 
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
-      const membership = await verifyOrganizationMembership(pool, payload.user_id, organizationId, ['admin', 'animation']);
+      const membership = await verifyOrganizationMembership(pool, payload.user_id, organizationId, {
+        requiredPermissions: ['communications.send'],
+      });
       if (!membership.authorized) {
         return res.status(403).json({ success: false, message: membership.message });
       }

--- a/routes/external-revenue.js
+++ b/routes/external-revenue.js
@@ -13,9 +13,17 @@ module.exports = (pool, logger) => {
   /**
    * GET /api/v1/revenue/external
    * List external revenue entries (donations, sponsorships, grants, other)
+   * Permission: finance.view
    */
   router.get('/v1/revenue/external', authenticate, asyncHandler(async (req, res) => {
     const organizationId = await getOrganizationId(req, pool);
+    const permissionCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId, {
+      requiredPermissions: ['finance.view'],
+    });
+
+    if (!permissionCheck.authorized) {
+      return error(res, permissionCheck.message, 403);
+    }
     const { start_date, end_date, revenue_type, category_id } = req.query;
 
     const hasCategoryFilter = category_id && category_id !== 'all';
@@ -94,13 +102,16 @@ module.exports = (pool, logger) => {
   /**
    * POST /api/v1/revenue/external
    * Create a new external revenue entry
+   * Permission: finance.manage
    */
   router.post('/v1/revenue/external', authenticate, asyncHandler(async (req, res) => {
     try {
       logger.info('[external-revenue] POST request received:', { body: req.body, user: req.user?.id });
 
       const organizationId = await getOrganizationId(req, pool);
-      const authCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId, ['admin', 'animation']);
+      const authCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId, {
+        requiredPermissions: ['finance.manage'],
+      });
 
       if (!authCheck.authorized) {
         return error(res, authCheck.message, 403);
@@ -187,10 +198,13 @@ module.exports = (pool, logger) => {
   /**
    * PUT /api/v1/revenue/external/:id
    * Update an external revenue entry
+   * Permission: finance.manage
    */
   router.put('/v1/revenue/external/:id', authenticate, asyncHandler(async (req, res) => {
     const organizationId = await getOrganizationId(req, pool);
-    const authCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId, ['admin', 'animation']);
+    const authCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId, {
+      requiredPermissions: ['finance.manage'],
+    });
 
     if (!authCheck.authorized) {
       return error(res, authCheck.message, 403);
@@ -280,10 +294,13 @@ module.exports = (pool, logger) => {
   /**
    * DELETE /api/v1/revenue/external/:id
    * Delete an external revenue entry
+   * Permission: finance.manage
    */
   router.delete('/v1/revenue/external/:id', authenticate, asyncHandler(async (req, res) => {
     const organizationId = await getOrganizationId(req, pool);
-    const authCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId, ['admin']);
+    const authCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId, {
+      requiredPermissions: ['finance.manage'],
+    });
 
     if (!authCheck.authorized) {
       return error(res, authCheck.message, 403);
@@ -309,9 +326,17 @@ module.exports = (pool, logger) => {
   /**
    * GET /api/v1/revenue/external/summary
    * Get summary of external revenue by category and type
+   * Permission: finance.view
    */
   router.get('/v1/revenue/external/summary', authenticate, asyncHandler(async (req, res) => {
     const organizationId = await getOrganizationId(req, pool);
+    const permissionCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId, {
+      requiredPermissions: ['finance.view'],
+    });
+
+    if (!permissionCheck.authorized) {
+      return error(res, permissionCheck.message, 403);
+    }
     const { start_date, end_date } = req.query;
 
     let query = `

--- a/routes/google-chat.js
+++ b/routes/google-chat.js
@@ -48,7 +48,8 @@ module.exports = (pool, logger) => {
    *     summary: Configure Google Chat integration
    *     description: Upload service account credentials and configure Google Chat for the organization (admin only)
    *     tags: [GoogleChat]
-   *     security:
+   *     x-permission: org.edit
+    *     security:
    *       - bearerAuth: []
    *     requestBody:
    *       required: true
@@ -89,7 +90,9 @@ module.exports = (pool, logger) => {
         const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
         // Only admins can configure Google Chat
-        const membership = await verifyOrganizationMembership(pool, payload.user_id, organizationId, ['admin']);
+        const membership = await verifyOrganizationMembership(pool, payload.user_id, organizationId, {
+          requiredPermissions: ['org.edit'],
+        });
         if (!membership.authorized) {
           return res.status(403).json({ error: 'Admin access required' });
         }
@@ -137,7 +140,8 @@ module.exports = (pool, logger) => {
    *     summary: Get Google Chat configuration status
    *     description: Check if Google Chat is configured for the organization
    *     tags: [GoogleChat]
-   *     security:
+   *     x-permission: org.view
+    *     security:
    *       - bearerAuth: []
    *     responses:
    *       200:
@@ -156,7 +160,9 @@ module.exports = (pool, logger) => {
 
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
-      const membership = await verifyOrganizationMembership(pool, payload.user_id, organizationId);
+      const membership = await verifyOrganizationMembership(pool, payload.user_id, organizationId, {
+        requiredPermissions: ['org.view'],
+      });
       if (!membership.authorized) {
         return res.status(403).json({ error: 'Insufficient permissions' });
       }
@@ -197,7 +203,8 @@ module.exports = (pool, logger) => {
    *     summary: Register a Google Chat Space
    *     description: Register a Google Chat Space for the organization (admin only)
    *     tags: [GoogleChat]
-   *     security:
+   *     x-permission: org.edit
+    *     security:
    *       - bearerAuth: []
    *     requestBody:
    *       required: true
@@ -240,7 +247,9 @@ module.exports = (pool, logger) => {
 
         const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
-        const membership = await verifyOrganizationMembership(pool, payload.user_id, organizationId, ['admin']);
+        const membership = await verifyOrganizationMembership(pool, payload.user_id, organizationId, {
+          requiredPermissions: ['org.edit'],
+        });
         if (!membership.authorized) {
           return res.status(403).json({ error: 'Admin access required' });
         }
@@ -311,7 +320,8 @@ module.exports = (pool, logger) => {
    *     summary: List registered Google Chat Spaces
    *     description: Get all registered Google Chat Spaces for the organization
    *     tags: [GoogleChat]
-   *     security:
+   *     x-permission: communications.send
+    *     security:
    *       - bearerAuth: []
    *     responses:
    *       200:
@@ -328,7 +338,9 @@ module.exports = (pool, logger) => {
 
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
-      const membership = await verifyOrganizationMembership(pool, payload.user_id, organizationId);
+      const membership = await verifyOrganizationMembership(pool, payload.user_id, organizationId, {
+        requiredPermissions: ['communications.send'],
+      });
       if (!membership.authorized) {
         return res.status(403).json({ error: 'Insufficient permissions' });
       }
@@ -362,7 +374,8 @@ module.exports = (pool, logger) => {
    *     summary: Send a message to a Google Chat Space
    *     description: Send a message to a specific Google Chat Space (admin only)
    *     tags: [GoogleChat]
-   *     security:
+   *     x-permission: communications.send
+    *     security:
    *       - bearerAuth: []
    *     requestBody:
    *       required: true
@@ -402,7 +415,9 @@ module.exports = (pool, logger) => {
 
         const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
-        const membership = await verifyOrganizationMembership(pool, payload.user_id, organizationId, ['admin']);
+        const membership = await verifyOrganizationMembership(pool, payload.user_id, organizationId, {
+          requiredPermissions: ['communications.send'],
+        });
         if (!membership.authorized) {
           return res.status(403).json({ error: 'Admin access required' });
         }
@@ -471,7 +486,8 @@ module.exports = (pool, logger) => {
    *     summary: Broadcast message to default announcement space
    *     description: Send a broadcast message to the organization's default Google Chat Space (admin only)
    *     tags: [GoogleChat]
-   *     security:
+   *     x-permission: communications.send
+    *     security:
    *       - bearerAuth: []
    *     requestBody:
    *       required: true
@@ -510,7 +526,9 @@ module.exports = (pool, logger) => {
 
         const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
-        const membership = await verifyOrganizationMembership(pool, payload.user_id, organizationId, ['admin']);
+        const membership = await verifyOrganizationMembership(pool, payload.user_id, organizationId, {
+          requiredPermissions: ['communications.send'],
+        });
         if (!membership.authorized) {
           return res.status(403).json({ error: 'Admin access required' });
         }
@@ -542,7 +560,8 @@ module.exports = (pool, logger) => {
    *     summary: Get message history
    *     description: Retrieve Google Chat message history for the organization
    *     tags: [GoogleChat]
-   *     security:
+   *     x-permission: communications.send
+    *     security:
    *       - bearerAuth: []
    *     parameters:
    *       - in: query
@@ -565,7 +584,9 @@ module.exports = (pool, logger) => {
 
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
-      const membership = await verifyOrganizationMembership(pool, payload.user_id, organizationId);
+      const membership = await verifyOrganizationMembership(pool, payload.user_id, organizationId, {
+        requiredPermissions: ['communications.send'],
+      });
       if (!membership.authorized) {
         return res.status(403).json({ error: 'Insufficient permissions' });
       }

--- a/routes/import.js
+++ b/routes/import.js
@@ -66,7 +66,9 @@ module.exports = function(pool, logger) {
 
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
-      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId, ['admin']);
+      const authCheck = await verifyOrganizationMembership(pool, decoded.user_id, organizationId, {
+        requiredPermissions: ['org.edit'],
+      });
       if (!authCheck.authorized) {
         return res.status(403).json({ success: false, message: 'Admin access required' });
       }

--- a/routes/medication.js
+++ b/routes/medication.js
@@ -4,7 +4,8 @@ const { authenticate, getOrganizationId } = require('../middleware/auth');
 const { success, error, asyncHandler } = require('../middleware/response');
 const { verifyOrganizationMembership } = require('../utils/api-helpers');
 
-const ALLOWED_ROLES = ['admin', 'animation', 'leader'];
+const MEDICATION_READ_PERMISSIONS = ['participants.view'];
+const MEDICATION_MANAGE_PERMISSIONS = ['participants.edit'];
 
 const validateStatus = (status) => ['scheduled', 'given', 'missed', 'cancelled'].includes(status);
 
@@ -35,10 +36,13 @@ module.exports = (pool, logger) => {
   /**
    * GET /v1/medication/requirements
    * List medication requirement definitions for the organization
+   * Permission: participants.view
    */
   router.get('/v1/medication/requirements', authenticate, asyncHandler(async (req, res) => {
     const organizationId = await getOrganizationId(req, pool);
-    const authCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId, ALLOWED_ROLES);
+    const authCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId, {
+      requiredPermissions: MEDICATION_READ_PERMISSIONS,
+    });
 
     if (!authCheck.authorized) {
       return error(res, authCheck.message, 403);
@@ -62,10 +66,13 @@ module.exports = (pool, logger) => {
   /**
    * GET /v1/medication/fiche-medications
    * List distinct medications captured in fiche_sante submissions
+   * Permission: participants.view
    */
   router.get('/v1/medication/fiche-medications', authenticate, asyncHandler(async (req, res) => {
     const organizationId = await getOrganizationId(req, pool);
-    const authCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId, ALLOWED_ROLES);
+    const authCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId, {
+      requiredPermissions: MEDICATION_READ_PERMISSIONS,
+    });
 
     if (!authCheck.authorized) {
       return error(res, authCheck.message, 403);
@@ -89,10 +96,13 @@ module.exports = (pool, logger) => {
   /**
    * POST /v1/medication/requirements
    * Create a medication requirement and participant assignments
+   * Permission: participants.edit
    */
   router.post('/v1/medication/requirements', authenticate, asyncHandler(async (req, res) => {
     const organizationId = await getOrganizationId(req, pool);
-    const authCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId, ALLOWED_ROLES);
+    const authCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId, {
+      requiredPermissions: MEDICATION_MANAGE_PERMISSIONS,
+    });
 
     if (!authCheck.authorized) {
       return error(res, authCheck.message, 403);
@@ -192,13 +202,16 @@ module.exports = (pool, logger) => {
     }
   }));
 
-  /**
-   * PUT /v1/medication/requirements/:id
-   * Update a medication requirement and participant assignments
-   */
+/**
+ * PUT /v1/medication/requirements/:id
+ * Update a medication requirement and participant assignments
+ * Permission: participants.edit
+ */
   router.put('/v1/medication/requirements/:id', authenticate, asyncHandler(async (req, res) => {
     const organizationId = await getOrganizationId(req, pool);
-    const authCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId, ALLOWED_ROLES);
+    const authCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId, {
+      requiredPermissions: MEDICATION_MANAGE_PERMISSIONS,
+    });
 
     if (!authCheck.authorized) {
       return error(res, authCheck.message, 403);
@@ -329,13 +342,16 @@ module.exports = (pool, logger) => {
     }
   }));
 
-  /**
-   * GET /v1/medication/participant-medications
-   * List participant medication assignments
-   */
+/**
+ * GET /v1/medication/participant-medications
+ * List participant medication assignments
+ * Permission: participants.view
+ */
   router.get('/v1/medication/participant-medications', authenticate, asyncHandler(async (req, res) => {
     const organizationId = await getOrganizationId(req, pool);
-    const authCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId, ALLOWED_ROLES);
+    const authCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId, {
+      requiredPermissions: MEDICATION_READ_PERMISSIONS,
+    });
 
     if (!authCheck.authorized) {
       return error(res, authCheck.message, 403);
@@ -353,13 +369,16 @@ module.exports = (pool, logger) => {
     return success(res, { participant_medications: result.rows }, 'Participant medications loaded');
   }));
 
-  /**
-   * GET /v1/medication/distributions
-   * List scheduled and historical medication distributions
-   */
+/**
+ * GET /v1/medication/distributions
+ * List scheduled and historical medication distributions
+ * Permission: participants.edit
+ */
   router.get('/v1/medication/distributions', authenticate, asyncHandler(async (req, res) => {
     const organizationId = await getOrganizationId(req, pool);
-    const authCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId, ALLOWED_ROLES);
+    const authCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId, {
+      requiredPermissions: MEDICATION_MANAGE_PERMISSIONS,
+    });
 
     if (!authCheck.authorized) {
       return error(res, authCheck.message, 403);
@@ -386,13 +405,16 @@ module.exports = (pool, logger) => {
     return success(res, { distributions: result.rows }, 'Medication distributions loaded');
   }));
 
-  /**
-   * POST /v1/medication/distributions
-   * Schedule or update medication distributions for a single participant per entry
-   */
+/**
+ * POST /v1/medication/distributions
+ * Schedule or update medication distributions for a single participant per entry
+ * Permission: participants.edit
+ */
   router.post('/v1/medication/distributions', authenticate, asyncHandler(async (req, res) => {
     const organizationId = await getOrganizationId(req, pool);
-    const authCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId, ALLOWED_ROLES);
+    const authCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId, {
+      requiredPermissions: MEDICATION_READ_PERMISSIONS,
+    });
 
     if (!authCheck.authorized) {
       return error(res, authCheck.message, 403);
@@ -503,13 +525,16 @@ module.exports = (pool, logger) => {
     }
   }));
 
-  /**
-   * PATCH /v1/medication/distributions/:id
-   * Update the status of a medication distribution entry
-   */
+/**
+ * PATCH /v1/medication/distributions/:id
+ * Update the status of a medication distribution entry
+ * Permission: participants.edit
+ */
   router.patch('/v1/medication/distributions/:id', authenticate, asyncHandler(async (req, res) => {
     const organizationId = await getOrganizationId(req, pool);
-    const authCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId, ALLOWED_ROLES);
+    const authCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId, {
+      requiredPermissions: MEDICATION_MANAGE_PERMISSIONS,
+    });
 
     if (!authCheck.authorized) {
       return error(res, authCheck.message, 403);
@@ -560,4 +585,3 @@ module.exports = (pool, logger) => {
 
   return router;
 };
-

--- a/routes/participants.js
+++ b/routes/participants.js
@@ -339,7 +339,9 @@ module.exports = (pool) => {
     }
 
     // Verify user belongs to this organization
-    const authCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId);
+    const authCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId, {
+      requiredPermissions: ['participants.edit'],
+    });
     if (!authCheck.authorized) {
       return error(res, authCheck.message, 403);
     }
@@ -470,7 +472,9 @@ module.exports = (pool) => {
     const organizationId = await getOrganizationId(req, pool);
 
     // Verify user belongs to this organization
-    const authCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId);
+    const authCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId, {
+      requiredPermissions: ['participants.create'],
+    });
     if (!authCheck.authorized) {
       return error(res, authCheck.message, 403);
     }
@@ -586,7 +590,9 @@ module.exports = (pool) => {
     const organizationId = await getOrganizationId(req, pool);
 
     // Verify user belongs to this organization
-    const authCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId);
+    const authCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId, {
+      requiredPermissions: ['participants.edit'],
+    });
     if (!authCheck.authorized) {
       return error(res, authCheck.message, 403);
     }
@@ -695,7 +701,9 @@ module.exports = (pool) => {
     const organizationId = await getOrganizationId(req, pool);
 
     // Verify user belongs to this organization
-    const authCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId);
+    const authCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId, {
+      requiredPermissions: ['participants.edit'],
+    });
     if (!authCheck.authorized) {
       return error(res, authCheck.message, 403);
     }
@@ -709,7 +717,9 @@ module.exports = (pool) => {
 
     // If user is trying to link someone else, they need admin role
     if (user_id !== req.user.id) {
-      const adminCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId, ['admin']);
+      const adminCheck = await verifyOrganizationMembership(pool, req.user.id, organizationId, {
+        requiredPermissions: ['users.assign_roles'],
+      });
       if (!adminCheck.authorized) {
         return error(res, 'Only admins can link participants to other users', 403);
       }


### PR DESCRIPTION
## Summary
- replace legacy role array checks with permission-based authorization across announcements, calendars, finance, notifications, Google Chat, imports, medication, and participants
- enhance verifyOrganizationMembership and participant access helper to resolve roles/permissions from the database
- assign new organizations with district role ids instead of hardcoded admin strings and document required permissions on endpoints

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945fabe7ba08324ae3ed9acb18e1578)