### PR TITLE
Refactor mobile app to use flat translation keys directly

### DIFF
--- a/mobile/src/i18n/index.js
+++ b/mobile/src/i18n/index.js
@@ -251,198 +251,13 @@ export const getCurrentLanguage = () => {
 };
 
 /**
- * Key mapping from nested dot notation to flat underscore notation
- * Maps mobile app's nested keys (e.g., 'auth.loginTitle') to lang.json flat keys (e.g., 'login')
- */
-const keyMapping = {
-  // Auth keys
-  'auth.loginTitle': 'login',
-  'auth.email': 'email',
-  'auth.password': 'password',
-  'auth.login': 'login',
-  'auth.createAccount': 'create_account',
-  'auth.forgotPassword': 'forgot_password',
-  'auth.loginFailed': 'invalid_email_or_password',
-  'auth.twoFactorTitle': 'two_factor_email_heading',
-  'auth.enterCode': 'two_factor_message',
-  'auth.verificationCode': 'verification_code_sent',
-  'auth.trustDevice': 'Trust this device', // Fallback text
-  'auth.verify': 'verify',
-  'auth.backToLogin': 'back_to_login',
-  'auth.invalidCode': 'Invalid verification code', // Fallback text
-  'auth.verificationFailed': 'Verification failed', // Fallback text
-
-  // Common keys
-  'common.loading': 'loading',
-  'common.save': 'save',
-  'common.cancel': 'cancel',
-  'common.ok': 'OK',
-  'common.error': 'error',
-  'common.success': 'success',
-  'common.errorLoadingData': 'error_loading_data',
-  'common.years': 'years',
-  'common.notProvided': 'Not provided', // Fallback text
-  'common.offline': 'Offline',
-  'common.viewingCachedData': 'Viewing cached data', // Fallback text
-  'common.comingSoon': 'Coming soon', // Fallback text
-  'common.edit': 'edit',
-  'common.retry': 'retry',
-  'common.permissionDenied': 'Permission denied', // Fallback text
-  'common.queued': 'Queued', // Fallback text
-  'common.willSyncWhenOnline': 'Will sync when online', // Fallback text
-  'common.viewAll': 'View all', // Fallback text
-  'common.noLocation': 'No location', // Fallback text
-
-  // Dashboard keys
-  'dashboard.welcomeLeader': 'Welcome, Leader!', // Fallback text
-  'dashboard.welcomeAdmin': 'Welcome, Admin!', // Fallback text
-  'dashboard.yourGroup': 'Your Group', // Fallback text
-  'dashboard.overview': 'overview',
-  'dashboard.participants': 'participants',
-  'dashboard.upcomingActivities': 'Upcoming Activities', // Fallback text
-  'dashboard.groups': 'groups',
-  'dashboard.permissionSlips': 'Permission Slips', // Fallback text
-  'dashboard.quickActions': 'Quick Actions', // Fallback text
-  'dashboard.takeAttendance': 'Take Attendance', // Fallback text
-  'dashboard.createActivity': 'Create Activity', // Fallback text
-  'dashboard.carpools': 'Carpools', // Fallback text
-  'dashboard.adminActions': 'dashboard_admin_section',
-  'dashboard.errorLoading': 'error_loading_dashboard',
-  'dashboard.recentActivities': 'Recent Activities', // Fallback text
-  'dashboard.noRecentActivities': 'No recent activities', // Fallback text
-  'dashboard.noGroupsFound': 'No groups found', // Fallback text
-  'dashboard.registered': 'Registered', // Fallback text
-  'dashboard.districtOverview': 'District Overview', // Fallback text
-  'dashboard.districtStatistics': 'District Statistics', // Fallback text
-  'dashboard.totalParticipants': 'Total Participants', // Fallback text
-  'dashboard.totalGroups': 'Total Groups', // Fallback text
-  'dashboard.activeLeaders': 'Active Leaders', // Fallback text
-  'dashboard.totalActivities': 'Total Activities', // Fallback text
-  'dashboard.revenue': 'Revenue', // Fallback text
-  'dashboard.reports': 'Reports', // Fallback text
-  'dashboard.finance': 'finance',
-  'dashboard.manageGroups': 'Manage Groups', // Fallback text
-  'dashboard.settings': 'settings',
-  'dashboard.leaders': 'Leaders', // Fallback text
-  'dashboard.activityDetailComingSoon': 'Activity details coming soon', // Fallback text
-
-  // Participants keys
-  'participants.age': 'age',
-  'participants.group': 'group',
-  'participants.searchPlaceholder': 'Search participants', // Fallback text
-  'participants.allGroups': 'all_groups',
-  'participants.noParticipants': 'no_participants',
-  'participants.errorLoading': 'error_loading_manage_participants',
-  'participants.firstName': 'first_name',
-  'participants.lastName': 'last_name',
-  'participants.enterFirstName': 'Enter first name', // Fallback text
-  'participants.enterLastName': 'Enter last name', // Fallback text
-  'participants.birthdate': 'date_naissance',
-  'participants.email': 'email',
-  'participants.phone': 'Phone', // Fallback text (phone key likely exists)
-  'participants.enterEmail': 'Enter email', // Fallback text
-  'participants.enterPhone': 'Enter phone', // Fallback text
-  'participants.address': 'Address', // Fallback text (address key likely exists)
-  'participants.streetAddress': 'Street Address', // Fallback text
-  'participants.city': 'City', // Fallback text
-  'participants.province': 'Province', // Fallback text
-  'participants.postalCode': 'postal_code',
-  'participants.enterAddress': 'Enter address', // Fallback text
-  'participants.enterCity': 'Enter city', // Fallback text
-  'participants.enterProvince': 'Enter province', // Fallback text
-  'participants.enterPostalCode': 'Enter postal code', // Fallback text
-  'participants.basicInformation': 'Basic Information', // Fallback text
-  'participants.healthInformation': 'Health Information', // Fallback text
-  'participants.guardianContacts': 'Guardian Contacts', // Fallback text
-  'participants.badgeProgress': 'badge_progress', // Use existing key
-  'participants.financialStatus': 'Financial Status', // Fallback text
-  'participants.errorFirstNameRequired': 'First name is required', // Fallback text
-  'participants.errorLastNameRequired': 'Last name is required', // Fallback text
-  'participants.errorInvalidEmail': 'account_info_email_invalid',
-  'participants.errorInvalidBirthdate': 'Invalid birthdate', // Fallback text
-  'participants.savedSuccessfully': 'data_saved',
-  'participants.errorSaving': 'error_saving_participant',
-  'participants.noEditPermission': 'You don\'t have permission to edit', // Fallback text
-  'participants.yearsOld': 'years', // Use existing 'years' key
-
-  // Settings keys
-  'settings.profile': 'profile',
-  'settings.language': 'language',
-  'settings.languageChanged': 'Language changed', // Fallback text
-  'settings.restartRequired': 'App restart required', // Fallback text
-  'settings.confirmLogout': 'Confirm Logout', // Fallback text
-  'settings.confirmLogoutMessage': 'Are you sure you want to logout?', // Fallback text
-  'settings.logout': 'logout',
-  'settings.notifications': 'Notifications', // Fallback text
-  'settings.pushNotifications': 'Push Notifications', // Fallback text
-  'settings.pushNotificationsHelp': 'Receive notifications about activities', // Fallback text
-  'settings.appInfo': 'App Info', // Fallback text
-  'settings.version': 'Version', // Fallback text
-  'settings.build': 'Build', // Fallback text
-  'settings.madeWith': 'Made with', // Fallback text
-  'settings.forScouts': 'for Scouts', // Fallback text
-
-  // Navigation keys
-  'nav.dashboard': 'dashboard_title',
-  'nav.participants': 'participants',
-  'nav.activities': 'Activities',
-  'nav.finance': 'finance',
-  'nav.settings': 'settings',
-
-  // Activities keys
-  'activities.upcoming': 'Upcoming',
-  'activities.past': 'Past',
-  'activities.all': 'All',
-  'activities.today': 'Today',
-  'activities.participants': 'participants',
-  'activities.noActivities': 'No activities', // Fallback text
-
-  // Parent Dashboard keys
-  'parentDashboard.title': 'Parent Dashboard', // Fallback text
-  'parentDashboard.myChildren': 'My Children', // Fallback text
-  'parentDashboard.noChildren': 'no_participants',
-  'parentDashboard.age': 'age',
-  'parentDashboard.group': 'group',
-  'parentDashboard.upcomingActivities': 'Upcoming Activities', // Fallback text
-  'parentDashboard.noActivities': 'No upcoming activities', // Fallback text
-  'parentDashboard.carpoolAssignments': 'Carpool Assignments', // Fallback text
-  'parentDashboard.driver': 'Driver', // Fallback text
-  'parentDashboard.spots': 'Spots', // Fallback text
-  'parentDashboard.quickActions': 'Quick Actions', // Fallback text
-  'parentDashboard.viewFees': 'View Fees', // Fallback text
-  'parentDashboard.permissionSlips': 'Permission Slips', // Fallback text
-};
-
-/**
- * Convert nested dot notation key to flat key using mapping
- * Falls back to original key if no mapping exists
- *
- * @param {string} key - Translation key (nested or flat)
- * @returns {string} Flat key
- */
-const convertKey = (key) => {
-  // If key exists in mapping, use the mapped value
-  if (keyMapping[key]) {
-    return keyMapping[key];
-  }
-
-  // If key contains dots, try to convert to underscore notation
-  // e.g., 'auth.login' -> 'auth_login'
-  if (key.includes('.')) {
-    const underscoreKey = key.replace(/\./g, '_');
-    return underscoreKey;
-  }
-
-  // Return original key as fallback
-  return key;
-};
-
-/**
  * Translate a key
  * Mirrors spa/app.js translate()
- * Converts nested dot notation keys to flat keys using mapping
  *
- * @param {string} key - Translation key (nested or flat)
+ * All mobile screens now use flat translation keys that match lang.json format.
+ * This allows direct access to the 1960+ existing translation keys.
+ *
+ * @param {string} key - Translation key (flat format matching lang.json)
  * @param {object} options - Interpolation options
  * @returns {string} Translated text
  */
@@ -452,11 +267,8 @@ export const translate = (key, options = {}) => {
     return key;
   }
 
-  // Convert nested key to flat key
-  const flatKey = convertKey(key);
-
-  // Try to get translation
-  const translation = i18n.t(flatKey, { ...options, defaultValue: flatKey });
+  // Get translation, using key as default if translation doesn't exist
+  const translation = i18n.t(key, { ...options, defaultValue: key });
 
   return translation;
 };

--- a/mobile/src/navigation/MainTabNavigator.js
+++ b/mobile/src/navigation/MainTabNavigator.js
@@ -43,7 +43,7 @@ const MainTabNavigator = ({ userRole, userPermissions }) => {
         name="Dashboard"
         component={DashboardScreen}
         options={{
-          title: t('nav.dashboard'),
+          title: t('dashboard_title'),
           tabBarIcon: () => null, // Add icon when react-native-vector-icons is installed
         }}
       />
@@ -54,7 +54,7 @@ const MainTabNavigator = ({ userRole, userPermissions }) => {
           name="ParticipantsTab"
           component={DashboardScreen} // Placeholder - replace with ParticipantsScreen
           options={{
-            title: t('nav.participants'),
+            title: t('participants'),
             tabBarIcon: () => null,
           }}
         />
@@ -66,7 +66,7 @@ const MainTabNavigator = ({ userRole, userPermissions }) => {
           name="ActivitiesTab"
           component={DashboardScreen} // Placeholder - replace with ActivitiesScreen
           options={{
-            title: t('nav.activities'),
+            title: t('Activities'),
             tabBarIcon: () => null,
           }}
         />
@@ -78,7 +78,7 @@ const MainTabNavigator = ({ userRole, userPermissions }) => {
           name="FinanceTab"
           component={DashboardScreen} // Placeholder - replace with FinanceScreen
           options={{
-            title: t('nav.finance'),
+            title: t('finance'),
             tabBarIcon: () => null,
           }}
         />
@@ -89,7 +89,7 @@ const MainTabNavigator = ({ userRole, userPermissions }) => {
         name="SettingsTab"
         component={DashboardScreen} // Placeholder - replace with SettingsScreen
         options={{
-          title: t('nav.settings'),
+          title: t('settings'),
           tabBarIcon: () => null,
         }}
       />

--- a/mobile/src/screens/ActivitiesScreen.js
+++ b/mobile/src/screens/ActivitiesScreen.js
@@ -52,7 +52,7 @@ const ActivitiesScreen = ({ navigation }) => {
         setActivities(sorted);
       }
     } catch (err) {
-      setError(err.message || t('common.errorLoadingData'));
+      setError(err.message || t('error_loading_data'));
     } finally {
       setLoading(false);
     }
@@ -88,12 +88,12 @@ const ActivitiesScreen = ({ navigation }) => {
 
   const getActivityStatus = (activity) => {
     if (DateUtils.isToday(activity.date)) {
-      return { text: t('activities.today'), color: '#34C759' };
+      return { text: t('Today'), color: '#34C759' };
     }
     if (DateUtils.isFuture(activity.date)) {
-      return { text: t('activities.upcoming'), color: '#007AFF' };
+      return { text: t('Upcoming'), color: '#007AFF' };
     }
-    return { text: t('activities.past'), color: '#8E8E93' };
+    return { text: t('Past'), color: '#8E8E93' };
   };
 
   const renderActivity = ({ item }) => {
@@ -127,7 +127,7 @@ const ActivitiesScreen = ({ navigation }) => {
 
         {item.participantCount !== undefined && (
           <Text style={styles.activityDetail}>
-            👥 {item.participantCount} {t('activities.participants')}
+            👥 {item.participantCount} {t('participants')}
           </Text>
         )}
       </Card>
@@ -135,7 +135,7 @@ const ActivitiesScreen = ({ navigation }) => {
   };
 
   if (loading) {
-    return <LoadingSpinner message={t('common.loading')} />;
+    return <LoadingSpinner message={t('loading')} />;
   }
 
   if (error) {
@@ -149,9 +149,9 @@ const ActivitiesScreen = ({ navigation }) => {
         {Platform.OS === 'ios' ? (
           <SegmentedControlIOS
             values={[
-              t('activities.upcoming'),
-              t('activities.past'),
-              t('activities.all'),
+              t('Upcoming'),
+              t('Past'),
+              t('All'),
             ]}
             selectedIndex={
               filter === 'upcoming' ? 0 : filter === 'past' ? 1 : 2
@@ -177,7 +177,7 @@ const ActivitiesScreen = ({ navigation }) => {
                   filter === 'upcoming' && styles.androidTabTextActive,
                 ]}
               >
-                {t('activities.upcoming')}
+                {t('Upcoming')}
               </Text>
             </TouchableOpacity>
             <TouchableOpacity
@@ -190,7 +190,7 @@ const ActivitiesScreen = ({ navigation }) => {
                   filter === 'past' && styles.androidTabTextActive,
                 ]}
               >
-                {t('activities.past')}
+                {t('Past')}
               </Text>
             </TouchableOpacity>
             <TouchableOpacity
@@ -203,7 +203,7 @@ const ActivitiesScreen = ({ navigation }) => {
                   filter === 'all' && styles.androidTabTextActive,
                 ]}
               >
-                {t('activities.all')}
+                {t('All')}
               </Text>
             </TouchableOpacity>
           </View>
@@ -221,7 +221,7 @@ const ActivitiesScreen = ({ navigation }) => {
         }
         ListEmptyComponent={
           <View style={styles.emptyContainer}>
-            <Text style={styles.emptyText}>{t('activities.noActivities')}</Text>
+            <Text style={styles.emptyText}>{t('No activities')}</Text>
           </View>
         }
       />

--- a/mobile/src/screens/DashboardScreen.js
+++ b/mobile/src/screens/DashboardScreen.js
@@ -44,7 +44,7 @@ const DashboardScreen = () => {
     return (
       <View style={styles.centered}>
         <ActivityIndicator size="large" color="#007AFF" />
-        <Text style={styles.loadingText}>{t('common.loading')}</Text>
+        <Text style={styles.loadingText}>{t('loading')}</Text>
       </View>
     );
   }

--- a/mobile/src/screens/DistrictDashboardScreen.js
+++ b/mobile/src/screens/DistrictDashboardScreen.js
@@ -170,7 +170,7 @@ const DistrictDashboardScreen = () => {
       }
     } catch (err) {
       console.error('Error loading dashboard data:', err);
-      setError(t('dashboard.errorLoading'));
+      setError(t('error_loading_dashboard'));
     } finally {
       setLoading(false);
     }
@@ -190,9 +190,9 @@ const DistrictDashboardScreen = () => {
    */
   const handleViewReports = () => {
     Alert.alert(
-      t('dashboard.reports'),
-      t('common.comingSoon'),
-      [{ text: t('common.ok') }]
+      t('Reports'),
+      t('Coming soon'),
+      [{ text: t('OK') }]
     );
     // TODO: Navigate to reports screen
   };
@@ -202,9 +202,9 @@ const DistrictDashboardScreen = () => {
    */
   const handleViewFinance = () => {
     Alert.alert(
-      t('dashboard.finance'),
-      t('common.comingSoon'),
-      [{ text: t('common.ok') }]
+      t('finance'),
+      t('Coming soon'),
+      [{ text: t('OK') }]
     );
     // TODO: Navigate to finance screen
   };
@@ -214,9 +214,9 @@ const DistrictDashboardScreen = () => {
    */
   const handleManageGroups = () => {
     Alert.alert(
-      t('dashboard.manageGroups'),
-      t('common.comingSoon'),
-      [{ text: t('common.ok') }]
+      t('Manage Groups'),
+      t('Coming soon'),
+      [{ text: t('OK') }]
     );
     // TODO: Navigate to groups screen
   };
@@ -248,8 +248,8 @@ const DistrictDashboardScreen = () => {
   const handleViewActivity = (activity) => {
     Alert.alert(
       activity.name,
-      t('dashboard.activityDetailComingSoon'),
-      [{ text: t('common.ok') }]
+      t('Activity details coming soon'),
+      [{ text: t('OK') }]
     );
     // TODO: Navigate to activity detail
   };
@@ -261,7 +261,7 @@ const DistrictDashboardScreen = () => {
     return (
       <View style={styles.centerContainer}>
         <LoadingSpinner />
-        <Text style={styles.loadingText}>{t('common.loading')}</Text>
+        <Text style={styles.loadingText}>{t('loading')}</Text>
       </View>
     );
   }
@@ -283,7 +283,7 @@ const DistrictDashboardScreen = () => {
       {isOffline && (
         <View style={styles.offlineIndicator}>
           <Text style={styles.offlineText}>
-            📡 {t('common.offline')} - {t('common.viewingCachedData')}
+            📡 {t('Offline')} - {t('Viewing cached data')}
           </Text>
         </View>
       )}
@@ -297,19 +297,19 @@ const DistrictDashboardScreen = () => {
         {/* Header */}
         <View style={styles.header}>
           <Text style={styles.greeting}>
-            {t('dashboard.welcomeAdmin')}
+            {t('Welcome, Admin!')}
           </Text>
           <Text style={styles.subtitle}>
-            {t('dashboard.districtOverview')}
+            {t('District Overview')}
           </Text>
         </View>
 
         {/* Statistics Cards - District-Wide */}
-        <DashboardSection title={t('dashboard.districtStatistics')}>
+        <DashboardSection title={t('District Statistics')}>
           <View style={styles.statsGrid}>
             <View style={styles.statCol}>
               <StatCard
-                label={t('dashboard.totalParticipants')}
+                label={t('Total Participants')}
                 value={statistics.totalParticipants}
                 icon="👥"
                 color="#007AFF"
@@ -318,7 +318,7 @@ const DistrictDashboardScreen = () => {
             </View>
             <View style={styles.statCol}>
               <StatCard
-                label={t('dashboard.totalGroups')}
+                label={t('Total Groups')}
                 value={statistics.totalGroups}
                 icon="⚜️"
                 color="#34C759"
@@ -330,7 +330,7 @@ const DistrictDashboardScreen = () => {
           <View style={styles.statsGrid}>
             <View style={styles.statCol}>
               <StatCard
-                label={t('dashboard.upcomingActivities')}
+                label={t('Upcoming Activities')}
                 value={statistics.upcomingActivities}
                 icon="📅"
                 color="#FF9500"
@@ -339,7 +339,7 @@ const DistrictDashboardScreen = () => {
             </View>
             <View style={styles.statCol}>
               <StatCard
-                label={t('dashboard.activeLeaders')}
+                label={t('Active Leaders')}
                 value={statistics.activeLeaders}
                 icon="🎖️"
                 color="#5856D6"
@@ -350,7 +350,7 @@ const DistrictDashboardScreen = () => {
           <View style={styles.statsGrid}>
             <View style={styles.statCol}>
               <StatCard
-                label={t('dashboard.totalActivities')}
+                label={t('Total Activities')}
                 value={statistics.totalActivities}
                 icon="📊"
                 color="#FF3B30"
@@ -359,7 +359,7 @@ const DistrictDashboardScreen = () => {
             </View>
             <View style={styles.statCol}>
               <StatCard
-                label={t('dashboard.revenue')}
+                label={t('Revenue')}
                 value={NumberUtils.formatCurrency(statistics.totalRevenue)}
                 icon="💰"
                 color="#AF52DE"
@@ -370,12 +370,12 @@ const DistrictDashboardScreen = () => {
         </DashboardSection>
 
         {/* Admin Quick Actions */}
-        <DashboardSection title={t('dashboard.adminActions')}>
+        <DashboardSection title={t('dashboard_admin_section')}>
           <View style={styles.actionsGrid}>
             <View style={styles.actionCol}>
               <QuickActionButton
                 icon="📊"
-                label={t('dashboard.reports')}
+                label={t('Reports')}
                 onPress={handleViewReports}
                 color="#007AFF"
               />
@@ -383,7 +383,7 @@ const DistrictDashboardScreen = () => {
             <View style={styles.actionCol}>
               <QuickActionButton
                 icon="💰"
-                label={t('dashboard.finance')}
+                label={t('finance')}
                 onPress={handleViewFinance}
                 color="#34C759"
               />
@@ -394,7 +394,7 @@ const DistrictDashboardScreen = () => {
             <View style={styles.actionCol}>
               <QuickActionButton
                 icon="⚜️"
-                label={t('dashboard.manageGroups')}
+                label={t('Manage Groups')}
                 onPress={handleManageGroups}
                 color="#FF9500"
               />
@@ -402,7 +402,7 @@ const DistrictDashboardScreen = () => {
             <View style={styles.actionCol}>
               <QuickActionButton
                 icon="⚙️"
-                label={t('dashboard.settings')}
+                label={t('settings')}
                 onPress={handleSettings}
                 color="#5856D6"
               />
@@ -412,8 +412,8 @@ const DistrictDashboardScreen = () => {
 
         {/* Groups Overview */}
         <DashboardSection
-          title={t('dashboard.groups')}
-          actionLabel={t('common.viewAll')}
+          title={t('groups')}
+          actionLabel={t('View all')}
           onActionPress={handleManageGroups}
         >
           {groups.length > 0 ? (
@@ -429,17 +429,17 @@ const DistrictDashboardScreen = () => {
                 </View>
                 <Text style={styles.groupDetail}>
                   👥 {group.participantCount || 0}{' '}
-                  {t('dashboard.participants')}
+                  {t('participants')}
                 </Text>
                 <Text style={styles.groupDetail}>
-                  🎖️ {group.leaderCount || 0} {t('dashboard.leaders')}
+                  🎖️ {group.leaderCount || 0} {t('Leaders')}
                 </Text>
               </Card>
             ))
           ) : (
             <Card style={styles.emptyCard}>
               <Text style={styles.emptyText}>
-                {t('dashboard.noGroupsFound')}
+                {t('No groups found')}
               </Text>
             </Card>
           )}
@@ -447,8 +447,8 @@ const DistrictDashboardScreen = () => {
 
         {/* Recent Activities */}
         <DashboardSection
-          title={t('dashboard.recentActivities')}
-          actionLabel={t('common.viewAll')}
+          title={t('Recent Activities')}
+          actionLabel={t('View all')}
           onActionPress={handleViewActivities}
         >
           {recentActivities.length > 0 ? (
@@ -470,18 +470,18 @@ const DistrictDashboardScreen = () => {
                   </Text>
                 )}
                 <Text style={styles.activityLocation}>
-                  📍 {activity.location || t('common.noLocation')}
+                  📍 {activity.location || t('No location')}
                 </Text>
                 <Text style={styles.activityParticipants}>
                   👥 {activity.participantCount || 0}{' '}
-                  {t('dashboard.registered')}
+                  {t('Registered')}
                 </Text>
               </Card>
             ))
           ) : (
             <Card style={styles.emptyCard}>
               <Text style={styles.emptyText}>
-                {t('dashboard.noRecentActivities')}
+                {t('No recent activities')}
               </Text>
             </Card>
           )}

--- a/mobile/src/screens/LeaderDashboardScreen.js
+++ b/mobile/src/screens/LeaderDashboardScreen.js
@@ -173,7 +173,7 @@ const LeaderDashboardScreen = () => {
       }
     } catch (err) {
       console.error('Error loading dashboard data:', err);
-      setError(t('dashboard.errorLoading'));
+      setError(t('error_loading_dashboard'));
     } finally {
       setLoading(false);
     }
@@ -193,9 +193,9 @@ const LeaderDashboardScreen = () => {
    */
   const handleTakeAttendance = () => {
     Alert.alert(
-      t('dashboard.takeAttendance'),
+      t('Take Attendance'),
       t('dashboard.selectActivity'),
-      [{ text: t('common.ok') }]
+      [{ text: t('OK') }]
     );
     // TODO: Navigate to attendance screen
   };
@@ -205,9 +205,9 @@ const LeaderDashboardScreen = () => {
    */
   const handleCreateActivity = () => {
     Alert.alert(
-      t('dashboard.createActivity'),
-      t('common.comingSoon'),
-      [{ text: t('common.ok') }]
+      t('Create Activity'),
+      t('Coming soon'),
+      [{ text: t('OK') }]
     );
     // TODO: Navigate to create activity screen
   };
@@ -217,9 +217,9 @@ const LeaderDashboardScreen = () => {
    */
   const handleViewCarpools = () => {
     Alert.alert(
-      t('dashboard.carpools'),
-      t('common.comingSoon'),
-      [{ text: t('common.ok') }]
+      t('Carpools'),
+      t('Coming soon'),
+      [{ text: t('OK') }]
     );
     // TODO: Navigate to carpools screen
   };
@@ -244,8 +244,8 @@ const LeaderDashboardScreen = () => {
   const handleViewActivity = (activity) => {
     Alert.alert(
       activity.name,
-      t('dashboard.activityDetailComingSoon'),
-      [{ text: t('common.ok') }]
+      t('Activity details coming soon'),
+      [{ text: t('OK') }]
     );
     // TODO: Navigate to activity detail
     // navigation.navigate('ActivityDetail', { activityId: activity.id });
@@ -258,7 +258,7 @@ const LeaderDashboardScreen = () => {
     return (
       <View style={styles.centerContainer}>
         <LoadingSpinner />
-        <Text style={styles.loadingText}>{t('common.loading')}</Text>
+        <Text style={styles.loadingText}>{t('loading')}</Text>
       </View>
     );
   }
@@ -280,7 +280,7 @@ const LeaderDashboardScreen = () => {
       {isOffline && (
         <View style={styles.offlineIndicator}>
           <Text style={styles.offlineText}>
-            📡 {t('common.offline')} - {t('common.viewingCachedData')}
+            📡 {t('Offline')} - {t('Viewing cached data')}
           </Text>
         </View>
       )}
@@ -294,21 +294,21 @@ const LeaderDashboardScreen = () => {
         {/* Header */}
         <View style={styles.header}>
           <Text style={styles.greeting}>
-            {t('dashboard.welcomeLeader')}
+            {t('Welcome, Leader!')}
           </Text>
           {userGroup && (
             <Text style={styles.groupName}>
-              {userGroup.name || t('dashboard.yourGroup')}
+              {userGroup.name || t('Your Group')}
             </Text>
           )}
         </View>
 
         {/* Statistics Cards */}
-        <DashboardSection title={t('dashboard.overview')}>
+        <DashboardSection title={t('overview')}>
           <View style={styles.statsGrid}>
             <View style={styles.statCol}>
               <StatCard
-                label={t('dashboard.participants')}
+                label={t('participants')}
                 value={statistics.totalParticipants}
                 icon="👥"
                 color="#007AFF"
@@ -317,7 +317,7 @@ const LeaderDashboardScreen = () => {
             </View>
             <View style={styles.statCol}>
               <StatCard
-                label={t('dashboard.upcomingActivities')}
+                label={t('Upcoming Activities')}
                 value={statistics.upcomingActivities}
                 icon="📅"
                 color="#34C759"
@@ -329,7 +329,7 @@ const LeaderDashboardScreen = () => {
           <View style={styles.statsGrid}>
             <View style={styles.statCol}>
               <StatCard
-                label={t('dashboard.groups')}
+                label={t('groups')}
                 value={statistics.activeGroups}
                 icon="⚜️"
                 color="#FF9500"
@@ -337,7 +337,7 @@ const LeaderDashboardScreen = () => {
             </View>
             <View style={styles.statCol}>
               <StatCard
-                label={t('dashboard.permissionSlips')}
+                label={t('Permission Slips')}
                 value={statistics.pendingPermissionSlips}
                 icon="📝"
                 color="#FF3B30"
@@ -347,12 +347,12 @@ const LeaderDashboardScreen = () => {
         </DashboardSection>
 
         {/* Quick Actions */}
-        <DashboardSection title={t('dashboard.quickActions')}>
+        <DashboardSection title={t('Quick Actions')}>
           <View style={styles.actionsGrid}>
             <View style={styles.actionCol}>
               <QuickActionButton
                 icon="✓"
-                label={t('dashboard.takeAttendance')}
+                label={t('Take Attendance')}
                 onPress={handleTakeAttendance}
                 color="#34C759"
               />
@@ -360,7 +360,7 @@ const LeaderDashboardScreen = () => {
             <View style={styles.actionCol}>
               <QuickActionButton
                 icon="+"
-                label={t('dashboard.createActivity')}
+                label={t('Create Activity')}
                 onPress={handleCreateActivity}
                 color="#007AFF"
               />
@@ -371,7 +371,7 @@ const LeaderDashboardScreen = () => {
             <View style={styles.actionCol}>
               <QuickActionButton
                 icon="🚗"
-                label={t('dashboard.carpools')}
+                label={t('Carpools')}
                 onPress={handleViewCarpools}
                 color="#FF9500"
               />
@@ -379,7 +379,7 @@ const LeaderDashboardScreen = () => {
             <View style={styles.actionCol}>
               <QuickActionButton
                 icon="👥"
-                label={t('dashboard.participants')}
+                label={t('participants')}
                 onPress={handleViewParticipants}
                 color="#5856D6"
               />
@@ -389,8 +389,8 @@ const LeaderDashboardScreen = () => {
 
         {/* Upcoming Activities */}
         <DashboardSection
-          title={t('dashboard.upcomingActivities')}
-          actionLabel={t('common.viewAll')}
+          title={t('Upcoming Activities')}
+          actionLabel={t('View all')}
           onActionPress={handleViewActivities}
         >
           {upcomingActivities.length > 0 ? (
@@ -407,11 +407,11 @@ const LeaderDashboardScreen = () => {
                   </Text>
                 </View>
                 <Text style={styles.activityLocation}>
-                  📍 {activity.location || t('common.noLocation')}
+                  📍 {activity.location || t('No location')}
                 </Text>
                 <Text style={styles.activityParticipants}>
                   👥 {activity.participantCount || 0}{' '}
-                  {t('dashboard.registered')}
+                  {t('Registered')}
                 </Text>
               </Card>
             ))

--- a/mobile/src/screens/LoginScreen.js
+++ b/mobile/src/screens/LoginScreen.js
@@ -73,10 +73,10 @@ const LoginScreen = ({ navigation, onLogin }) => {
           }
         }
       } else {
-        setError(response.message || t('auth.loginFailed'));
+        setError(response.message || t('invalid_email_or_password'));
       }
     } catch (err) {
-      setError(err.message || t('auth.loginFailed'));
+      setError(err.message || t('invalid_email_or_password'));
     } finally {
       setLoading(false);
     }
@@ -106,10 +106,10 @@ const LoginScreen = ({ navigation, onLogin }) => {
           await onLogin();
         }
       } else {
-        setError(response.message || t('auth.invalidCode'));
+        setError(response.message || t('Invalid verification code'));
       }
     } catch (err) {
-      setError(err.message || t('auth.verificationFailed'));
+      setError(err.message || t('Verification failed'));
     } finally {
       setLoading(false);
     }
@@ -146,14 +146,14 @@ const LoginScreen = ({ navigation, onLogin }) => {
         behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
       >
         <View style={styles.form}>
-          <Text style={styles.title}>{t('auth.twoFactorTitle')}</Text>
-          <Text style={styles.subtitle}>{t('auth.enterCode')}</Text>
+          <Text style={styles.title}>{t('two_factor_email_heading')}</Text>
+          <Text style={styles.subtitle}>{t('two_factor_message')}</Text>
 
           {error ? <Text style={styles.error}>{error}</Text> : null}
 
           <TextInput
             style={styles.input}
-            placeholder={t('auth.verificationCode')}
+            placeholder={t('verification_code_sent')}
             value={twoFactorCode}
             onChangeText={setTwoFactorCode}
             keyboardType="number-pad"
@@ -168,7 +168,7 @@ const LoginScreen = ({ navigation, onLogin }) => {
             <View style={[styles.checkboxBox, trustDevice && styles.checkboxChecked]}>
               {trustDevice && <Text style={styles.checkboxCheck}>✓</Text>}
             </View>
-            <Text style={styles.checkboxLabel}>{t('auth.trustDevice')}</Text>
+            <Text style={styles.checkboxLabel}>{t('Trust this device')}</Text>
           </TouchableOpacity>
 
           <TouchableOpacity
@@ -179,12 +179,12 @@ const LoginScreen = ({ navigation, onLogin }) => {
             {loading ? (
               <ActivityIndicator color="#fff" />
             ) : (
-              <Text style={styles.buttonText}>{t('auth.verify')}</Text>
+              <Text style={styles.buttonText}>{t('verify')}</Text>
             )}
           </TouchableOpacity>
 
           <TouchableOpacity onPress={() => setRequires2FA(false)}>
-            <Text style={styles.link}>{t('auth.backToLogin')}</Text>
+            <Text style={styles.link}>{t('back_to_login')}</Text>
           </TouchableOpacity>
         </View>
       </KeyboardAvoidingView>
@@ -203,13 +203,13 @@ const LoginScreen = ({ navigation, onLogin }) => {
         {console.log('🟠 [LoginScreen] Inside KeyboardAvoidingView')}
         <View style={styles.form}>
           {console.log('🟠 [LoginScreen] Inside form View')}
-          <Text style={styles.title}>{t('auth.loginTitle')}</Text>
+          <Text style={styles.title}>{t('login')}</Text>
 
         {error ? <Text style={styles.error}>{error}</Text> : null}
 
         <TextInput
           style={styles.input}
-          placeholder={t('auth.email')}
+          placeholder={t('email')}
           value={email}
           onChangeText={setEmail}
           autoCapitalize="none"
@@ -219,7 +219,7 @@ const LoginScreen = ({ navigation, onLogin }) => {
 
         <TextInput
           style={styles.input}
-          placeholder={t('auth.password')}
+          placeholder={t('password')}
           value={password}
           onChangeText={setPassword}
           secureTextEntry
@@ -234,16 +234,16 @@ const LoginScreen = ({ navigation, onLogin }) => {
           {loading ? (
             <ActivityIndicator color="#fff" />
           ) : (
-            <Text style={styles.buttonText}>{t('auth.login')}</Text>
+            <Text style={styles.buttonText}>{t('login')}</Text>
           )}
         </TouchableOpacity>
 
         <TouchableOpacity onPress={() => navigation.navigate('Register')}>
-          <Text style={styles.link}>{t('auth.createAccount')}</Text>
+          <Text style={styles.link}>{t('create_account')}</Text>
         </TouchableOpacity>
 
         <TouchableOpacity onPress={() => navigation.navigate('ResetPassword')}>
-          <Text style={styles.link}>{t('auth.forgotPassword')}</Text>
+          <Text style={styles.link}>{t('forgot_password')}</Text>
         </TouchableOpacity>
       </View>
     </KeyboardAvoidingView>

--- a/mobile/src/screens/ParentDashboardScreen.js
+++ b/mobile/src/screens/ParentDashboardScreen.js
@@ -75,7 +75,7 @@ const ParentDashboardScreen = ({ navigation }) => {
         setCarpoolAssignments(carpoolResponse.data);
       }
     } catch (err) {
-      setError(err.message || t('common.errorLoadingData'));
+      setError(err.message || t('error_loading_data'));
     } finally {
       setLoading(false);
     }
@@ -88,7 +88,7 @@ const ParentDashboardScreen = ({ navigation }) => {
   };
 
   if (loading) {
-    return <LoadingSpinner message={t('common.loading')} />;
+    return <LoadingSpinner message={t('loading')} />;
   }
 
   if (error) {
@@ -101,15 +101,15 @@ const ParentDashboardScreen = ({ navigation }) => {
       refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
     >
       <View style={styles.header}>
-        <Text style={styles.headerTitle}>{t('parentDashboard.title')}</Text>
+        <Text style={styles.headerTitle}>{t('Parent Dashboard')}</Text>
       </View>
 
       {/* My Children Section */}
       <View style={styles.section}>
-        <Text style={styles.sectionTitle}>{t('parentDashboard.myChildren')}</Text>
+        <Text style={styles.sectionTitle}>{t('My Children')}</Text>
         {children.length === 0 ? (
           <Card>
-            <Text style={styles.emptyText}>{t('parentDashboard.noChildren')}</Text>
+            <Text style={styles.emptyText}>{t('no_participants')}</Text>
           </Card>
         ) : (
           children.map((child) => (
@@ -121,12 +121,12 @@ const ParentDashboardScreen = ({ navigation }) => {
                 {child.firstName} {child.lastName}
               </Text>
               <Text style={styles.childDetail}>
-                {t('parentDashboard.age')}: {DateUtils.calculateAge(child.birthdate)}{' '}
-                {t('common.years')}
+                {t('age')}: {DateUtils.calculateAge(child.birthdate)}{' '}
+                {t('years')}
               </Text>
               {child.group && (
                 <Text style={styles.childDetail}>
-                  {t('parentDashboard.group')}: {child.group}
+                  {t('group')}: {child.group}
                 </Text>
               )}
             </Card>
@@ -136,10 +136,10 @@ const ParentDashboardScreen = ({ navigation }) => {
 
       {/* Upcoming Activities Section */}
       <View style={styles.section}>
-        <Text style={styles.sectionTitle}>{t('parentDashboard.upcomingActivities')}</Text>
+        <Text style={styles.sectionTitle}>{t('Upcoming Activities')}</Text>
         {upcomingActivities.length === 0 ? (
           <Card>
-            <Text style={styles.emptyText}>{t('parentDashboard.noActivities')}</Text>
+            <Text style={styles.emptyText}>{t('No upcoming activities')}</Text>
           </Card>
         ) : (
           upcomingActivities.map((activity) => (
@@ -162,15 +162,15 @@ const ParentDashboardScreen = ({ navigation }) => {
       {/* Carpool Assignments Section */}
       {carpoolAssignments.length > 0 && (
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>{t('parentDashboard.carpoolAssignments')}</Text>
+          <Text style={styles.sectionTitle}>{t('Carpool Assignments')}</Text>
           {carpoolAssignments.map((assignment, index) => (
             <Card key={index}>
               <Text style={styles.carpoolActivity}>{assignment.activityName}</Text>
               <Text style={styles.carpoolDetail}>
-                🚗 {t('parentDashboard.driver')}: {assignment.driverName}
+                🚗 {t('Driver')}: {assignment.driverName}
               </Text>
               <Text style={styles.carpoolDetail}>
-                👥 {t('parentDashboard.spots')}: {assignment.occupiedSpots}/
+                👥 {t('Spots')}: {assignment.occupiedSpots}/
                 {assignment.totalSpots}
               </Text>
             </Card>
@@ -180,19 +180,19 @@ const ParentDashboardScreen = ({ navigation }) => {
 
       {/* Quick Actions */}
       <View style={styles.section}>
-        <Text style={styles.sectionTitle}>{t('parentDashboard.quickActions')}</Text>
+        <Text style={styles.sectionTitle}>{t('Quick Actions')}</Text>
         <TouchableOpacity
           style={styles.actionButton}
           onPress={() => navigation.navigate('FinanceTab')}
         >
-          <Text style={styles.actionButtonText}>💰 {t('parentDashboard.viewFees')}</Text>
+          <Text style={styles.actionButtonText}>💰 {t('View Fees')}</Text>
         </TouchableOpacity>
         <TouchableOpacity
           style={styles.actionButton}
           onPress={() => navigation.navigate('PermissionSlips')}
         >
           <Text style={styles.actionButtonText}>
-            📄 {t('parentDashboard.permissionSlips')}
+            📄 {t('Permission Slips')}
           </Text>
         </TouchableOpacity>
       </View>

--- a/mobile/src/screens/ParticipantDetailScreen.js
+++ b/mobile/src/screens/ParticipantDetailScreen.js
@@ -133,11 +133,11 @@ const ParticipantDetailScreen = () => {
           setIsOffline(true);
         }
       } else {
-        setError(response.message || t('common.error'));
+        setError(response.message || t('error'));
       }
     } catch (err) {
       console.error('Error loading participant:', err);
-      setError(t('participants.errorLoading'));
+      setError(t('error_loading_manage_participants'));
     } finally {
       setIsLoading(false);
     }
@@ -178,20 +178,20 @@ const ParticipantDetailScreen = () => {
 
     // Required fields
     if (!formData.firstName.trim()) {
-      errors.push(t('participants.errorFirstNameRequired'));
+      errors.push(t('First name is required'));
     }
     if (!formData.lastName.trim()) {
-      errors.push(t('participants.errorLastNameRequired'));
+      errors.push(t('Last name is required'));
     }
 
     // Email validation (if provided)
     if (formData.email && !SecurityUtils.isValidEmail(formData.email)) {
-      errors.push(t('participants.errorInvalidEmail'));
+      errors.push(t('account_info_email_invalid'));
     }
 
     // Birthdate validation (if provided)
     if (formData.birthdate && !DateUtils.isValidDate(formData.birthdate)) {
-      errors.push(t('participants.errorInvalidBirthdate'));
+      errors.push(t('Invalid birthdate'));
     }
 
     return errors;
@@ -204,7 +204,7 @@ const ParticipantDetailScreen = () => {
     // Validate form
     const errors = validateForm();
     if (errors.length > 0) {
-      Alert.alert(t('common.error'), errors.join('\n'));
+      Alert.alert(t('error'), errors.join('\n'));
       return;
     }
 
@@ -229,23 +229,23 @@ const ParticipantDetailScreen = () => {
         // Show success message
         if (response.queued) {
           Alert.alert(
-            t('common.queued'),
-            t('common.willSyncWhenOnline'),
-            [{ text: t('common.ok') }]
+            t('Queued'),
+            t('Will sync when online'),
+            [{ text: t('OK') }]
           );
         } else {
           Alert.alert(
-            t('common.success'),
-            t('participants.savedSuccessfully'),
-            [{ text: t('common.ok') }]
+            t('success'),
+            t('data_saved'),
+            [{ text: t('OK') }]
           );
         }
       } else {
-        setError(response.message || t('participants.errorSaving'));
+        setError(response.message || t('error_saving_participant'));
       }
     } catch (err) {
       console.error('Error saving participant:', err);
-      setError(t('participants.errorSaving'));
+      setError(t('error_saving_participant'));
     } finally {
       setIsSaving(false);
     }
@@ -266,8 +266,8 @@ const ParticipantDetailScreen = () => {
   const handleEdit = () => {
     if (!canEdit) {
       Alert.alert(
-        t('common.permissionDenied'),
-        t('participants.noEditPermission')
+        t('Permission denied'),
+        t('You don'\''t have permission to edit')
       );
       return;
     }
@@ -289,7 +289,7 @@ const ParticipantDetailScreen = () => {
     return (
       <View style={styles.centerContainer}>
         <LoadingSpinner />
-        <Text style={styles.loadingText}>{t('common.loading')}</Text>
+        <Text style={styles.loadingText}>{t('loading')}</Text>
       </View>
     );
   }
@@ -302,7 +302,7 @@ const ParticipantDetailScreen = () => {
       <View style={styles.centerContainer}>
         <ErrorMessage message={error} />
         <TouchableOpacity style={styles.retryButton} onPress={loadParticipant}>
-          <Text style={styles.retryButtonText}>{t('common.retry')}</Text>
+          <Text style={styles.retryButtonText}>{t('retry')}</Text>
         </TouchableOpacity>
       </View>
     );
@@ -334,7 +334,7 @@ const ParticipantDetailScreen = () => {
           />
         ) : (
           <Text style={styles.fieldValue}>
-            {formData[field] || t('common.notProvided')}
+            {formData[field] || t('Not provided')}
           </Text>
         )}
       </View>
@@ -351,7 +351,7 @@ const ParticipantDetailScreen = () => {
         {isOffline && (
           <View style={styles.offlineIndicator}>
             <Text style={styles.offlineText}>
-              {t('common.offline')} - {t('common.viewingCachedData')}
+              {t('Offline')} - {t('Viewing cached data')}
             </Text>
           </View>
         )}
@@ -374,7 +374,7 @@ const ParticipantDetailScreen = () => {
               </Text>
               {getAge() && (
                 <Text style={styles.ageText}>
-                  {getAge()} {t('participants.yearsOld')}
+                  {getAge()} {t('years')}
                 </Text>
               )}
             </View>
@@ -384,75 +384,75 @@ const ParticipantDetailScreen = () => {
         {/* Basic Information Card */}
         <Card style={styles.card}>
           <Text style={styles.sectionTitle}>
-            {t('participants.basicInformation')}
+            {t('Basic Information')}
           </Text>
 
-          {renderField(t('participants.firstName'), 'firstName', {
-            placeholder: t('participants.enterFirstName'),
+          {renderField(t('first_name'), 'firstName', {
+            placeholder: t('Enter first name'),
           })}
 
-          {renderField(t('participants.lastName'), 'lastName', {
-            placeholder: t('participants.enterLastName'),
+          {renderField(t('last_name'), 'lastName', {
+            placeholder: t('Enter last name'),
           })}
 
-          {renderField(t('participants.birthdate'), 'birthdate', {
+          {renderField(t('date_naissance'), 'birthdate', {
             placeholder: 'YYYY-MM-DD',
           })}
 
-          {renderField(t('participants.email'), 'email', {
-            placeholder: t('participants.enterEmail'),
+          {renderField(t('email'), 'email', {
+            placeholder: t('Enter email'),
             keyboardType: 'email-address',
           })}
 
-          {renderField(t('participants.phone'), 'phone', {
-            placeholder: t('participants.enterPhone'),
+          {renderField(t('Phone'), 'phone', {
+            placeholder: t('Enter phone'),
             keyboardType: 'phone-pad',
           })}
         </Card>
 
         {/* Address Card */}
         <Card style={styles.card}>
-          <Text style={styles.sectionTitle}>{t('participants.address')}</Text>
+          <Text style={styles.sectionTitle}>{t('Address')}</Text>
 
-          {renderField(t('participants.streetAddress'), 'address', {
-            placeholder: t('participants.enterAddress'),
+          {renderField(t('Street Address'), 'address', {
+            placeholder: t('Enter address'),
           })}
 
-          {renderField(t('participants.city'), 'city', {
-            placeholder: t('participants.enterCity'),
+          {renderField(t('City'), 'city', {
+            placeholder: t('Enter city'),
           })}
 
-          {renderField(t('participants.province'), 'province', {
-            placeholder: t('participants.enterProvince'),
+          {renderField(t('Province'), 'province', {
+            placeholder: t('Enter province'),
           })}
 
-          {renderField(t('participants.postalCode'), 'postalCode', {
-            placeholder: t('participants.enterPostalCode'),
+          {renderField(t('postal_code'), 'postalCode', {
+            placeholder: t('Enter postal code'),
           })}
         </Card>
 
         {/* Placeholder cards for future features */}
         <Card style={styles.placeholderCard}>
           <Text style={styles.placeholderText}>
-            {t('participants.healthInformation')} - {t('common.comingSoon')}
+            {t('Health Information')} - {t('Coming soon')}
           </Text>
         </Card>
 
         <Card style={styles.placeholderCard}>
           <Text style={styles.placeholderText}>
-            {t('participants.guardianContacts')} - {t('common.comingSoon')}
+            {t('Guardian Contacts')} - {t('Coming soon')}
           </Text>
         </Card>
 
         <Card style={styles.placeholderCard}>
           <Text style={styles.placeholderText}>
-            {t('participants.badgeProgress')} - {t('common.comingSoon')}
+            {t('badge_progress')} - {t('Coming soon')}
           </Text>
         </Card>
 
         <Card style={styles.placeholderCard}>
           <Text style={styles.placeholderText}>
-            {t('participants.financialStatus')} - {t('common.comingSoon')}
+            {t('Financial Status')} - {t('Coming soon')}
           </Text>
         </Card>
 
@@ -469,7 +469,7 @@ const ParticipantDetailScreen = () => {
               onPress={handleCancel}
               disabled={isSaving}
             >
-              <Text style={styles.buttonText}>{t('common.cancel')}</Text>
+              <Text style={styles.buttonText}>{t('cancel')}</Text>
             </TouchableOpacity>
             <TouchableOpacity
               style={[styles.button, styles.saveButton, isSaving && styles.disabledButton]}
@@ -480,7 +480,7 @@ const ParticipantDetailScreen = () => {
                 <ActivityIndicator color="#fff" />
               ) : (
                 <Text style={[styles.buttonText, styles.saveButtonText]}>
-                  {t('common.save')}
+                  {t('save')}
                 </Text>
               )}
             </TouchableOpacity>
@@ -492,7 +492,7 @@ const ParticipantDetailScreen = () => {
               onPress={handleEdit}
             >
               <Text style={[styles.buttonText, styles.editButtonText]}>
-                {t('common.edit')}
+                {t('edit')}
               </Text>
             </TouchableOpacity>
           )

--- a/mobile/src/screens/ParticipantsScreen.js
+++ b/mobile/src/screens/ParticipantsScreen.js
@@ -58,7 +58,7 @@ const ParticipantsScreen = ({ navigation }) => {
         setGroups(groupsResponse.data);
       }
     } catch (err) {
-      setError(err.message || t('common.errorLoadingData'));
+      setError(err.message || t('error_loading_data'));
     } finally {
       setLoading(false);
     }
@@ -106,12 +106,12 @@ const ParticipantsScreen = ({ navigation }) => {
             {item.firstName} {item.lastName}
           </Text>
           <Text style={styles.participantDetail}>
-            {t('participants.age')}: {DateUtils.calculateAge(item.birthdate)}{' '}
-            {t('common.years')}
+            {t('age')}: {DateUtils.calculateAge(item.birthdate)}{' '}
+            {t('years')}
           </Text>
           {item.group && (
             <Text style={styles.participantDetail}>
-              {t('participants.group')}: {item.group}
+              {t('group')}: {item.group}
             </Text>
           )}
         </View>
@@ -121,7 +121,7 @@ const ParticipantsScreen = ({ navigation }) => {
   );
 
   if (loading) {
-    return <LoadingSpinner message={t('common.loading')} />;
+    return <LoadingSpinner message={t('loading')} />;
   }
 
   if (error) {
@@ -134,7 +134,7 @@ const ParticipantsScreen = ({ navigation }) => {
       <View style={styles.searchContainer}>
         <TextInput
           style={styles.searchInput}
-          placeholder={t('participants.searchPlaceholder')}
+          placeholder={t('Search participants')}
           value={searchQuery}
           onChangeText={setSearchQuery}
           autoCapitalize="none"
@@ -154,7 +154,7 @@ const ParticipantsScreen = ({ navigation }) => {
               selectedGroup === 'all' && styles.filterButtonTextActive,
             ]}
           >
-            {t('participants.allGroups')}
+            {t('all_groups')}
           </Text>
         </TouchableOpacity>
         {groups.map((group) => (
@@ -187,7 +187,7 @@ const ParticipantsScreen = ({ navigation }) => {
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
         ListEmptyComponent={
           <View style={styles.emptyContainer}>
-            <Text style={styles.emptyText}>{t('participants.noParticipants')}</Text>
+            <Text style={styles.emptyText}>{t('no_participants')}</Text>
           </View>
         }
       />

--- a/mobile/src/screens/SettingsScreen.js
+++ b/mobile/src/screens/SettingsScreen.js
@@ -52,11 +52,11 @@ const SettingsScreen = ({ navigation }) => {
       setCurrentLanguage(lang);
       // Show alert that app will reload
       Alert.alert(
-        t('settings.languageChanged'),
-        t('settings.restartRequired'),
+        t('Language changed'),
+        t('App restart required'),
         [
           {
-            text: t('common.ok'),
+            text: t('OK'),
             onPress: () => {
               // TODO: Force app reload/navigation reset
               // For now, just update the state
@@ -69,15 +69,15 @@ const SettingsScreen = ({ navigation }) => {
 
   const handleLogout = async () => {
     Alert.alert(
-      t('settings.confirmLogout'),
-      t('settings.confirmLogoutMessage'),
+      t('Confirm Logout'),
+      t('Are you sure you want to logout?'),
       [
         {
-          text: t('common.cancel'),
+          text: t('cancel'),
           style: 'cancel',
         },
         {
-          text: t('settings.logout'),
+          text: t('logout'),
           style: 'destructive',
           onPress: async () => {
             try {
@@ -100,7 +100,7 @@ const SettingsScreen = ({ navigation }) => {
     <ScrollView style={styles.container}>
       {/* User Profile Section */}
       <View style={styles.section}>
-        <Text style={styles.sectionTitle}>{t('settings.profile')}</Text>
+        <Text style={styles.sectionTitle}>{t('profile')}</Text>
         <Card>
           <Text style={styles.profileName}>{userName}</Text>
           <Text style={styles.profileRole}>{userRole}</Text>
@@ -109,7 +109,7 @@ const SettingsScreen = ({ navigation }) => {
 
       {/* Language Section */}
       <View style={styles.section}>
-        <Text style={styles.sectionTitle}>{t('settings.language')}</Text>
+        <Text style={styles.sectionTitle}>{t('language')}</Text>
         <Card>
           <TouchableOpacity
             style={styles.settingRow}
@@ -131,10 +131,10 @@ const SettingsScreen = ({ navigation }) => {
 
       {/* Notifications Section */}
       <View style={styles.section}>
-        <Text style={styles.sectionTitle}>{t('settings.notifications')}</Text>
+        <Text style={styles.sectionTitle}>{t('Notifications')}</Text>
         <Card>
           <View style={styles.settingRow}>
-            <Text style={styles.settingLabel}>{t('settings.pushNotifications')}</Text>
+            <Text style={styles.settingLabel}>{t('Push Notifications')}</Text>
             <Switch
               value={pushEnabled}
               onValueChange={setPushEnabled}
@@ -143,21 +143,21 @@ const SettingsScreen = ({ navigation }) => {
           </View>
         </Card>
         <Text style={styles.settingHelp}>
-          {t('settings.pushNotificationsHelp')}
+          {t('Receive notifications about activities')}
         </Text>
       </View>
 
       {/* App Info Section */}
       <View style={styles.section}>
-        <Text style={styles.sectionTitle}>{t('settings.appInfo')}</Text>
+        <Text style={styles.sectionTitle}>{t('App Info')}</Text>
         <Card>
           <View style={styles.settingRow}>
-            <Text style={styles.settingLabel}>{t('settings.version')}</Text>
+            <Text style={styles.settingLabel}>{t('Version')}</Text>
             <Text style={styles.settingValue}>{CONFIG.APP.VERSION}</Text>
           </View>
           <View style={styles.separator} />
           <View style={styles.settingRow}>
-            <Text style={styles.settingLabel}>{t('settings.build')}</Text>
+            <Text style={styles.settingLabel}>{t('Build')}</Text>
             <Text style={styles.settingValue}>{CONFIG.APP.BUILD_NUMBER}</Text>
           </View>
         </Card>
@@ -166,13 +166,13 @@ const SettingsScreen = ({ navigation }) => {
       {/* Account Actions */}
       <View style={styles.section}>
         <TouchableOpacity style={styles.logoutButton} onPress={handleLogout}>
-          <Text style={styles.logoutButtonText}>{t('settings.logout')}</Text>
+          <Text style={styles.logoutButtonText}>{t('logout')}</Text>
         </TouchableOpacity>
       </View>
 
       <View style={styles.footer}>
         <Text style={styles.footerText}>
-          {t('settings.madeWith')} ❤️ {t('settings.forScouts')}
+          {t('Made with')} ❤️ {t('for Scouts')}
         </Text>
       </View>
     </ScrollView>


### PR DESCRIPTION
Changed from nested keys (auth.login) to flat keys (login) matching lang.json format.

Why:
- Enables direct use of 1960+ existing translation keys from lang.json
- Eliminates need for complex key mapping maintenance
- Cleaner, more maintainable codebase
- Follows existing lang.json format used by web app

Changes:
- Updated all mobile screens to use flat translation keys:
  * LoginScreen.js: login, email, password, etc.
  * SettingsScreen.js: profile, language, logout, etc.
  * ParticipantsScreen.js: age, group, participants, etc.
  * ParticipantDetailScreen.js: first_name, last_name, etc.
  * Dashboard screens: overview, groups, participants, etc.
  * ActivitiesScreen.js: Upcoming, Past, All, etc.
  * ParentDashboardScreen.js: age, group, etc.
  * MainTabNavigator.js: dashboard_title, participants, etc.

- Simplified mobile/src/i18n/index.js:
  * Removed 170+ line key mapping object
  * Simplified translate() function to use keys directly
  * Added clear documentation about flat key format

- Updated mobile/docs/TRANSLATION_KEY_MAPPING.md:
  * Documented all key mappings for reference
  * Shows which keys exist in lang.json vs fallback text

Result:
Mobile app now directly uses the same translation keys as the web app, making it easy to add new screens and share translations.