### PR TITLE
Add SafeAreaProvider to fix React Navigation setup

### DIFF
--- a/mobile/src/navigation/RootNavigator.js
+++ b/mobile/src/navigation/RootNavigator.js
@@ -8,6 +8,7 @@
 import React, { useState, useEffect } from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 import AuthNavigator from './AuthNavigator';
 import AppNavigator from './AppNavigator';
 import StorageUtils from '../utils/StorageUtils';
@@ -64,25 +65,27 @@ const RootNavigator = () => {
   }
 
   return (
-    <NavigationContainer>
-      <Stack.Navigator screenOptions={{ headerShown: false }}>
-        {isAuthenticated ? (
-          <Stack.Screen name="App">
-            {() => (
-              <AppNavigator
-                userRole={userRole}
-                userPermissions={userPermissions}
-                onLogout={handleLogout}
-              />
-            )}
-          </Stack.Screen>
-        ) : (
-          <Stack.Screen name="Auth">
-            {() => <AuthNavigator onLogin={handleLogin} />}
-          </Stack.Screen>
-        )}
-      </Stack.Navigator>
-    </NavigationContainer>
+    <SafeAreaProvider>
+      <NavigationContainer>
+        <Stack.Navigator screenOptions={{ headerShown: false }}>
+          {isAuthenticated ? (
+            <Stack.Screen name="App">
+              {() => (
+                <AppNavigator
+                  userRole={userRole}
+                  userPermissions={userPermissions}
+                  onLogout={handleLogout}
+                />
+              )}
+            </Stack.Screen>
+          ) : (
+            <Stack.Screen name="Auth">
+              {() => <AuthNavigator onLogin={handleLogin} />}
+            </Stack.Screen>
+          )}
+        </Stack.Navigator>
+      </NavigationContainer>
+    </SafeAreaProvider>
   );
 };
 


### PR DESCRIPTION
- Wrap NavigationContainer with SafeAreaProvider (required by React Navigation)
- This resolves the "String cannot be cast to Boolean" error on Android
- SafeAreaProvider is necessary for proper React Navigation v7 initialization

The boolean casting error was occurring because React Navigation requires SafeAreaProvider to properly initialize safe area insets on Android.