### PR TITLE
Handle public organization settings fallback

### DIFF
--- a/spa/api/api-endpoints.js
+++ b/spa/api/api-endpoints.js
@@ -2077,10 +2077,15 @@ export async function switchOrganization(organizationId) {
  */
 export async function getOrganizationSettings(orgId = null) {
     const params = orgId ? { organization_id: orgId } : {};
-    return API.get('organization-settings', params, {
-        cacheKey: `org_settings_${orgId || 'current'}`,
-        cacheDuration: CONFIG.CACHE_DURATION.LONG
-    });
+    try {
+        return await API.get('organization-settings', params, {
+            cacheKey: `org_settings_${orgId || 'current'}`,
+            cacheDuration: CONFIG.CACHE_DURATION.LONG
+        });
+    } catch (error) {
+        debugWarn('Falling back to public organization settings:', error);
+        return getPublicOrganizationSettings();
+    }
 }
 
 /**

--- a/spa/api/api-helpers.js
+++ b/spa/api/api-helpers.js
@@ -122,10 +122,12 @@ export function buildPublicUrl(endpoint, params = {}) {
  */
 export async function fetchPublic(endpoint, options = {}) {
     const url = buildPublicUrl(endpoint);
+    const organizationId = getCurrentOrganizationId();
     const response = await fetch(url, {
         ...options,
         headers: {
             'Content-Type': 'application/json',
+            ...(organizationId ? { 'x-organization-id': organizationId } : {}),
             ...options.headers
         }
     });


### PR DESCRIPTION
## Summary
- add shared helpers to load organization settings and expose a public-safe subset with organization fallback handling
- serve public organization settings without authentication while keeping the existing protected route for full data
- update frontend helpers to include organization headers on public calls and fall back to public settings when authenticated requests fail

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69460081008c832498609c89d9582404)