### PR TITLE
Lazy load reunion and activity widgets

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,8 +97,6 @@
         }
     }
     </script>
-
-    <script type="module" defer src="/spa/activity-widget.js"></script>
 </head>
 <body>
     <div id="app"></div>
@@ -122,7 +120,6 @@
 
     <!-- App will load initial data via API call -->
     <script type="module" defer src="/spa/app.js"></script>
-    <script type="module" defer src="/spa/init-activity-widget.js"></script>
     <a href="/politique-de-confidentialite.html" target="_blank" class="privacy-policy-link">Politique de confidentialité</a>
     <div id="loading-indicator" class="hidden">
         Loading...


### PR DESCRIPTION
Problem: activity-widget.js was being loaded eagerly in index.html, blocking the critical rendering path and causing:
- 1,052 ms delay for activity-widget.js
- 4,191 ms delay for reunion-preparation API call
- Total critical path latency of 4,191 ms

Solution:
- Removed eager loading of activity-widget.js from index.html
- Removed eager loading of init-activity-widget.js from index.html
- Router already has lazy loading logic that loads the widget only on specific routes (dashboard, activities, carpool, carpoolLanding)
- Widget now loads on-demand only when needed and user is authorized

Performance impact:
- Reduces critical path latency by ~4.2 seconds
- Defers API calls until widget is actually needed
- Improves Time to Interactive (TTI) and Largest Contentful Paint (LCP)