### PR TITLE
Enable Settings screen with logout functionality in mobile app

### DIFF
--- a/mobile/src/navigation/MainTabNavigator.js
+++ b/mobile/src/navigation/MainTabNavigator.js
@@ -7,14 +7,13 @@
 
 import React from 'react';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import { DashboardScreen } from '../screens';
+import { DashboardScreen, SettingsScreen } from '../screens';
 import { translate as t } from '../i18n';
 
 // Import future screens
 // import ParticipantsScreen from '../screens/ParticipantsScreen';
 // import ActivitiesScreen from '../screens/ActivitiesScreen';
 // import FinanceScreen from '../screens/FinanceScreen';
-// import SettingsScreen from '../screens/SettingsScreen';
 
 const Tab = createBottomTabNavigator();
 
@@ -87,7 +86,7 @@ const MainTabNavigator = ({ userRole, userPermissions }) => {
       {/* Settings - available to all users */}
       <Tab.Screen
         name="SettingsTab"
-        component={DashboardScreen} // Placeholder - replace with SettingsScreen
+        component={SettingsScreen}
         options={{
           title: t('settings'),
           tabBarIcon: () => null,


### PR DESCRIPTION
The Settings tab was using DashboardScreen as a placeholder. This commit enables the actual SettingsScreen which includes a logout button.

Changes to mobile/src/navigation/MainTabNavigator.js:
- Import SettingsScreen from '../screens'
- Replace DashboardScreen placeholder with SettingsScreen component
- Remove commented import line (no longer needed)

This allows users to:
- Access the Settings tab from the bottom navigation
- View app version and user information
- Logout from the mobile app using the red logout button

The logout button shows a confirmation dialog before logging out and clearing user session data.