### PR TITLE
Handle HEIC uploads by converting to WebP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "express-validator": "^6.12.1",
         "glob": "^13.0.0",
         "google-auth-library": "^10.5.0",
+        "heic-convert": "^2.1.0",
         "helmet": "^4.6.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.2",
@@ -7773,6 +7774,41 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/heic-convert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/heic-convert/-/heic-convert-2.1.0.tgz",
+      "integrity": "sha512-1qDuRvEHifTVAj3pFIgkqGgJIr0M3X7cxEPjEp0oG4mo8GFjq99DpCo8Eg3kg17Cy0MTjxpFdoBHOatj7ZVKtg==",
+      "license": "ISC",
+      "dependencies": {
+        "heic-decode": "^2.0.0",
+        "jpeg-js": "^0.4.4",
+        "pngjs": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/heic-convert/node_modules/pngjs": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/heic-decode": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/heic-decode/-/heic-decode-2.1.0.tgz",
+      "integrity": "sha512-0fB3O3WMk38+PScbHLVp66jcNhsZ/ErtQ6u2lMYu/YxXgbBtl+oKOhGQHa4RpvE68k8IzbWkABzHnyAIjR758A==",
+      "license": "ISC",
+      "dependencies": {
+        "libheif-js": "^1.19.8"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/helmet": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
@@ -9280,6 +9316,12 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -9462,6 +9504,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/libheif-js": {
+      "version": "1.19.8",
+      "resolved": "https://registry.npmjs.org/libheif-js/-/libheif-js-1.19.8.tgz",
+      "integrity": "sha512-vQJWusIxO7wavpON1dusciL8Go9jsIQ+EUrckauFYAiSTjcmLAsuJh3SszLpvkwPci3JcL41ek2n+LUZGFpPIQ==",
+      "license": "LGPL-3.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/libsignal": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "express-validator": "^6.12.1",
     "glob": "^13.0.0",
     "google-auth-library": "^10.5.0",
+    "heic-convert": "^2.1.0",
     "helmet": "^4.6.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.0.2",


### PR DESCRIPTION
## Summary
- add a shared image conversion helper that converts HEIC/HEIF uploads to resized WebP before storing in Supabase
- reuse the helper in the equipment photo upload endpoint and centralize WebP constants
- add the heic-convert dependency to support HEIC processing

## Testing
- npm test -- --runInBand *(fails: jest cannot parse ESM dependency @whiskeysockets/baileys in api.test.js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946f2480ce48324932f5f61cb6fd27b)