### PR TITLE
Debug offline sync and page visibility issues

### DIFF
--- a/config/meeting_sections.js
+++ b/config/meeting_sections.js
@@ -1,0 +1,21 @@
+export default {
+  "defaultSection": "cubs",
+  "sections": {
+    "cubs": {
+      "honorField": {
+        "fieldKey": "youth_of_honor",
+        "labelKey": "youth_of_honor_label_cubs",
+        "required": false
+      },
+      "activityTemplates": [
+        { "time": "18:45", "duration": "00:10", "activityKey": "activity_welcome_cubs", "typeKey": "activity_type_preparation" },
+        { "time": "18:55", "duration": "00:30", "activityKey": "activity_big_game", "typeKey": "activity_type_game" },
+        { "time": "19:25", "duration": "00:05", "activityKey": "activity_water_break", "typeKey": "activity_type_pause" },
+        { "time": "19:30", "duration": "00:20", "activityKey": "activity_technique", "typeKey": "activity_technique" },
+        { "time": "19:50", "duration": "00:20", "activityKey": "activity_discussion", "typeKey": "activity_discussion" },
+        { "time": "20:10", "duration": "00:30", "activityKey": "activity_short_game", "typeKey": "activity_type_game" },
+        { "time": "20:40", "duration": "00:05", "activityKey": "activity_prayer_departure", "typeKey": "activity_type_conclusion" }
+      ]
+    }
+  }
+};

--- a/spa/utils/meetingSections.js
+++ b/spa/utils/meetingSections.js
@@ -1,4 +1,4 @@
-import defaultMeetingSections from "../../config/meeting_sections.json" assert { type: "json" };
+import defaultMeetingSections from "../../config/meeting_sections.js";
 
 /**
  * Merge custom meeting section configuration with defaults.


### PR DESCRIPTION
…S module

The import assertion syntax (assert { type: "json" }) was causing a syntax error in browsers that don't support this feature. Fixed by:

1. Converting config/meeting_sections.json to config/meeting_sections.js
2. Updating import to use standard ES6 module syntax

This resolves the routing error on /preparation-reunions page.