### PR TITLE
Add user role permission summary view

### DIFF
--- a/ROLE_SYSTEM_README.md
+++ b/ROLE_SYSTEM_README.md
@@ -335,6 +335,16 @@ ADD COLUMN role_ids JSONB DEFAULT '[]'::jsonb;
 - Check user's roles: `SELECT * FROM user_permissions WHERE user_id = 'xxx';`
 - Verify role-permission mapping: `SELECT * FROM role_permissions WHERE role_id = X;`
 - Check if permission exists: `SELECT * FROM permissions WHERE permission_key = 'xxx';`
+- Use the summary view to audit assignments: `SELECT * FROM user_role_permissions_summary WHERE organization_id = 1 ORDER BY full_name;`
+
+### User Role & Permission View
+
+Use the `user_role_permissions_summary` view to quickly review account access:
+
+- **Columns**: `organization_id`, `user_id`, `full_name`, `roles` (text[]), `permissions` (text[])
+- **Includes** legacy `user_organizations.role` plus new `role_ids` entries
+- **Aggregation** deduplicates role and permission keys for each organization/user pairing
+- **Example**: `SELECT full_name, roles, permissions FROM user_role_permissions_summary WHERE user_id = 42;`
 
 ## 📞 Support
 

--- a/migrations/006_create_user_role_permissions_view.sql
+++ b/migrations/006_create_user_role_permissions_view.sql
@@ -1,0 +1,41 @@
+-- Migration: Create user role and permission summary view
+-- Description: Adds a consolidated view of user full names, role names, and permission keys per organization
+-- This migration is idempotent and can be run multiple times safely
+
+DROP VIEW IF EXISTS user_role_permissions_summary;
+
+CREATE OR REPLACE VIEW user_role_permissions_summary AS
+SELECT
+    uo.organization_id,
+    u.id AS user_id,
+    u.full_name,
+    COALESCE(
+        ARRAY(
+            SELECT DISTINCT role_name
+            FROM (
+                SELECT r.role_name
+                FROM jsonb_array_elements_text(COALESCE(uo.role_ids, '[]'::jsonb)) AS role_id_text(role_id)
+                JOIN roles r ON r.id = role_id_text.role_id::integer
+                UNION ALL
+                SELECT uo.role
+            ) AS role_list(role_name)
+            WHERE role_name IS NOT NULL
+            ORDER BY role_name
+        ),
+        ARRAY[]::text[]
+    ) AS roles,
+    COALESCE(
+        ARRAY(
+            SELECT DISTINCT p.permission_key
+            FROM jsonb_array_elements_text(COALESCE(uo.role_ids, '[]'::jsonb)) AS role_id_text(role_id)
+            JOIN role_permissions rp ON rp.role_id = role_id_text.role_id::integer
+            JOIN permissions p ON p.id = rp.permission_id
+            ORDER BY p.permission_key
+        ),
+        ARRAY[]::text[]
+    ) AS permissions
+FROM users u
+JOIN user_organizations uo ON u.id = uo.user_id;
+
+COMMENT ON VIEW user_role_permissions_summary IS
+    'Summarizes each user''s full name, role names, and aggregated permission keys by organization';


### PR DESCRIPTION
## Summary
- add a migration that creates the `user_role_permissions_summary` view aggregating each user’s full name, roles, and permission keys per organization
- document how to query the new summary view for quick access audits

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946d01d52bc83249543171d9547c380)