### PR TITLE
Fix HEIC inventory photo uploads

### DIFF
--- a/routes/resources.js
+++ b/routes/resources.js
@@ -19,9 +19,9 @@ const { handleOrganizationResolutionError } = require("../utils/api-helpers");
 const { sendEmail } = require("../utils/index");
 const {
   MAX_FILE_SIZE,
-  ALLOWED_MIME_TYPES,
   OUTPUT_MIME_TYPE,
   validateFile,
+  isAllowedImageType,
   generateFilePath,
   uploadFile,
   deleteFile,
@@ -41,7 +41,7 @@ const upload = multer({
     fileSize: MAX_FILE_SIZE,
   },
   fileFilter: (req, file, cb) => {
-    if (ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+    if (isAllowedImageType(file)) {
       cb(null, true);
     } else {
       cb(
@@ -509,7 +509,6 @@ module.exports = (pool) => {
           filePath,
           OUTPUT_MIME_TYPE,
         );
-        alert(OUTPUT_MIME_TYPE);
 
         if (!uploadResult.success) {
           return error(


### PR DESCRIPTION
## Summary
- broaden HEIC/HEIF detection on the inventory photo upload backend, including alias MIME types and safe extension fallbacks
- mirror the allowed file detection on the inventory UI so HEIC uploads aren’t blocked when browsers omit MIME data
- clean up the equipment photo upload route by removing a stray alert call

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946efb52e70832494e6c026585e2802)