### PR TITLE
Add WhatsApp auth migration and align helper script

### DIFF
--- a/WHATSAPP_BAILEYS_SETUP.md
+++ b/WHATSAPP_BAILEYS_SETUP.md
@@ -32,17 +32,17 @@ This integration uses **@whiskeysockets/baileys**, an unofficial WhatsApp Web AP
 
 ### 1. Database Migration
 
-Run the migration to create the WhatsApp connections table:
+Run the migrations to create/update the WhatsApp connections table (including auth storage via `migrations/20250212000000_migrate_whatsapp_auth_to_database.js`):
 
 ```bash
-# Using psql directly
-psql $DATABASE_URL -f migrations/add_whatsapp_baileys_integration.sql
+# Apply all pending migrations
+npm run migrate -- up
 
-# OR using npm migration script
-npm run migrate:up
+# OR use the helper script that wraps the same command
+node scripts/run-whatsapp-migration.js
 ```
 
-This creates the `whatsapp_baileys_connections` table to store connection status and session data.
+This creates the `whatsapp_baileys_connections` table to store connection status and serialized Baileys credentials/keys.
 
 ### 2. Environment Variables
 
@@ -379,7 +379,7 @@ CREATE TABLE whatsapp_baileys_connections (
 1. **services/whatsapp-baileys.js** - Core WhatsApp service
 2. **routes/whatsapp-baileys.js** - API endpoints
 3. **spa/modules/whatsapp-connection.js** - Frontend UI
-4. **migrations/add_whatsapp_baileys_integration.sql** - Database schema
+4. **migrations/20250212000000_migrate_whatsapp_auth_to_database.js** - Database schema
 
 ## 🎨 Frontend Customization
 

--- a/migrations/20250212000000_migrate_whatsapp_auth_to_database.js
+++ b/migrations/20250212000000_migrate_whatsapp_auth_to_database.js
@@ -1,0 +1,140 @@
+/**
+ * Ensure WhatsApp Baileys auth state is stored in the database.
+ *
+ * Creates the whatsapp_baileys_connections table when missing and
+ * backfills required columns/indexes for environments that already
+ * created the table manually.
+ *
+ * The table stores connection status plus the serialized Baileys
+ * credentials/keys used by services/whatsapp-database-auth.js.
+ */
+exports.up = (pgm) => {
+  pgm.createTable(
+    'whatsapp_baileys_connections',
+    {
+      id: 'id',
+      organization_id: {
+        type: 'integer',
+        notNull: true,
+        unique: true,
+        references: 'organizations',
+        onDelete: 'CASCADE',
+      },
+      is_connected: {
+        type: 'boolean',
+        default: false,
+      },
+      connected_phone_number: {
+        type: 'varchar(20)',
+      },
+      session_data: {
+        type: 'text',
+      },
+      auth_creds: {
+        type: 'jsonb',
+        default: pgm.func("'{}'::jsonb"),
+      },
+      auth_keys: {
+        type: 'jsonb',
+        default: pgm.func("'{}'::jsonb"),
+      },
+      last_connected_at: {
+        type: 'timestamp',
+      },
+      last_disconnected_at: {
+        type: 'timestamp',
+      },
+      created_at: {
+        type: 'timestamp',
+        default: pgm.func('now()'),
+      },
+      updated_at: {
+        type: 'timestamp',
+        default: pgm.func('now()'),
+      },
+    },
+    { ifNotExists: true }
+  );
+
+  pgm.addColumns(
+    'whatsapp_baileys_connections',
+    {
+      is_connected: {
+        type: 'boolean',
+        default: false,
+      },
+      connected_phone_number: {
+        type: 'varchar(20)',
+      },
+      session_data: {
+        type: 'text',
+      },
+      auth_creds: {
+        type: 'jsonb',
+        default: pgm.func("'{}'::jsonb"),
+      },
+      auth_keys: {
+        type: 'jsonb',
+        default: pgm.func("'{}'::jsonb"),
+      },
+      last_connected_at: {
+        type: 'timestamp',
+      },
+      last_disconnected_at: {
+        type: 'timestamp',
+      },
+      created_at: {
+        type: 'timestamp',
+        default: pgm.func('now()'),
+      },
+      updated_at: {
+        type: 'timestamp',
+        default: pgm.func('now()'),
+      },
+    },
+    { ifNotExists: true }
+  );
+
+  pgm.createIndex('whatsapp_baileys_connections', 'organization_id', {
+    name: 'idx_whatsapp_baileys_org_id',
+    unique: true,
+    ifNotExists: true,
+  });
+
+  pgm.createIndex('whatsapp_baileys_connections', ['organization_id', 'is_connected'], {
+    name: 'idx_whatsapp_baileys_connected',
+    where: 'is_connected = TRUE',
+    ifNotExists: true,
+  });
+
+  pgm.sql(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.table_constraints
+        WHERE constraint_name = 'whatsapp_baileys_connections_organization_id_fkey'
+      ) THEN
+        ALTER TABLE whatsapp_baileys_connections
+        ADD CONSTRAINT whatsapp_baileys_connections_organization_id_fkey
+        FOREIGN KEY (organization_id)
+        REFERENCES organizations(id)
+        ON DELETE CASCADE;
+      END IF;
+    END$$;
+  `);
+};
+
+exports.down = (pgm) => {
+  pgm.dropIndex('whatsapp_baileys_connections', ['organization_id', 'is_connected'], {
+    name: 'idx_whatsapp_baileys_connected',
+    ifExists: true,
+  });
+
+  pgm.dropIndex('whatsapp_baileys_connections', 'organization_id', {
+    name: 'idx_whatsapp_baileys_org_id',
+    ifExists: true,
+  });
+
+  pgm.dropTable('whatsapp_baileys_connections', { ifExists: true, cascade: true });
+};


### PR DESCRIPTION
## Summary
- add a node-pg-migrate migration that ensures the whatsapp_baileys_connections table can store Baileys auth credentials
- update the run-whatsapp-migration helper to call the standard npm migration command instead of a missing SQL file
- refresh the WhatsApp setup guide to reference the new migration path and helper script

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946011fa324832494ae3b688b39c805)