### PR TITLE
Fix syntax error in ParticipantDetailScreen.js

### DIFF
--- a/mobile/src/screens/ParticipantDetailScreen.js
+++ b/mobile/src/screens/ParticipantDetailScreen.js
@@ -267,7 +267,7 @@ const ParticipantDetailScreen = () => {
     if (!canEdit) {
       Alert.alert(
         t('Permission denied'),
-        t('You don'\''t have permission to edit')
+        t("You don't have permission to edit")
       );
       return;
     }


### PR DESCRIPTION
Fixed incorrect quote escaping in translation key that was causing a JavaScript syntax error.