### PR TITLE
Ensure user cache refresh after admin updates

### DIFF
--- a/spa/ajax-functions.js
+++ b/spa/ajax-functions.js
@@ -124,6 +124,7 @@ export {
     checkPermission,
     approveUser,
     updateUserRole,
+    clearUserCaches,
 
     // Participants
     getParticipants,


### PR DESCRIPTION
## Summary
- add a scoped cache key for user listings and a helper to clear organization-specific caches
- refresh user data with cache busting after approvals and role updates while keeping optimistic UI updates
- re-export the cache helper alongside existing admin user API calls

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946c85f58c883249e0010af173e7fdd)