### PR TITLE
Use permission-based admin access controls

### DIFF
--- a/spa/dashboard.js
+++ b/spa/dashboard.js
@@ -20,10 +20,10 @@ import { clearActivityRelatedCaches } from "./indexedDB.js";
 import {
   hasPermission,
   hasAnyPermission,
+  canAccessAdminPanel,
   canCreateOrganization,
   canManageRoles,
   canViewRoles,
-  isAdmin
 } from "./utils/PermissionUtils.js";
 
 export class Dashboard {
@@ -296,7 +296,7 @@ export class Dashboard {
     const showRoleManagement = canViewRoles();
     const showOrgCreation = canCreateOrganization();
     const showReports = hasAnyPermission('reports.view', 'reports.export');
-    const showAdminPanel = isAdmin(); // Old admin panel (legacy)
+    const showAdminPanel = canAccessAdminPanel(); // Old admin panel (legacy)
 
     // Build administration section links
     const administrationLinks = [];

--- a/spa/router.js
+++ b/spa/router.js
@@ -16,8 +16,11 @@ import {
   canManageInventory,
   canManagePoints,
   canManageRoles,
+  canViewRoles,
   canSendCommunications,
+  canAccessAdminPanel,
   canAccessParentTools,
+  canManageForms,
   canViewActivities,
   canViewAttendance,
   canViewBadges,
@@ -30,8 +33,6 @@ import {
   canViewParticipants,
   canViewReports,
   canViewUsers,
-  hasAnyRole,
-  hasRole,
   isParent
 } from "./utils/PermissionUtils.js";
 
@@ -219,7 +220,7 @@ export class Router {
           await report.init();
           break;
           case "admin":
-          if (!guard(hasAnyRole('district', 'unitadmin', 'demoadmin'))) {
+          if (!guard(canAccessAdminPanel())) {
             break;
           }
           await this.loadAdminPage();
@@ -329,7 +330,7 @@ export class Router {
           await this.loadCalendarsPage(param);
           break;
           case "createOrganization":
-          if (!guard(canCreateOrganization() || hasRole('district'))) {
+          if (!guard(canCreateOrganization())) {
               break;
           }
           const CreateOrganization = await this.loadModule('CreateOrganization');
@@ -477,7 +478,7 @@ export class Router {
           await this.loadAccountInfo();
           break;
         case "formBuilder":
-          if (!guard(hasAnyRole('district', 'unitadmin'))) {
+          if (!guard(canManageForms())) {
             break;
           }
           const FormBuilder = await this.loadModule('FormBuilder');
@@ -501,9 +502,9 @@ export class Router {
           await carpoolDashboard.init();
           break;
         case "roleManagement":
-          // Only accessible by users with roles.view permission (district/unitadmin)
+          // Only accessible by users with role management permissions
           // Permission check is done within the RoleManagement component
-          if (!guard(canManageRoles() || hasAnyRole('district', 'unitadmin'))) {
+          if (!guard(canManageRoles() || canViewRoles())) {
             break;
           }
           const RoleManagement = await this.loadModule('RoleManagement');

--- a/spa/utils/PermissionUtils.js
+++ b/spa/utils/PermissionUtils.js
@@ -164,8 +164,6 @@ export function canAccessParentTools() {
     'district',
     'unitadmin',
     'leader',
-    'admin',
-    'animation',
     'demoadmin'
   ];
 
@@ -173,7 +171,11 @@ export function canAccessParentTools() {
     return true;
   }
 
-  return hasAnyRole(...parentFriendlyStaffRoles) && canViewParticipants();
+  if (!canViewParticipants()) {
+    return false;
+  }
+
+  return hasAnyRole(...parentFriendlyStaffRoles);
 }
 
 /**
@@ -480,6 +482,35 @@ export function canViewCarpools() {
  */
 export function canManageCarpools() {
   return hasPermission('carpools.manage');
+}
+
+/**
+ * Determine if the current user can access administrative tools
+ *
+ * Combines permission checks with leadership roles to keep compatibility
+ * with existing role payloads coming from /api/roles.
+ *
+ * @returns {boolean} True when the user can access admin interfaces
+ */
+export function canAccessAdminPanel() {
+  if (canManageUsers() || canViewUsers() || canManageRoles() || canViewRoles() || canCreateOrganization() || canSendCommunications()) {
+    return true;
+  }
+
+  return hasAnyRole('district', 'unitadmin', 'leader', 'demoadmin');
+}
+
+/**
+ * Determine if the current user can manage form builder tools
+ *
+ * @returns {boolean} True when user has form permissions or admin access
+ */
+export function canManageForms() {
+  if (hasAnyPermission('forms.view', 'forms.create', 'forms.edit', 'forms.manage')) {
+    return true;
+  }
+
+  return canAccessAdminPanel();
 }
 
 /**


### PR DESCRIPTION
## Summary
- align parent-facing access helpers with district/leader roles and participant permissions
- centralize permission-based admin and form builder access checks in the router and dashboard
- gate admin panel data loading and user actions by available permissions instead of legacy role strings

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945fada70d883248210a650ae99d3b3)