### PR TITLE
Add local group membership APIs and schema

### DIFF
--- a/api.js
+++ b/api.js
@@ -590,6 +590,7 @@ const externalRevenueRoutes = require("./routes/external-revenue")(
   logger,
 );
 const resourcesRoutes = require("./routes/resources")(pool);
+const localGroupsRoutes = require("./routes/localGroups")(pool);
 const userProfileRoutes = require("./routes/userProfile")(pool, logger);
 const rolesRoutes = require("./routes/roles")(pool, logger);
 
@@ -868,6 +869,14 @@ logger.info("   - GET /api/v1/groups/:id");
 logger.info("   - POST /api/v1/groups");
 logger.info("   - PUT /api/v1/groups/:id");
 logger.info("   - DELETE /api/v1/groups/:id");
+
+// Local Group Routes (handles /api/v1/local-groups)
+app.use("/api/v1/local-groups", localGroupsRoutes);
+logger.info("✅ Local group routes loaded");
+logger.info("   - GET /api/v1/local-groups");
+logger.info("   - GET /api/v1/local-groups/memberships");
+logger.info("   - POST /api/v1/local-groups/memberships");
+logger.info("   - DELETE /api/v1/local-groups/memberships/:localGroupId");
 
 // Public Routes (handles /api/translations, /api/news)
 // Endpoints: translations, news

--- a/migrations/009_create_local_groups.sql
+++ b/migrations/009_create_local_groups.sql
@@ -1,0 +1,38 @@
+-- Migration: Create local groups and organization membership mapping
+-- Description: Adds local_groups and organization_local_groups tables with baseline data
+
+-- Create local_groups table to catalog regional groupings
+CREATE TABLE IF NOT EXISTS local_groups (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(150) NOT NULL,
+    slug VARCHAR(150) NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Create join table linking organizations to local groups
+CREATE TABLE IF NOT EXISTS organization_local_groups (
+    organization_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    local_group_id INTEGER NOT NULL REFERENCES local_groups(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (organization_id, local_group_id)
+);
+
+-- Baseline local groups to avoid hardcoding in application logic
+INSERT INTO local_groups (name, slug)
+VALUES
+    ('Groupe 6 Aylmer', 'groupe-6-aylmer'),
+    ('Hull', 'hull'),
+    ('Gatineau', 'gatineau'),
+    ('Ottawa', 'ottawa')
+ON CONFLICT (slug) DO NOTHING;
+
+-- Enroll initial organizations into Groupe 6 Aylmer for onboarding continuity
+WITH target_group AS (
+    SELECT id FROM local_groups WHERE slug = 'groupe-6-aylmer' LIMIT 1
+)
+INSERT INTO organization_local_groups (organization_id, local_group_id)
+SELECT orgs.organization_id, target_group.id
+FROM target_group
+CROSS JOIN (VALUES (1), (2)) AS orgs(organization_id)
+ON CONFLICT DO NOTHING;

--- a/routes/localGroups.js
+++ b/routes/localGroups.js
@@ -1,0 +1,135 @@
+/**
+ * Local Groups Routes
+ *
+ * Provides CRUD-style endpoints for local group catalog and organization memberships.
+ * Endpoints are prefixed with /api/v1/local-groups.
+ *
+ * @module routes/localGroups
+ */
+
+const express = require('express');
+const router = express.Router();
+const { authenticate, blockDemoRoles, getOrganizationId, requirePermission } = require('../middleware/auth');
+const { success, error, asyncHandler } = require('../middleware/response');
+
+/**
+ * Validate and normalize a local group identifier.
+ *
+ * @param {*} value - Incoming value to validate.
+ * @returns {number|null} Parsed identifier or null when invalid.
+ */
+function parseLocalGroupId(value) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return null;
+  }
+  return parsed;
+}
+
+module.exports = (pool) => {
+  /**
+   * GET /api/v1/local-groups
+   * List all available local groups.
+   */
+  router.get('/', authenticate, requirePermission('org.view'), asyncHandler(async (req, res) => {
+    const { rows } = await pool.query(
+      `SELECT id, name, slug
+       FROM local_groups
+       ORDER BY name`
+    );
+
+    return success(res, rows, 'Local groups retrieved successfully');
+  }));
+
+  /**
+   * GET /api/v1/local-groups/memberships
+   * Retrieve current organization's local group memberships.
+   */
+  router.get('/memberships', authenticate, requirePermission('org.view'), asyncHandler(async (req, res) => {
+    const organizationId = await getOrganizationId(req, pool);
+
+    const { rows } = await pool.query(
+      `SELECT lg.id, lg.name, lg.slug
+       FROM local_groups lg
+       INNER JOIN organization_local_groups olg
+         ON olg.local_group_id = lg.id
+       WHERE olg.organization_id = $1
+       ORDER BY lg.name`,
+      [organizationId]
+    );
+
+    return success(res, rows, 'Organization local group memberships retrieved successfully');
+  }));
+
+  /**
+   * POST /api/v1/local-groups/memberships
+   * Add organization membership to a local group.
+   */
+  router.post('/memberships', authenticate, blockDemoRoles, requirePermission('org.edit'), asyncHandler(async (req, res) => {
+    const organizationId = await getOrganizationId(req, pool);
+    const parsedId = parseLocalGroupId(req.body?.local_group_id);
+
+    if (!parsedId) {
+      return error(res, 'A valid local_group_id is required', 400);
+    }
+
+    const groupResult = await pool.query(
+      'SELECT id, name, slug FROM local_groups WHERE id = $1',
+      [parsedId]
+    );
+
+    if (groupResult.rows.length === 0) {
+      return error(res, 'Local group not found', 404);
+    }
+
+    await pool.query(
+      `INSERT INTO organization_local_groups (organization_id, local_group_id)
+       VALUES ($1, $2)
+       ON CONFLICT DO NOTHING`,
+      [organizationId, parsedId]
+    );
+
+    const membershipsResult = await pool.query(
+      `SELECT lg.id, lg.name, lg.slug
+       FROM local_groups lg
+       INNER JOIN organization_local_groups olg
+         ON olg.local_group_id = lg.id
+       WHERE olg.organization_id = $1
+       ORDER BY lg.name`,
+      [organizationId]
+    );
+
+    return success(res, {
+      added: groupResult.rows[0],
+      memberships: membershipsResult.rows
+    }, 'Local group membership added successfully', 201);
+  }));
+
+  /**
+   * DELETE /api/v1/local-groups/memberships/:localGroupId
+   * Remove organization membership from a local group.
+   */
+  router.delete('/memberships/:localGroupId', authenticate, blockDemoRoles, requirePermission('org.edit'), asyncHandler(async (req, res) => {
+    const organizationId = await getOrganizationId(req, pool);
+    const parsedId = parseLocalGroupId(req.params.localGroupId);
+
+    if (!parsedId) {
+      return error(res, 'A valid localGroupId is required', 400);
+    }
+
+    const deletionResult = await pool.query(
+      `DELETE FROM organization_local_groups
+       WHERE organization_id = $1 AND local_group_id = $2
+       RETURNING local_group_id`,
+      [organizationId, parsedId]
+    );
+
+    if (deletionResult.rows.length === 0) {
+      return error(res, 'Membership not found for organization', 404);
+    }
+
+    return success(res, null, 'Local group membership removed successfully', 200);
+  }));
+
+  return router;
+};

--- a/routes/organizations.js
+++ b/routes/organizations.js
@@ -58,6 +58,28 @@ async function loadOrganizationSettings(pool, organizationId) {
   await ensureProgramSectionsSeeded(pool, organizationId);
   settings.program_sections = await getProgramSections(pool, organizationId);
 
+  const [localGroupMemberships, allLocalGroups] = await Promise.all([
+    pool.query(
+      `SELECT lg.id, lg.name, lg.slug
+       FROM local_groups lg
+       INNER JOIN organization_local_groups olg
+         ON olg.local_group_id = lg.id
+       WHERE olg.organization_id = $1
+       ORDER BY lg.name`,
+      [organizationId]
+    ),
+    pool.query(
+      `SELECT id, name, slug
+       FROM local_groups
+       ORDER BY name`
+    )
+  ]);
+
+  settings.local_groups = {
+    memberships: localGroupMemberships.rows,
+    available: allLocalGroups.rows
+  };
+
   return settings;
 }
 

--- a/test/local-groups.test.js
+++ b/test/local-groups.test.js
@@ -1,0 +1,106 @@
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+
+// Mock pg module before requiring app
+jest.mock('pg', () => {
+  const mClient = {
+    query: jest.fn(),
+    release: jest.fn()
+  };
+  const mPool = {
+    connect: jest.fn(() => Promise.resolve(mClient)),
+    query: jest.fn(),
+    on: jest.fn()
+  };
+  return {
+    Pool: jest.fn(() => mPool),
+    __esModule: true,
+    __mClient: mClient,
+    __mPool: mPool
+  };
+});
+
+const { Pool } = require('pg');
+let app;
+
+beforeAll(() => {
+  process.env.JWT_SECRET_KEY = 'testsecret';
+  process.env.STRIPE_SECRET_KEY = 'sk_test_dummy';
+  app = require('../api');
+});
+
+beforeEach(() => {
+  const { __mClient, __mPool } = require('pg');
+  __mClient.query.mockReset();
+  __mClient.release.mockReset();
+  __mPool.connect.mockClear();
+  __mPool.query.mockReset();
+  __mPool.query.mockResolvedValue({ rows: [] });
+});
+
+afterEach(() => {
+  Pool.mockClear();
+});
+
+describe('Local groups API', () => {
+  test('returns memberships for current organization', async () => {
+    const token = jwt.sign({ user_id: 10, organizationId: 5 }, 'testsecret');
+    const { __mPool } = require('pg');
+
+    __mPool.query
+      .mockResolvedValueOnce({ rows: [{ permission_key: 'org.view' }] }) // permissions
+      .mockResolvedValueOnce({ rows: [{ role_name: 'admin', display_name: 'Admin' }] }) // roles
+      .mockResolvedValueOnce({ rows: [{ id: 1, name: 'Groupe 6 Aylmer', slug: 'groupe-6-aylmer' }] }); // memberships
+
+    const res = await request(app)
+      .get('/api/v1/local-groups/memberships')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].slug).toBe('groupe-6-aylmer');
+  });
+
+  test('prevents membership changes without permission', async () => {
+    const token = jwt.sign({ user_id: 11, organizationId: 7 }, 'testsecret');
+    const { __mPool } = require('pg');
+
+    __mPool.query
+      .mockResolvedValueOnce({ rows: [] }) // demo roles
+      .mockResolvedValueOnce({ rows: [] }) // permissions missing org.edit
+      .mockResolvedValueOnce({ rows: [] }); // roles
+
+    const res = await request(app)
+      .post('/api/v1/local-groups/memberships')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ local_group_id: 2 });
+
+    expect(res.status).toBe(403);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toBe('Insufficient permissions');
+  });
+
+  test('adds membership when authorized', async () => {
+    const token = jwt.sign({ user_id: 12, organizationId: 9 }, 'testsecret');
+    const { __mPool } = require('pg');
+
+    __mPool.query
+      .mockResolvedValueOnce({ rows: [] }) // demo roles
+      .mockResolvedValueOnce({ rows: [{ permission_key: 'org.edit' }] }) // permissions
+      .mockResolvedValueOnce({ rows: [{ role_name: 'admin', display_name: 'Admin' }] }) // roles
+      .mockResolvedValueOnce({ rows: [{ id: 2, name: 'Hull', slug: 'hull' }] }) // group exists
+      .mockResolvedValueOnce({ rows: [] }) // insert membership
+      .mockResolvedValueOnce({ rows: [{ id: 2, name: 'Hull', slug: 'hull' }] }); // memberships
+
+    const res = await request(app)
+      .post('/api/v1/local-groups/memberships')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ local_group_id: 2 });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.added.slug).toBe('hull');
+    expect(res.body.data.memberships).toHaveLength(1);
+  });
+});

--- a/test/setupJest.js
+++ b/test/setupJest.js
@@ -6,3 +6,5 @@ jest.mock('@whiskeysockets/baileys', () => ({
   makeCacheableSignalKeyStore: jest.fn(() => ({})),
   useMultiFileAuthState: jest.fn(() => Promise.resolve({ state: {}, saveCreds: jest.fn() }))
 }));
+
+process.env.STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY || 'sk_test_dummy';


### PR DESCRIPTION
## Summary
- add database tables for local groups plus seed data and initial memberships
- expose /api/v1/local-groups routes for listing and managing organization memberships and surface memberships in organization settings payloads
- add Jest coverage for membership retrieval and authorization plus test fixture updates

## Testing
- npm test -- --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69481450e6688324bf6abe48d60503a1)