### PR TITLE
Align leader flags with updated participant_groups schema

### DIFF
--- a/attached_assets/architecture.md
+++ b/attached_assets/architecture.md
@@ -1703,8 +1703,9 @@ CREATE TABLE participant_groups (
   participant_id INTEGER REFERENCES participants(id) ON DELETE CASCADE,
   group_id INTEGER REFERENCES groups(id) ON DELETE CASCADE,
   organization_id INTEGER NOT NULL REFERENCES organizations(id),
-  is_leader BOOLEAN DEFAULT FALSE,
-  is_second_leader BOOLEAN DEFAULT FALSE,
+  first_leader BOOLEAN DEFAULT FALSE,
+  second_leader BOOLEAN DEFAULT FALSE,
+  roles TEXT,
   PRIMARY KEY (participant_id, group_id, organization_id)
 );
 ```

--- a/routes/groups.js
+++ b/routes/groups.js
@@ -109,14 +109,14 @@ module.exports = (pool) => {
 
     // Get members
     const membersResult = await pool.query(
-      `SELECT p.*, pg.is_leader, pg.is_second_leader,
+      `SELECT p.*, pg.first_leader, pg.second_leader,
               COALESCE(SUM(pts.value), 0) as total_points
        FROM participants p
        JOIN participant_groups pg ON p.id = pg.participant_id
        LEFT JOIN points pts ON p.id = pts.participant_id AND pts.organization_id = $1
        WHERE pg.group_id = $2 AND pg.organization_id = $1
-       GROUP BY p.id, pg.is_leader, pg.is_second_leader
-       ORDER BY pg.is_leader DESC, pg.is_second_leader DESC, p.first_name`,
+       GROUP BY p.id, pg.first_leader, pg.second_leader
+       ORDER BY pg.first_leader DESC, pg.second_leader DESC, p.first_name`,
       [organizationId, id]
     );
 

--- a/routes/honors.js
+++ b/routes/honors.js
@@ -57,7 +57,7 @@ module.exports = (pool, logger) => {
       // Get participants
       const participantsResult = await pool.query(
         `SELECT p.id as participant_id, p.first_name, p.last_name,
-                pg.group_id, g.name as group_name, pg.is_leader, pg.is_second_leader
+                pg.group_id, g.name as group_name, pg.first_leader, pg.second_leader
          FROM participants p
          JOIN participant_organizations po ON p.id = po.participant_id
          LEFT JOIN participant_groups pg ON p.id = pg.participant_id AND pg.organization_id = $1

--- a/spa/api/api-endpoints.js
+++ b/spa/api/api-endpoints.js
@@ -767,12 +767,18 @@ export async function updateGroupName(groupId, newName) {
 /**
  * Update participant's group membership (RESTful v1 endpoint)
  */
-export async function updateParticipantGroup(participantId, groupId, isLeader = false, isSecondLeader = false, roles = null) {
+export async function updateParticipantGroup(
+    participantId,
+    groupId,
+    firstLeader = false,
+    secondLeader = false,
+    roles = null
+) {
     return API.patch(`v1/participants/${participantId}/group-membership`, {
         group_id: groupId,
-        is_leader: isLeader,
-        is_second_leader: isSecondLeader,
-        roles: roles
+        first_leader: firstLeader,
+        second_leader: secondLeader,
+        roles
     });
 }
 

--- a/spa/group-participant-report.js
+++ b/spa/group-participant-report.js
@@ -1,6 +1,7 @@
 import { getParticipants, getGroups } from "./ajax-functions.js";
 import { debugLog, debugError, debugWarn, debugInfo } from "./utils/DebugUtils.js";
 import { translate } from "./app.js";
+import { normalizeParticipantList } from "./utils/ParticipantRoleUtils.js";
 
 export class PrintableGroupParticipantReport {
 		constructor(app) {
@@ -42,7 +43,9 @@ export class PrintableGroupParticipantReport {
 				]);
 
 				// Support both new format (data) and old format (participants/groups)
-				this.participants = participantsResponse.data || participantsResponse.participants || [];
+				this.participants = normalizeParticipantList(
+          participantsResponse.data || participantsResponse.participants || []
+        );
 				this.groups = groupsResponse.data || groupsResponse.groups || [];
 
 				// Sort groups alphabetically
@@ -106,10 +109,10 @@ export class PrintableGroupParticipantReport {
 				return this.groups.map(group => {
 						const groupParticipants = this.participants.filter(p => p.group_id === group.id);
 						groupParticipants.sort((a, b) => {
-								if (a.is_leader) return -1;
-								if (b.is_leader) return 1;
-								if (a.is_second_leader) return 1;
-								if (b.is_second_leader) return -1;
+								if (a.first_leader) return -1;
+								if (b.first_leader) return 1;
+								if (a.second_leader) return 1;
+								if (b.second_leader) return -1;
 								return a.first_name.localeCompare(b.first_name);
 						});
 
@@ -118,8 +121,8 @@ export class PrintableGroupParticipantReport {
 										${index === 0 ? `<td rowspan="${groupParticipants.length}">${group.name}</td>` : ''}
 										<td>${participant.first_name} ${participant.last_name}</td>
 										<td>
-												${participant.is_leader ? `<strong>${translate("leader")}</strong>` : 
-													participant.is_second_leader ? `<strong>${translate("second_leader")}</strong>` : ""}
+												${participant.first_leader ? `<strong>${translate("leader")}</strong>` : 
+													participant.second_leader ? `<strong>${translate("second_leader")}</strong>` : ""}
 										</td>
 								</tr>
 						`).join('');

--- a/spa/manage_participants.js
+++ b/spa/manage_participants.js
@@ -12,6 +12,7 @@ import { CONFIG } from "./config.js";
 import { debugLog, debugError } from "./utils/DebugUtils.js";
 import { escapeHTML } from "./utils/SecurityUtils.js";
 import { canViewParticipants } from "./utils/PermissionUtils.js";
+import { normalizeParticipantList } from "./utils/ParticipantRoleUtils.js";
 
 export class ManageParticipants {
   constructor(app) {
@@ -80,7 +81,8 @@ export class ManageParticipants {
 
     if (participantsResponse.success) {
       // Support both new format (data) and old format (participants)
-      this.participants = participantsResponse.data || participantsResponse.participants || [];
+      const rawParticipants = participantsResponse.data || participantsResponse.participants || [];
+      this.participants = normalizeParticipantList(rawParticipants);
     } else {
       debugError("Failed to fetch participants data");
       this.participants = [];
@@ -214,9 +216,9 @@ export class ManageParticipants {
           </td>
           <td>
             <select class="role-select" data-participant-id="${participant.id}" ${!participant.group_id ? "disabled" : ""}>
-              <option value="none" ${!participant.is_leader && !participant.is_second_leader ? "selected" : ""}>${translate("none")}</option>
-              <option value="leader" ${participant.is_leader ? "selected" : ""}>${translate("leader")}</option>
-              <option value="second_leader" ${participant.is_second_leader ? "selected" : ""}>${translate("second_leader")}</option>
+              <option value="none" ${!participant.first_leader && !participant.second_leader ? "selected" : ""}>${translate("none")}</option>
+              <option value="leader" ${participant.first_leader ? "selected" : ""}>${translate("leader")}</option>
+              <option value="second_leader" ${participant.second_leader ? "selected" : ""}>${translate("second_leader")}</option>
             </select>
           </td>
           <td>
@@ -312,8 +314,8 @@ export class ManageParticipants {
       const requestData = {
           participant_id: participantId,
           group_id: groupId,
-          is_leader: false,
-          is_second_leader: false,
+          first_leader: false,
+          second_leader: false,
           roles: null
       };
 
@@ -323,8 +325,8 @@ export class ManageParticipants {
           const result = await updateParticipantGroup(
               requestData.participant_id,
               requestData.group_id,
-              requestData.is_leader,
-              requestData.is_second_leader,
+              requestData.first_leader,
+              requestData.second_leader,
               requestData.roles
           );
 
@@ -369,16 +371,16 @@ export class ManageParticipants {
       return;
     }
 
-    // Ensure we are passing valid boolean values (true/false) for is_leader and is_second_leader
-    const isLeader = role === "leader" ? true : false;
-    const isSecondLeader = role === "second_leader" ? true : false;
+    // Ensure we are passing valid boolean values (true/false) for first_leader and second_leader
+    const isLeader = role === "leader";
+    const isSecondLeader = role === "second_leader";
 
     // Log the data that will be sent
     const requestData = {
       participant_id: participantId,
       group_id: groupId,
-      is_leader: isLeader,
-      is_second_leader: isSecondLeader,
+      first_leader: isLeader,
+      second_leader: isSecondLeader,
       roles: roles
     };
 
@@ -420,15 +422,15 @@ export class ManageParticipants {
 
     // Get current role values
     const role = roleSelect.value;
-    const isLeader = role === "leader" ? true : false;
-    const isSecondLeader = role === "second_leader" ? true : false;
+    const isLeader = role === "leader";
+    const isSecondLeader = role === "second_leader";
 
     // Log the data that will be sent
     const requestData = {
       participant_id: participantId,
       group_id: groupId,
-      is_leader: isLeader,
-      is_second_leader: isSecondLeader,
+      first_leader: isLeader,
+      second_leader: isSecondLeader,
       roles: roles
     };
 

--- a/spa/utils/ParticipantRoleUtils.js
+++ b/spa/utils/ParticipantRoleUtils.js
@@ -1,0 +1,42 @@
+/**
+ * Normalize participant leader role flags to align with the current database schema.
+ * Ensures both legacy (is_leader) and new (first_leader) field names are present
+ * so downstream consumers can safely read consistent values.
+ *
+ * @param {Object} participant - Participant object with potential leader flags.
+ * @returns {Object} Participant object augmented with normalized leader flags.
+ */
+export function normalizeParticipantRoles(participant) {
+  if (!participant || typeof participant !== 'object') {
+    return participant;
+  }
+
+  const firstLeader = Boolean(
+    participant.first_leader ?? participant.is_leader ?? false
+  );
+  const secondLeader = Boolean(
+    participant.second_leader ?? participant.is_second_leader ?? false
+  );
+
+  return {
+    ...participant,
+    first_leader: firstLeader,
+    second_leader: secondLeader,
+    is_leader: firstLeader,
+    is_second_leader: secondLeader
+  };
+}
+
+/**
+ * Normalize leader role flags for an array of participants.
+ *
+ * @param {Array} participants - List of participants to normalize.
+ * @returns {Array} New array with normalized participant objects.
+ */
+export function normalizeParticipantList(participants = []) {
+  if (!Array.isArray(participants)) {
+    return [];
+  }
+
+  return participants.map(normalizeParticipantRoles);
+}


### PR DESCRIPTION
## Summary
- update honors and group detail queries to use the renamed participant_groups leader columns
- normalize leader role flags across participant-facing screens and API calls so UI renders and updates use first/second leader fields
- document the participant_groups schema changes in the architecture notes

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69470082258483249c9412724e2824fe)