### PR TITLE
Keep 2FA validation after parent logout

### DIFF
--- a/spa/utils/ClientCleanupUtils.js
+++ b/spa/utils/ClientCleanupUtils.js
@@ -1,5 +1,5 @@
 import { debugLog, debugWarn, debugError } from './DebugUtils.js';
-import { clearStorage } from './StorageUtils.js';
+import { clearUserData } from './StorageUtils.js';
 import { deleteIndexedDB } from '../indexedDB.js';
 
 /**
@@ -36,14 +36,16 @@ async function clearAllCaches() {
 /**
  * Clear all client-side storage, caches, and IndexedDB data.
  * Intended for logout flows to prevent cross-account data leakage.
+ * Preserves device-level preferences like 2FA device trust tokens.
  * @returns {Promise<void>} Resolves when cleanup tasks finish
  */
 export async function clearAllClientData() {
-  debugLog('Clearing client data (localStorage, sessionStorage, caches, IndexedDB)');
+  debugLog('Clearing user data (preserving device preferences like 2FA device tokens)');
 
-  // Clear Web Storage synchronously to remove tokens immediately
-  clearStorage(false);
-  clearStorage(true);
+  // Clear user-specific data while preserving device-level preferences
+  // This ensures device_token (2FA trust) and language preferences persist
+  clearUserData(false); // localStorage - selective clearing
+  clearUserData(true);  // sessionStorage - full clearing (no device prefs here)
 
   // Clear Cache Storage and IndexedDB
   await Promise.all([


### PR DESCRIPTION
Previously, logging out would clear ALL localStorage data including the device_token, forcing users to go through 2FA verification again on their next login even though the device was still trusted on the server.

Changes:
- Add clearUserData() function to StorageUtils.js that selectively clears user-specific data while preserving device-level preferences
- Preserve device_token (2FA device trust), organizationId, language prefs
- Update clearAllClientData() to use clearUserData() instead of clearStorage()
- User session data (jwtToken, userRole, etc.) is still cleared properly

Result: Users can now logout and login again without being prompted for 2FA on trusted devices, greatly improving the user experience.

Fixes: 2FA validation prompt after logout on trusted devices