### PR TITLE
Port leader SPA tools to mobile: points, attendance, meetings, honors & medication

### DIFF
--- a/mobile/src/api/api-endpoints.js
+++ b/mobile/src/api/api-endpoints.js
@@ -355,6 +355,120 @@ export const getFinanceSummary = async () => {
 
 /**
  * ============================================================================
+ * POINTS (Legacy)
+ * ============================================================================
+ */
+
+/**
+ * Update points for participants or groups
+ */
+export const updatePoints = async (updates) => {
+  return API.post(CONFIG.ENDPOINTS.UPDATE_POINTS, updates);
+};
+
+/**
+ * Get points report
+ */
+export const getPointsReport = async () => {
+  return API.get(CONFIG.ENDPOINTS.POINTS_REPORT);
+};
+
+/**
+ * Get points leaderboard
+ */
+export const getPointsLeaderboard = async (type = 'individuals', limit = 10) => {
+  return API.get(CONFIG.ENDPOINTS.POINTS_LEADERBOARD, { type, limit });
+};
+
+/**
+ * ============================================================================
+ * HONORS (Legacy)
+ * ============================================================================
+ */
+
+/**
+ * Get honors and participants for a date
+ */
+export const getHonors = async (date = null) => {
+  const params = date ? { date } : {};
+  return API.get(CONFIG.ENDPOINTS.HONORS, params);
+};
+
+/**
+ * Award honor to participant(s)
+ */
+export const awardHonor = async (honorData) => {
+  return API.post(CONFIG.ENDPOINTS.AWARD_HONOR, honorData);
+};
+
+/**
+ * Get honors report
+ */
+export const getHonorsReport = async () => {
+  return API.get(CONFIG.ENDPOINTS.HONORS_REPORT);
+};
+
+/**
+ * Get honors history
+ */
+export const getHonorsHistory = async (options = {}) => {
+  const params = {};
+  if (options.startDate) params.start_date = options.startDate;
+  if (options.endDate) params.end_date = options.endDate;
+  if (options.participantId) params.participant_id = options.participantId;
+  return API.get(CONFIG.ENDPOINTS.HONORS_HISTORY, params);
+};
+
+/**
+ * ============================================================================
+ * MEETINGS / REUNIONS (Legacy)
+ * ============================================================================
+ */
+
+/**
+ * Get meeting preparation for a date
+ */
+export const getReunionPreparation = async (date) => {
+  return API.get(CONFIG.ENDPOINTS.REUNION_PREPARATION, { date });
+};
+
+/**
+ * Save meeting preparation
+ */
+export const saveReunionPreparation = async (payload) => {
+  return API.post(CONFIG.ENDPOINTS.SAVE_REUNION_PREPARATION, payload);
+};
+
+/**
+ * Get meeting dates
+ */
+export const getReunionDates = async () => {
+  return API.get(CONFIG.ENDPOINTS.REUNION_DATES);
+};
+
+/**
+ * Get next meeting information
+ */
+export const getNextMeetingInfo = async () => {
+  return API.get(CONFIG.ENDPOINTS.NEXT_MEETING_INFO);
+};
+
+/**
+ * Get meeting activities templates
+ */
+export const getMeetingActivities = async () => {
+  return API.get(CONFIG.ENDPOINTS.MEETING_ACTIVITIES);
+};
+
+/**
+ * Get animators
+ */
+export const getAnimateurs = async () => {
+  return API.get(CONFIG.ENDPOINTS.ANIMATEURS);
+};
+
+/**
+ * ============================================================================
  * BUDGET (V1)
  * ============================================================================
  */
@@ -439,6 +553,38 @@ export const getParticipantMedications = async (participantId) => {
  */
 export const getMedicationDistributions = async (params) => {
   return API.get(`${CONFIG.ENDPOINTS.MEDICATION}/distributions`, params);
+};
+
+/**
+ * Get medication suggestions from fiche_sante submissions
+ */
+export const getFicheMedications = async () => {
+  return API.get(`${CONFIG.ENDPOINTS.MEDICATION}/fiche-medications`);
+};
+
+/**
+ * Create or update medication requirement
+ */
+export const saveMedicationRequirement = async (payload) => {
+  if (payload?.id) {
+    return API.put(`${CONFIG.ENDPOINTS.MEDICATION}/requirements/${payload.id}`, payload);
+  }
+
+  return API.post(`${CONFIG.ENDPOINTS.MEDICATION}/requirements`, payload);
+};
+
+/**
+ * Record medication distributions
+ */
+export const recordMedicationDistribution = async (payload) => {
+  return API.post(`${CONFIG.ENDPOINTS.MEDICATION}/distributions`, payload);
+};
+
+/**
+ * Mark medication distribution as given
+ */
+export const markMedicationDistributionAsGiven = async (distributionId, payload) => {
+  return API.patch(`${CONFIG.ENDPOINTS.MEDICATION}/distributions/${distributionId}`, payload);
 };
 
 /**
@@ -620,6 +766,22 @@ export default {
   createFeeDefinition,
   getParticipantFees,
   getFinanceSummary,
+  // Points
+  updatePoints,
+  getPointsReport,
+  getPointsLeaderboard,
+  // Honors
+  getHonors,
+  awardHonor,
+  getHonorsReport,
+  getHonorsHistory,
+  // Meetings
+  getReunionPreparation,
+  saveReunionPreparation,
+  getReunionDates,
+  getNextMeetingInfo,
+  getMeetingActivities,
+  getAnimateurs,
   // Budget
   getBudgetCategories,
   getBudgetItems,
@@ -633,6 +795,10 @@ export default {
   getMedicationRequirements,
   getParticipantMedications,
   getMedicationDistributions,
+  getFicheMedications,
+  saveMedicationRequirement,
+  recordMedicationDistribution,
+  markMedicationDistributionAsGiven,
   // Resources
   getEquipment,
   getEquipmentReservations,

--- a/mobile/src/config/index.js
+++ b/mobile/src/config/index.js
@@ -103,11 +103,23 @@ const CONFIG = {
     TRANSLATIONS: '/translations',
     PARTICIPANTS_LEGACY: '/participants',
     POINTS_DATA: '/points-data',
+    UPDATE_POINTS: '/update-points',
+    POINTS_REPORT: '/points-report',
+    POINTS_LEADERBOARD: '/points-leaderboard',
     BADGE_SUMMARY: '/badge-summary',
     HONORS: '/honors',
+    AWARD_HONOR: '/award-honor',
+    HONORS_REPORT: '/honors-report',
+    HONORS_HISTORY: '/honors-history',
     FUNDRAISERS: '/fundraisers',
     CALENDARS: '/calendars',
     FORMS: '/form-formats',
+    REUNION_PREPARATION: '/reunion-preparation',
+    SAVE_REUNION_PREPARATION: '/save-reunion-preparation',
+    REUNION_DATES: '/reunion-dates',
+    MEETING_ACTIVITIES: '/activites-rencontre',
+    NEXT_MEETING_INFO: '/next-meeting-info',
+    ANIMATEURS: '/animateurs',
   },
 
   // Storage keys (mirrors spa CONFIG.STORAGE_KEYS)
@@ -147,6 +159,8 @@ const CONFIG = {
     TOUCH_TARGET_SIZE: 44, // Minimum touch target size for accessibility
     ANIMATION_DURATION: 300,
     DEBOUNCE_DELAY: 300,
+    POINTS_QUICK_ACTIONS: [-5, -1, 1, 5],
+    ATTENDANCE_STATUSES: ['present', 'late', 'absent', 'excused'],
   },
 
   // Feature flags

--- a/mobile/src/navigation/AppNavigator.js
+++ b/mobile/src/navigation/AppNavigator.js
@@ -9,7 +9,15 @@ import { createStackNavigator } from '@react-navigation/stack';
 import MainTabNavigator from './MainTabNavigator';
 
 // Import modal/detail screens
-import { ParticipantDetailScreen } from '../screens';
+import {
+  ParticipantDetailScreen,
+  ManagePointsScreen,
+  AttendanceScreen,
+  MeetingPreparationScreen,
+  NextMeetingScreen,
+  HonorsScreen,
+  MedicationScreen,
+} from '../screens';
 
 // Import future modal/detail screens
 // import ActivityDetailScreen from '../screens/ActivityDetailScreen';
@@ -37,6 +45,54 @@ const AppNavigator = ({ userRole, userPermissions }) => {
         options={{
           headerShown: true,
           title: 'Participant Details',
+        }}
+      />
+
+      <Stack.Screen
+        name="ManagePoints"
+        component={ManagePointsScreen}
+        options={{
+          headerShown: true,
+        }}
+      />
+
+      <Stack.Screen
+        name="Attendance"
+        component={AttendanceScreen}
+        options={{
+          headerShown: true,
+        }}
+      />
+
+      <Stack.Screen
+        name="MeetingPreparation"
+        component={MeetingPreparationScreen}
+        options={{
+          headerShown: true,
+        }}
+      />
+
+      <Stack.Screen
+        name="NextMeeting"
+        component={NextMeetingScreen}
+        options={{
+          headerShown: true,
+        }}
+      />
+
+      <Stack.Screen
+        name="Honors"
+        component={HonorsScreen}
+        options={{
+          headerShown: true,
+        }}
+      />
+
+      <Stack.Screen
+        name="Medication"
+        component={MedicationScreen}
+        options={{
+          headerShown: true,
         }}
       />
 

--- a/mobile/src/screens/AttendanceScreen.js
+++ b/mobile/src/screens/AttendanceScreen.js
@@ -1,0 +1,338 @@
+/**
+ * AttendanceScreen
+ *
+ * Mirrors spa/attendance.js for leaders.
+ * Allows marking attendance by date with status selection.
+ */
+
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  RefreshControl,
+  TouchableOpacity,
+  TextInput,
+} from 'react-native';
+import {
+  getAttendance,
+  getAttendanceDates,
+  getParticipants,
+  createAttendance,
+} from '../api/api-endpoints';
+import { translate as t } from '../i18n';
+import DateUtils from '../utils/DateUtils';
+import SecurityUtils from '../utils/SecurityUtils';
+import { Button, Card, ErrorMessage, LoadingSpinner } from '../components';
+import CONFIG from '../config';
+import theme, { commonStyles } from '../theme';
+import { debugError } from '../utils/DebugUtils';
+
+/**
+ * Normalize participant names to handle API variations.
+ * @param {object} participant - Participant record.
+ * @returns {object} Normalized participant record.
+ */
+const normalizeParticipant = (participant) => {
+  return {
+    id: participant.id || participant.participant_id,
+    firstName: participant.firstName || participant.first_name || '',
+    lastName: participant.lastName || participant.last_name || '',
+    groupName: participant.group || participant.group_name || '',
+  };
+};
+
+const AttendanceScreen = () => {
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState('');
+  const [participants, setParticipants] = useState([]);
+  const [attendanceMap, setAttendanceMap] = useState({});
+  const [availableDates, setAvailableDates] = useState([]);
+  const [selectedDate, setSelectedDate] = useState('');
+  const [customDate, setCustomDate] = useState('');
+  const [savingId, setSavingId] = useState(null);
+
+  const sortedParticipants = useMemo(() => {
+    return [...participants].sort((a, b) =>
+      `${a.lastName} ${a.firstName}`.localeCompare(`${b.lastName} ${b.firstName}`)
+    );
+  }, [participants]);
+
+  /**
+   * Load attendance data for the selected date.
+   */
+  const loadAttendanceData = async (dateOverride = null) => {
+    try {
+      setError('');
+      const targetDate = dateOverride || selectedDate;
+
+      const [participantsResponse, attendanceResponse, datesResponse] = await Promise.all([
+        getParticipants(),
+        getAttendance(targetDate ? { date: targetDate } : undefined),
+        getAttendanceDates(),
+      ]);
+
+      const participantRows = participantsResponse.success
+        ? (participantsResponse.data || []).map(normalizeParticipant)
+        : [];
+
+      const attendanceRows = attendanceResponse.success
+        ? attendanceResponse.data || []
+        : [];
+
+      const dateRows = datesResponse.success ? datesResponse.data || [] : [];
+
+      const map = attendanceRows.reduce((acc, record) => {
+        acc[record.participant_id] = record.status;
+        return acc;
+      }, {});
+
+      setParticipants(participantRows);
+      setAttendanceMap(map);
+
+      const dates = dateRows.length > 0 ? dateRows : [];
+      const today = DateUtils.formatDate(new Date());
+      const uniqueDates = Array.from(new Set([today, ...dates]));
+      setAvailableDates(uniqueDates);
+
+      if (!targetDate) {
+        setSelectedDate(uniqueDates[0]);
+      }
+    } catch (err) {
+      debugError('Error loading attendance data:', err);
+      setError(err.message || t('error_loading_attendance'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadAttendanceData();
+  }, []);
+
+  useEffect(() => {
+    if (selectedDate) {
+      loadAttendanceData(selectedDate);
+    }
+  }, [selectedDate]);
+
+  const onRefresh = async () => {
+    setRefreshing(true);
+    await loadAttendanceData(selectedDate);
+    setRefreshing(false);
+  };
+
+  /**
+   * Persist an attendance update.
+   * @param {number} participantId - Participant ID.
+   * @param {string} status - Attendance status.
+   */
+  const handleStatusUpdate = async (participantId, status) => {
+    setSavingId(participantId);
+    try {
+      const previousStatus = attendanceMap[participantId];
+      const response = await createAttendance({
+        participant_id: participantId,
+        status,
+        date: selectedDate,
+        previous_status: previousStatus,
+      });
+
+      if (!response.success) {
+        throw new Error(response.message || t('error_loading_attendance'));
+      }
+
+      setAttendanceMap((prev) => ({ ...prev, [participantId]: status }));
+    } catch (err) {
+      debugError('Error updating attendance:', err);
+      setError(err.message || t('error_loading_attendance'));
+    } finally {
+      setSavingId(null);
+    }
+  };
+
+  const handleDateSubmit = () => {
+    const sanitized = SecurityUtils.sanitizeInput(customDate);
+    if (!sanitized) {
+      setError(t('error_loading_attendance'));
+      return;
+    }
+
+    setSelectedDate(sanitized);
+    setCustomDate('');
+  };
+
+  if (loading) {
+    return <LoadingSpinner message={t('loading')} />;
+  }
+
+  if (error) {
+    return <ErrorMessage message={error} onRetry={loadAttendanceData} />;
+  }
+
+  return (
+    <ScrollView
+      style={commonStyles.container}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+    >
+      <View style={styles.header}>
+        <Text style={styles.title}>{t('attendance_overview')}</Text>
+        <Text style={styles.subtitle}>{t('attendance')}</Text>
+      </View>
+
+      <View style={styles.dateSection}>
+        <Text style={styles.sectionTitle}>{t('select_date')}</Text>
+        <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+          <View style={styles.dateChips}>
+            {availableDates.map((date) => (
+              <TouchableOpacity
+                key={date}
+                onPress={() => setSelectedDate(date)}
+                style={[
+                  styles.dateChip,
+                  selectedDate === date && styles.dateChipActive,
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.dateChipText,
+                    selectedDate === date && styles.dateChipTextActive,
+                  ]}
+                >
+                  {DateUtils.formatDate(date)}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        </ScrollView>
+
+        <View style={styles.customDateRow}>
+          <TextInput
+            style={styles.input}
+            placeholder={t('date')}
+            value={customDate}
+            onChangeText={setCustomDate}
+          />
+          <Button title={t('update')} onPress={handleDateSubmit} />
+        </View>
+      </View>
+
+      <View style={styles.listSection}>
+        {sortedParticipants.length === 0 ? (
+          <Card>
+            <Text style={styles.emptyText}>{t('no_participants')}</Text>
+          </Card>
+        ) : (
+          sortedParticipants.map((participant) => (
+            <Card key={participant.id} style={styles.attendanceCard}>
+              <Text style={styles.participantName}>
+                {participant.firstName} {participant.lastName}
+              </Text>
+              {participant.groupName ? (
+                <Text style={styles.groupName}>{participant.groupName}</Text>
+              ) : null}
+              <View style={styles.statusRow}>
+                {CONFIG.UI.ATTENDANCE_STATUSES.map((status) => {
+                  const isActive = attendanceMap[participant.id] === status;
+                  return (
+                    <Button
+                      key={`${participant.id}-${status}`}
+                      title={t(status)}
+                      onPress={() => handleStatusUpdate(participant.id, status)}
+                      variant={isActive ? 'primary' : 'secondary'}
+                      size="small"
+                      disabled={savingId === participant.id}
+                      style={styles.statusButton}
+                    />
+                  );
+                })}
+              </View>
+            </Card>
+          ))
+        )}
+      </View>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  header: {
+    padding: theme.spacing.lg,
+  },
+  title: {
+    ...commonStyles.heading2,
+  },
+  subtitle: {
+    ...commonStyles.caption,
+  },
+  sectionTitle: {
+    ...commonStyles.sectionTitle,
+    marginBottom: theme.spacing.sm,
+  },
+  dateSection: {
+    paddingHorizontal: theme.spacing.lg,
+    paddingBottom: theme.spacing.md,
+  },
+  dateChips: {
+    flexDirection: 'row',
+    gap: theme.spacing.sm,
+    marginBottom: theme.spacing.md,
+  },
+  dateChip: {
+    paddingVertical: theme.spacing.sm,
+    paddingHorizontal: theme.spacing.md,
+    borderRadius: theme.borderRadius.full,
+    backgroundColor: theme.colors.surface,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+  },
+  dateChipActive: {
+    backgroundColor: theme.colors.primary,
+    borderColor: theme.colors.primary,
+  },
+  dateChipText: {
+    ...commonStyles.caption,
+  },
+  dateChipTextActive: {
+    color: theme.colors.surface,
+  },
+  customDateRow: {
+    flexDirection: 'row',
+    gap: theme.spacing.sm,
+    alignItems: 'center',
+  },
+  input: {
+    ...commonStyles.input,
+    flex: 1,
+  },
+  listSection: {
+    paddingHorizontal: theme.spacing.lg,
+    paddingBottom: theme.spacing.xl,
+  },
+  attendanceCard: {
+    marginBottom: theme.spacing.sm,
+  },
+  participantName: {
+    ...commonStyles.heading3,
+  },
+  groupName: {
+    ...commonStyles.caption,
+    marginBottom: theme.spacing.sm,
+  },
+  statusRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: theme.spacing.sm,
+  },
+  statusButton: {
+    minWidth: theme.spacing.xxl,
+  },
+  emptyText: {
+    ...commonStyles.bodyText,
+    textAlign: 'center',
+  },
+});
+
+export default AttendanceScreen;

--- a/mobile/src/screens/HonorsScreen.js
+++ b/mobile/src/screens/HonorsScreen.js
@@ -1,0 +1,369 @@
+/**
+ * HonorsScreen
+ *
+ * Mirrors spa/manage_honors.js for leaders.
+ * Allows selecting participants to award honors with reasons.
+ */
+
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  RefreshControl,
+  TouchableOpacity,
+  TextInput,
+} from 'react-native';
+import { awardHonor, getHonors } from '../api/api-endpoints';
+import { translate as t } from '../i18n';
+import DateUtils from '../utils/DateUtils';
+import SecurityUtils from '../utils/SecurityUtils';
+import { Button, Card, ErrorMessage, LoadingSpinner } from '../components';
+import theme, { commonStyles } from '../theme';
+import { debugError } from '../utils/DebugUtils';
+
+/**
+ * Build participant honor stats for the selected date.
+ * @param {Array} participants - Participants list.
+ * @param {Array} honors - Honors list.
+ * @param {string} selectedDate - Selected date.
+ * @returns {Array} Enriched participant list.
+ */
+const buildHonorsList = (participants, honors, selectedDate) => {
+  return participants.map((participant) => {
+    const honorsForDate = honors.filter(
+      (honor) =>
+        honor.participant_id === participant.participant_id &&
+        honor.date === selectedDate
+    );
+    const totalHonors = honors.filter(
+      (honor) =>
+        honor.participant_id === participant.participant_id &&
+        new Date(honor.date) <= new Date(selectedDate)
+    ).length;
+
+    return {
+      ...participant,
+      honoredToday: honorsForDate.length > 0,
+      totalHonors,
+      reason: honorsForDate[0]?.reason || '',
+    };
+  });
+};
+
+const HonorsScreen = () => {
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState('');
+  const [participants, setParticipants] = useState([]);
+  const [honors, setHonors] = useState([]);
+  const [availableDates, setAvailableDates] = useState([]);
+  const [selectedDate, setSelectedDate] = useState('');
+  const [customDate, setCustomDate] = useState('');
+  const [selectedHonors, setSelectedHonors] = useState({});
+  const [saving, setSaving] = useState(false);
+
+  const honorsList = useMemo(
+    () => buildHonorsList(participants, honors, selectedDate),
+    [participants, honors, selectedDate]
+  );
+
+  const isPastDate = () => {
+    if (!selectedDate) return false;
+    const target = new Date(selectedDate);
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    return target < today;
+  };
+
+  /**
+   * Load honors data for selected date.
+   */
+  const loadHonorsData = async (dateOverride = null) => {
+    try {
+      setError('');
+      const targetDate = dateOverride || selectedDate;
+      const response = await getHonors(targetDate);
+
+      if (response.success) {
+        const data = response.data || response;
+        setParticipants(data.participants || []);
+        setHonors(data.honors || []);
+
+        const dates = data.availableDates || [];
+        const today = DateUtils.formatDate(new Date());
+        const uniqueDates = Array.from(new Set([today, ...dates]));
+        setAvailableDates(uniqueDates);
+
+        if (!targetDate) {
+          setSelectedDate(uniqueDates[0]);
+        }
+      } else {
+        throw new Error(response.message || t('error_loading_honors'));
+      }
+    } catch (err) {
+      debugError('Error loading honors:', err);
+      setError(err.message || t('error_loading_honors'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadHonorsData();
+  }, []);
+
+  useEffect(() => {
+    if (selectedDate) {
+      loadHonorsData(selectedDate);
+    }
+  }, [selectedDate]);
+
+  const onRefresh = async () => {
+    setRefreshing(true);
+    await loadHonorsData(selectedDate);
+    setRefreshing(false);
+  };
+
+  const toggleParticipant = (participantId) => {
+    setSelectedHonors((prev) => ({
+      ...prev,
+      [participantId]: {
+        ...prev[participantId],
+        selected: !prev[participantId]?.selected,
+      },
+    }));
+  };
+
+  const updateReason = (participantId, reason) => {
+    setSelectedHonors((prev) => ({
+      ...prev,
+      [participantId]: {
+        ...prev[participantId],
+        reason,
+      },
+    }));
+  };
+
+  const handleAwardHonors = async () => {
+    const honorsPayload = Object.entries(selectedHonors)
+      .filter(([, value]) => value?.selected)
+      .map(([participantId, value]) => ({
+        participantId,
+        date: selectedDate,
+        reason: SecurityUtils.sanitizeInput(value?.reason || ''),
+      }))
+      .filter((honor) => honor.reason);
+
+    if (honorsPayload.length === 0) {
+      setError(t('select_individuals'));
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const response = await awardHonor(honorsPayload);
+      if (!response.success) {
+        throw new Error(response.message || t('error_awarding_honor'));
+      }
+      setSelectedHonors({});
+      await loadHonorsData(selectedDate);
+    } catch (err) {
+      debugError('Error awarding honors:', err);
+      setError(err.message || t('error_awarding_honor'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDateSubmit = () => {
+    const sanitized = SecurityUtils.sanitizeInput(customDate);
+    if (!sanitized) {
+      setError(t('error_loading_honors'));
+      return;
+    }
+
+    setSelectedDate(sanitized);
+    setCustomDate('');
+  };
+
+  if (loading) {
+    return <LoadingSpinner message={t('loading')} />;
+  }
+
+  if (error) {
+    return <ErrorMessage message={error} onRetry={loadHonorsData} />;
+  }
+
+  return (
+    <ScrollView
+      style={commonStyles.container}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+    >
+      <View style={styles.header}>
+        <Text style={styles.title}>{t('youth_of_honor')}</Text>
+        <Text style={styles.subtitle}>{t('manage_honors')}</Text>
+      </View>
+
+      <View style={styles.dateSection}>
+        <Text style={styles.sectionTitle}>{t('select_date')}</Text>
+        <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+          <View style={styles.dateChips}>
+            {availableDates.map((date) => (
+              <TouchableOpacity
+                key={date}
+                onPress={() => setSelectedDate(date)}
+                style={[
+                  styles.dateChip,
+                  selectedDate === date && styles.dateChipActive,
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.dateChipText,
+                    selectedDate === date && styles.dateChipTextActive,
+                  ]}
+                >
+                  {DateUtils.formatDate(date)}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        </ScrollView>
+        <View style={styles.customDateRow}>
+          <TextInput
+            style={styles.input}
+            placeholder={t('date')}
+            value={customDate}
+            onChangeText={setCustomDate}
+          />
+          <Button title={t('update')} onPress={handleDateSubmit} />
+        </View>
+      </View>
+
+      <View style={styles.listSection}>
+        {honorsList.length === 0 ? (
+          <Card>
+            <Text style={styles.emptyText}>{t('no_honors_on_this_date')}</Text>
+          </Card>
+        ) : (
+          honorsList.map((participant) => {
+            const isDisabled = isPastDate() || participant.honoredToday;
+            const selection = selectedHonors[participant.participant_id] || {};
+            return (
+              <Card key={participant.participant_id} style={styles.card}>
+                <TouchableOpacity
+                  onPress={() => toggleParticipant(participant.participant_id)}
+                  disabled={isDisabled}
+                >
+                  <Text style={styles.participantName}>
+                    {participant.first_name} {participant.last_name}
+                  </Text>
+                  <Text style={styles.captionText}>
+                    {t('honors_count')}: {participant.totalHonors}
+                  </Text>
+                  {participant.reason ? (
+                    <Text style={styles.captionText}>{participant.reason}</Text>
+                  ) : null}
+                </TouchableOpacity>
+                {!isDisabled && selection?.selected ? (
+                  <TextInput
+                    style={styles.input}
+                    placeholder={t('honor_reason_prompt')}
+                    value={selection.reason || ''}
+                    onChangeText={(value) => updateReason(participant.participant_id, value)}
+                  />
+                ) : null}
+              </Card>
+            );
+          })
+        )}
+      </View>
+
+      <View style={styles.saveSection}>
+        <Button
+          title={t('award_honor')}
+          onPress={handleAwardHonors}
+          loading={saving}
+          disabled={isPastDate()}
+        />
+      </View>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  header: {
+    padding: theme.spacing.lg,
+  },
+  title: {
+    ...commonStyles.heading2,
+  },
+  subtitle: {
+    ...commonStyles.caption,
+  },
+  sectionTitle: {
+    ...commonStyles.sectionTitle,
+    marginBottom: theme.spacing.sm,
+  },
+  dateSection: {
+    paddingHorizontal: theme.spacing.lg,
+    paddingBottom: theme.spacing.md,
+  },
+  dateChips: {
+    flexDirection: 'row',
+    gap: theme.spacing.sm,
+    marginBottom: theme.spacing.md,
+  },
+  dateChip: {
+    paddingVertical: theme.spacing.sm,
+    paddingHorizontal: theme.spacing.md,
+    borderRadius: theme.borderRadius.full,
+    backgroundColor: theme.colors.surface,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+  },
+  dateChipActive: {
+    backgroundColor: theme.colors.primary,
+    borderColor: theme.colors.primary,
+  },
+  dateChipText: {
+    ...commonStyles.caption,
+  },
+  dateChipTextActive: {
+    color: theme.colors.surface,
+  },
+  customDateRow: {
+    flexDirection: 'row',
+    gap: theme.spacing.sm,
+    alignItems: 'center',
+  },
+  input: {
+    ...commonStyles.input,
+    flex: 1,
+    marginBottom: theme.spacing.sm,
+  },
+  listSection: {
+    paddingHorizontal: theme.spacing.lg,
+  },
+  card: {
+    marginBottom: theme.spacing.sm,
+  },
+  participantName: {
+    ...commonStyles.heading3,
+  },
+  captionText: {
+    ...commonStyles.caption,
+  },
+  emptyText: {
+    ...commonStyles.bodyText,
+    textAlign: 'center',
+  },
+  saveSection: {
+    paddingHorizontal: theme.spacing.lg,
+    paddingVertical: theme.spacing.lg,
+  },
+});
+
+export default HonorsScreen;

--- a/mobile/src/screens/LeaderDashboardScreen.js
+++ b/mobile/src/screens/LeaderDashboardScreen.js
@@ -20,6 +20,7 @@ import {
   ScrollView,
   RefreshControl,
   Alert,
+  TouchableOpacity,
 } from 'react-native';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
 
@@ -33,13 +34,14 @@ import { translate as t } from '../i18n';
 import StorageUtils from '../utils/StorageUtils';
 import DateUtils from '../utils/DateUtils';
 import CacheManager from '../utils/CacheManager';
+import theme, { commonStyles } from '../theme';
+import { debugError } from '../utils/DebugUtils';
 
 // Components
 import {
   LoadingSpinner,
   ErrorMessage,
   StatCard,
-  QuickActionButton,
   DashboardSection,
   Card,
 } from '../components';
@@ -106,7 +108,7 @@ const LeaderDashboardScreen = () => {
 
       setUserGroup({ id: groupId, name: groupName });
     } catch (error) {
-      console.error('Error loading user group:', error);
+      debugError('Error loading user group:', error);
     }
   };
 
@@ -172,7 +174,7 @@ const LeaderDashboardScreen = () => {
         setIsOffline(true);
       }
     } catch (err) {
-      console.error('Error loading dashboard data:', err);
+      debugError('Error loading dashboard data:', err);
       setError(t('error_loading_dashboard'));
     } finally {
       setLoading(false);
@@ -186,42 +188,6 @@ const LeaderDashboardScreen = () => {
     setRefreshing(true);
     await loadDashboardData();
     setRefreshing(false);
-  };
-
-  /**
-   * Navigate to take attendance
-   */
-  const handleTakeAttendance = () => {
-    Alert.alert(
-      t('Take Attendance'),
-      t('dashboard.selectActivity'),
-      [{ text: t('OK') }]
-    );
-    // TODO: Navigate to attendance screen
-  };
-
-  /**
-   * Navigate to create activity
-   */
-  const handleCreateActivity = () => {
-    Alert.alert(
-      t('Create Activity'),
-      t('Coming soon'),
-      [{ text: t('OK') }]
-    );
-    // TODO: Navigate to create activity screen
-  };
-
-  /**
-   * Navigate to carpools
-   */
-  const handleViewCarpools = () => {
-    Alert.alert(
-      t('Carpools'),
-      t('Coming soon'),
-      [{ text: t('OK') }]
-    );
-    // TODO: Navigate to carpools screen
   };
 
   /**
@@ -274,6 +240,15 @@ const LeaderDashboardScreen = () => {
     );
   }
 
+  const leaderTiles = [
+    { key: 'attendance', label: t('attendance'), screen: 'Attendance' },
+    { key: 'points', label: t('manage_points'), screen: 'ManagePoints' },
+    { key: 'honors', label: t('youth_of_honor'), screen: 'Honors' },
+    { key: 'meetingPrep', label: t('preparation_reunions'), screen: 'MeetingPreparation' },
+    { key: 'nextMeeting', label: t('next_meeting'), screen: 'NextMeeting' },
+    { key: 'medication', label: t('medication_management_title'), screen: 'Medication' },
+  ];
+
   return (
     <View style={styles.container}>
       {/* Offline indicator */}
@@ -294,11 +269,11 @@ const LeaderDashboardScreen = () => {
         {/* Header */}
         <View style={styles.header}>
           <Text style={styles.greeting}>
-            {t('Welcome, Leader!')}
+            {t('dashboard_title')}
           </Text>
           {userGroup && (
             <Text style={styles.groupName}>
-              {userGroup.name || t('Your Group')}
+              {t('group')}: {userGroup.name || t('groups')}
             </Text>
           )}
         </View>
@@ -346,44 +321,17 @@ const LeaderDashboardScreen = () => {
           </View>
         </DashboardSection>
 
-        {/* Quick Actions */}
-        <DashboardSection title={t('Quick Actions')}>
-          <View style={styles.actionsGrid}>
-            <View style={styles.actionCol}>
-              <QuickActionButton
-                icon="✓"
-                label={t('Take Attendance')}
-                onPress={handleTakeAttendance}
-                color="#34C759"
-              />
-            </View>
-            <View style={styles.actionCol}>
-              <QuickActionButton
-                icon="+"
-                label={t('Create Activity')}
-                onPress={handleCreateActivity}
-                color="#007AFF"
-              />
-            </View>
-          </View>
-
-          <View style={styles.actionsGrid}>
-            <View style={styles.actionCol}>
-              <QuickActionButton
-                icon="🚗"
-                label={t('Carpools')}
-                onPress={handleViewCarpools}
-                color="#FF9500"
-              />
-            </View>
-            <View style={styles.actionCol}>
-              <QuickActionButton
-                icon="👥"
-                label={t('participants')}
-                onPress={handleViewParticipants}
-                color="#5856D6"
-              />
-            </View>
+        <DashboardSection title={t('dashboard_day_to_day_section')}>
+          <View style={styles.tileGrid}>
+            {leaderTiles.map((tile) => (
+              <TouchableOpacity
+                key={tile.key}
+                style={styles.tile}
+                onPress={() => navigation.navigate(tile.screen)}
+              >
+                <Text style={styles.tileLabel}>{tile.label}</Text>
+              </TouchableOpacity>
+            ))}
           </View>
         </DashboardSection>
 
@@ -433,109 +381,121 @@ const LeaderDashboardScreen = () => {
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
-    backgroundColor: '#f5f5f5',
+    ...commonStyles.container,
   },
   centerContainer: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    padding: 20,
-    backgroundColor: '#f5f5f5',
+    padding: theme.spacing.lg,
+    backgroundColor: theme.colors.background,
   },
   loadingText: {
-    marginTop: 10,
-    fontSize: 16,
-    color: '#666',
+    marginTop: theme.spacing.sm,
+    fontSize: theme.fontSize.base,
+    color: theme.colors.textLight,
   },
   offlineIndicator: {
-    backgroundColor: '#FFA500',
-    padding: 12,
+    backgroundColor: theme.colors.warning,
+    padding: theme.spacing.md,
     alignItems: 'center',
   },
   offlineText: {
-    color: '#fff',
-    fontSize: 14,
-    fontWeight: '600',
+    color: theme.colors.surface,
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.semibold,
   },
   scrollView: {
     flex: 1,
   },
   header: {
-    padding: 20,
-    paddingBottom: 10,
+    padding: theme.spacing.lg,
+    paddingBottom: theme.spacing.sm,
   },
   greeting: {
-    fontSize: 28,
-    fontWeight: 'bold',
-    color: '#333',
-    marginBottom: 4,
+    fontSize: theme.fontSize.xxxl,
+    fontWeight: theme.fontWeight.bold,
+    color: theme.colors.text,
+    marginBottom: theme.spacing.xs,
   },
   groupName: {
-    fontSize: 16,
-    color: '#666',
-    fontWeight: '500',
+    fontSize: theme.fontSize.base,
+    color: theme.colors.textLight,
+    fontWeight: theme.fontWeight.medium,
   },
   statsGrid: {
     flexDirection: 'row',
-    paddingHorizontal: 20,
-    gap: 12,
+    paddingHorizontal: theme.spacing.lg,
+    gap: theme.spacing.sm,
   },
   statCol: {
     flex: 1,
   },
-  actionsGrid: {
-    flexDirection: 'row',
-    paddingHorizontal: 20,
-    gap: 12,
-  },
-  actionCol: {
-    flex: 1,
-  },
   activityCard: {
-    marginHorizontal: 20,
-    marginBottom: 12,
-    padding: 16,
+    marginHorizontal: theme.spacing.lg,
+    marginBottom: theme.spacing.sm,
+    padding: theme.spacing.md,
   },
   activityHeader: {
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'flex-start',
-    marginBottom: 8,
+    marginBottom: theme.spacing.sm,
   },
   activityName: {
-    fontSize: 18,
-    fontWeight: '600',
-    color: '#333',
+    fontSize: theme.fontSize.lg,
+    fontWeight: theme.fontWeight.semibold,
+    color: theme.colors.text,
     flex: 1,
-    marginRight: 12,
+    marginRight: theme.spacing.sm,
   },
   activityDate: {
-    fontSize: 14,
-    color: '#007AFF',
-    fontWeight: '500',
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.primary,
+    fontWeight: theme.fontWeight.medium,
   },
   activityLocation: {
-    fontSize: 14,
-    color: '#666',
-    marginBottom: 4,
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.textLight,
+    marginBottom: theme.spacing.xs,
   },
   activityParticipants: {
-    fontSize: 14,
-    color: '#666',
+    fontSize: theme.fontSize.sm,
+    color: theme.colors.textLight,
   },
   emptyCard: {
-    marginHorizontal: 20,
-    padding: 30,
+    marginHorizontal: theme.spacing.lg,
+    padding: theme.spacing.xl,
     alignItems: 'center',
   },
   emptyText: {
-    fontSize: 16,
-    color: '#999',
+    fontSize: theme.fontSize.base,
+    color: theme.colors.textMuted,
     textAlign: 'center',
   },
   bottomSpacing: {
-    height: 30,
+    height: theme.spacing.xl,
+  },
+  tileGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: theme.spacing.sm,
+    paddingHorizontal: theme.spacing.lg,
+  },
+  tile: {
+    flexBasis: '48%',
+    backgroundColor: theme.colors.surface,
+    borderRadius: theme.borderRadius.md,
+    padding: theme.spacing.md,
+    minHeight: theme.touchTarget.min,
+    justifyContent: 'center',
+    alignItems: 'center',
+    ...theme.shadows.sm,
+  },
+  tileLabel: {
+    ...commonStyles.bodyText,
+    fontWeight: theme.fontWeight.semibold,
+    textAlign: 'center',
   },
 });
 

--- a/mobile/src/screens/ManagePointsScreen.js
+++ b/mobile/src/screens/ManagePointsScreen.js
@@ -1,0 +1,376 @@
+/**
+ * ManagePointsScreen
+ *
+ * Mirrors spa/manage_points.js for leaders.
+ * Provides quick point adjustments for participants and groups.
+ */
+
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TextInput,
+  TouchableOpacity,
+  RefreshControl,
+} from 'react-native';
+import { getParticipants, getGroups, updatePoints } from '../api/api-endpoints';
+import { translate as t } from '../i18n';
+import { Card, LoadingSpinner, ErrorMessage, Button } from '../components';
+import SecurityUtils from '../utils/SecurityUtils';
+import CONFIG from '../config';
+import theme, { commonStyles } from '../theme';
+import { debugError, debugLog } from '../utils/DebugUtils';
+
+const VIEW_MODES = {
+  PARTICIPANTS: 'participants',
+  GROUPS: 'groups',
+};
+
+/**
+ * Build a grouped map for participants by group.
+ * @param {Array} participants - Participant list.
+ * @returns {Record<string, Array>} Grouped participants.
+ */
+const buildGroupedParticipants = (participants) => {
+  return participants.reduce((acc, participant) => {
+    const groupKey = participant.group_name || t('groups');
+    if (!acc[groupKey]) {
+      acc[groupKey] = [];
+    }
+    acc[groupKey].push(participant);
+    return acc;
+  }, {});
+};
+
+const ManagePointsScreen = () => {
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState('');
+  const [participants, setParticipants] = useState([]);
+  const [groups, setGroups] = useState([]);
+  const [viewMode, setViewMode] = useState(VIEW_MODES.PARTICIPANTS);
+  const [customPoints, setCustomPoints] = useState('');
+  const [selectedId, setSelectedId] = useState(null);
+  const [selectedType, setSelectedType] = useState(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const groupedParticipants = useMemo(
+    () => buildGroupedParticipants(participants),
+    [participants]
+  );
+
+  const groupTotals = useMemo(() => {
+    return groups.map((group) => {
+      const members = participants.filter((participant) => participant.group_id === group.id);
+      const totalPoints = members.reduce(
+        (sum, member) => sum + Number(member.total_points || 0),
+        0
+      );
+      return { ...group, totalPoints };
+    });
+  }, [groups, participants]);
+
+  /**
+   * Load participants and groups for points management.
+   */
+  const loadPointsData = async () => {
+    try {
+      setError('');
+      const [participantsResponse, groupsResponse] = await Promise.all([
+        getParticipants(),
+        getGroups(),
+      ]);
+
+      const participantRows = participantsResponse.success
+        ? participantsResponse.data || []
+        : [];
+      const groupRows = groupsResponse.success ? groupsResponse.data || [] : [];
+
+      setParticipants(participantRows);
+      setGroups(groupRows);
+    } catch (err) {
+      debugError('Error loading points data:', err);
+      setError(err.message || t('error_loading_manage_points'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadPointsData();
+  }, []);
+
+  const onRefresh = async () => {
+    setRefreshing(true);
+    await loadPointsData();
+    setRefreshing(false);
+  };
+
+  /**
+   * Submit a points update to the API.
+   * @param {number} points - Points delta.
+   */
+  const handlePointsUpdate = async (points) => {
+    if (!selectedId || !selectedType) {
+      setError(t('select_participant'));
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const response = await updatePoints([
+        {
+          type: selectedType,
+          id: selectedId,
+          points,
+          timestamp: new Date().toISOString(),
+        },
+      ]);
+
+      if (!response.success) {
+        throw new Error(response.message || t('error_loading_data'));
+      }
+
+      debugLog('Points updated:', response.data);
+      await loadPointsData();
+      setCustomPoints('');
+    } catch (err) {
+      debugError('Error updating points:', err);
+      setError(err.message || t('error_loading_manage_points'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleCustomPointsSubmit = () => {
+    const sanitized = SecurityUtils.sanitizeNumber(customPoints, true);
+    const parsed = Number(sanitized);
+
+    if (Number.isNaN(parsed) || parsed === 0) {
+      setError(t('error_loading_data'));
+      return;
+    }
+
+    handlePointsUpdate(parsed);
+  };
+
+  const renderParticipantCard = (participant) => {
+    const isSelected = selectedId === participant.id && selectedType === 'participant';
+    return (
+      <Card
+        key={participant.id}
+        onPress={() => {
+          setSelectedId(participant.id);
+          setSelectedType('participant');
+        }}
+        style={[styles.card, isSelected && styles.cardSelected]}
+      >
+        <View style={styles.cardHeader}>
+          <Text style={styles.cardTitle}>
+            {participant.firstName || participant.first_name}{' '}
+            {participant.lastName || participant.last_name}
+          </Text>
+          <Text style={styles.pointsValue}>
+            {Number(participant.total_points || 0)} {t('points')}
+          </Text>
+        </View>
+        <Text style={styles.cardSubtitle}>
+          {participant.group_name || t('groups')}
+        </Text>
+      </Card>
+    );
+  };
+
+  const renderGroupCard = (group) => {
+    const isSelected = selectedId === group.id && selectedType === 'group';
+    return (
+      <Card
+        key={group.id}
+        onPress={() => {
+          setSelectedId(group.id);
+          setSelectedType('group');
+        }}
+        style={[styles.card, isSelected && styles.cardSelected]}
+      >
+        <View style={styles.cardHeader}>
+          <Text style={styles.cardTitle}>{group.name}</Text>
+          <Text style={styles.pointsValue}>
+            {Number(group.totalPoints || 0)} {t('points')}
+          </Text>
+        </View>
+        <Text style={styles.cardSubtitle}>
+          {t('groups')}
+        </Text>
+      </Card>
+    );
+  };
+
+  if (loading) {
+    return <LoadingSpinner message={t('loading')} />;
+  }
+
+  if (error) {
+    return <ErrorMessage message={error} onRetry={loadPointsData} />;
+  }
+
+  return (
+    <ScrollView
+      style={commonStyles.container}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+    >
+      <View style={styles.header}>
+        <Text style={styles.title}>{t('manage_points')}</Text>
+        <Text style={styles.subtitle}>{t('points')}</Text>
+      </View>
+
+      <View style={styles.toggleRow}>
+        <Button
+          title={t('participants')}
+          variant={viewMode === VIEW_MODES.PARTICIPANTS ? 'primary' : 'secondary'}
+          onPress={() => setViewMode(VIEW_MODES.PARTICIPANTS)}
+          style={styles.toggleButton}
+        />
+        <Button
+          title={t('groups')}
+          variant={viewMode === VIEW_MODES.GROUPS ? 'primary' : 'secondary'}
+          onPress={() => setViewMode(VIEW_MODES.GROUPS)}
+          style={styles.toggleButton}
+        />
+      </View>
+
+      <View style={styles.quickActions}>
+        <Text style={styles.sectionTitle}>{t('points')}</Text>
+        <View style={styles.actionRow}>
+          {CONFIG.UI.POINTS_QUICK_ACTIONS.map((value) => (
+            <Button
+              key={`points-${value}`}
+              title={`${value > 0 ? '+' : ''}${value}`}
+              onPress={() => handlePointsUpdate(value)}
+              disabled={submitting}
+              variant={value > 0 ? 'success' : 'danger'}
+              style={styles.quickButton}
+              size="small"
+            />
+          ))}
+        </View>
+        <View style={styles.customRow}>
+          <TextInput
+            style={styles.input}
+            placeholder={t('points')}
+            keyboardType="numeric"
+            value={customPoints}
+            onChangeText={setCustomPoints}
+          />
+          <Button
+            title={t('update')}
+            onPress={handleCustomPointsSubmit}
+            disabled={submitting}
+            style={styles.updateButton}
+          />
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        {viewMode === VIEW_MODES.PARTICIPANTS ? (
+          Object.entries(groupedParticipants).map(([groupName, members]) => (
+            <View key={groupName} style={styles.groupSection}>
+              <Text style={styles.groupTitle}>{groupName}</Text>
+              {members.map(renderParticipantCard)}
+            </View>
+          ))
+        ) : (
+          groupTotals.map(renderGroupCard)
+        )}
+      </View>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  header: {
+    padding: theme.spacing.lg,
+    paddingBottom: theme.spacing.md,
+  },
+  title: {
+    ...commonStyles.heading2,
+  },
+  subtitle: {
+    ...commonStyles.caption,
+  },
+  toggleRow: {
+    flexDirection: 'row',
+    gap: theme.spacing.sm,
+    paddingHorizontal: theme.spacing.lg,
+    marginBottom: theme.spacing.md,
+  },
+  toggleButton: {
+    flex: 1,
+  },
+  quickActions: {
+    ...commonStyles.card,
+    marginHorizontal: theme.spacing.lg,
+  },
+  sectionTitle: {
+    ...commonStyles.sectionTitle,
+    marginBottom: theme.spacing.sm,
+  },
+  actionRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: theme.spacing.sm,
+    marginBottom: theme.spacing.md,
+  },
+  quickButton: {
+    minWidth: theme.spacing.xxl,
+  },
+  customRow: {
+    flexDirection: 'row',
+    gap: theme.spacing.sm,
+    alignItems: 'center',
+  },
+  input: {
+    ...commonStyles.input,
+    flex: 1,
+  },
+  updateButton: {
+    minWidth: theme.spacing.xxl,
+  },
+  section: {
+    paddingHorizontal: theme.spacing.lg,
+    paddingBottom: theme.spacing.xl,
+  },
+  groupSection: {
+    marginBottom: theme.spacing.lg,
+  },
+  groupTitle: {
+    ...commonStyles.sectionTitle,
+    marginBottom: theme.spacing.sm,
+  },
+  card: {
+    marginBottom: theme.spacing.sm,
+  },
+  cardSelected: {
+    borderWidth: 2,
+    borderColor: theme.colors.primary,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  cardTitle: {
+    ...commonStyles.heading3,
+    flex: 1,
+  },
+  cardSubtitle: {
+    ...commonStyles.caption,
+  },
+  pointsValue: {
+    ...commonStyles.bodyText,
+    fontWeight: theme.fontWeight.semibold,
+  },
+});
+
+export default ManagePointsScreen;

--- a/mobile/src/screens/MedicationScreen.js
+++ b/mobile/src/screens/MedicationScreen.js
@@ -1,0 +1,630 @@
+/**
+ * MedicationScreen
+ *
+ * Mirrors spa/medication_management.js for leaders.
+ * Supports medication planning and dispensing with alerts.
+ */
+
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  RefreshControl,
+  TextInput,
+  TouchableOpacity,
+} from 'react-native';
+import {
+  getMedicationRequirements,
+  getParticipantMedications,
+  getMedicationDistributions,
+  getParticipants,
+  getFicheMedications,
+  saveMedicationRequirement,
+  recordMedicationDistribution,
+  markMedicationDistributionAsGiven,
+} from '../api/api-endpoints';
+import { translate as t } from '../i18n';
+import DateUtils from '../utils/DateUtils';
+import SecurityUtils from '../utils/SecurityUtils';
+import { Button, Card, ErrorMessage, LoadingSpinner } from '../components';
+import theme, { commonStyles } from '../theme';
+import { debugError } from '../utils/DebugUtils';
+
+const TABS = {
+  PLANNING: 'planning',
+  DISPENSING: 'dispensing',
+};
+
+const MedicationScreen = () => {
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState('');
+  const [activeTab, setActiveTab] = useState(TABS.PLANNING);
+  const [requirements, setRequirements] = useState([]);
+  const [participantMedications, setParticipantMedications] = useState([]);
+  const [distributions, setDistributions] = useState([]);
+  const [participants, setParticipants] = useState([]);
+  const [suggestions, setSuggestions] = useState([]);
+  const [editingRequirement, setEditingRequirement] = useState(null);
+  const [requirementForm, setRequirementForm] = useState({
+    medication_name: '',
+    dosage_instructions: '',
+    frequency_text: '',
+    route: '',
+    general_notes: '',
+    start_date: '',
+    end_date: '',
+    participant_id: '',
+  });
+  const [distributionForm, setDistributionForm] = useState({
+    medication_requirement_id: '',
+    scheduled_for: '',
+    activity_name: '',
+    dose_amount: '',
+    dose_unit: '',
+    dose_notes: '',
+  });
+  const [witnessNames, setWitnessNames] = useState({});
+  const [saving, setSaving] = useState(false);
+
+  const requirementOptions = useMemo(() => {
+    return requirements.map((requirement) => ({
+      id: requirement.id,
+      label: requirement.medication_name,
+    }));
+  }, [requirements]);
+
+  /**
+   * Load medication data for planning and dispensing.
+   */
+  const loadMedicationData = async () => {
+    try {
+      setError('');
+      const [
+        requirementsResponse,
+        assignmentsResponse,
+        distributionsResponse,
+        participantsResponse,
+        suggestionsResponse,
+      ] = await Promise.all([
+        getMedicationRequirements(),
+        getParticipantMedications(),
+        getMedicationDistributions({ upcoming_only: true }),
+        getParticipants(),
+        getFicheMedications(),
+      ]);
+
+      setRequirements(
+        requirementsResponse.success ? requirementsResponse.data?.requirements || [] : []
+      );
+      setParticipantMedications(
+        assignmentsResponse.success
+          ? assignmentsResponse.data?.participant_medications || []
+          : []
+      );
+      setDistributions(
+        distributionsResponse.success ? distributionsResponse.data?.distributions || [] : []
+      );
+      setParticipants(
+        participantsResponse.success ? participantsResponse.data || [] : []
+      );
+      setSuggestions(
+        suggestionsResponse.success ? suggestionsResponse.data?.medications || [] : []
+      );
+    } catch (err) {
+      debugError('Error loading medication data:', err);
+      setError(err.message || t('error_loading_data'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadMedicationData();
+  }, []);
+
+  const onRefresh = async () => {
+    setRefreshing(true);
+    await loadMedicationData();
+    setRefreshing(false);
+  };
+
+  const handleSelectRequirement = (requirement) => {
+    setEditingRequirement(requirement);
+    setRequirementForm({
+      medication_name: requirement.medication_name || '',
+      dosage_instructions: requirement.dosage_instructions || '',
+      frequency_text: requirement.frequency_text || '',
+      route: requirement.route || '',
+      general_notes: requirement.general_notes || '',
+      start_date: requirement.start_date || '',
+      end_date: requirement.end_date || '',
+      participant_id: participantMedications.find(
+        (assignment) => assignment.medication_requirement_id === requirement.id
+      )?.participant_id || '',
+    });
+  };
+
+  const handleSaveRequirement = async () => {
+    setSaving(true);
+    try {
+      const payload = {
+        id: editingRequirement?.id,
+        medication_name: SecurityUtils.sanitizeInput(requirementForm.medication_name),
+        dosage_instructions: SecurityUtils.sanitizeInput(requirementForm.dosage_instructions),
+        frequency_text: SecurityUtils.sanitizeInput(requirementForm.frequency_text),
+        route: SecurityUtils.sanitizeInput(requirementForm.route),
+        general_notes: SecurityUtils.sanitizeInput(requirementForm.general_notes),
+        start_date: SecurityUtils.sanitizeInput(requirementForm.start_date),
+        end_date: SecurityUtils.sanitizeInput(requirementForm.end_date),
+        participant_ids: [Number(requirementForm.participant_id)],
+      };
+
+      const response = await saveMedicationRequirement(payload);
+      if (!response.success) {
+        throw new Error(response.message || t('error_loading_data'));
+      }
+
+      setEditingRequirement(null);
+      setRequirementForm({
+        medication_name: '',
+        dosage_instructions: '',
+        frequency_text: '',
+        route: '',
+        general_notes: '',
+        start_date: '',
+        end_date: '',
+        participant_id: '',
+      });
+      await loadMedicationData();
+    } catch (err) {
+      debugError('Error saving medication requirement:', err);
+      setError(err.message || t('error_loading_data'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleScheduleDistribution = async () => {
+    setSaving(true);
+    try {
+      const assignment = participantMedications.find(
+        (item) =>
+          item.medication_requirement_id ===
+          Number(distributionForm.medication_requirement_id)
+      );
+
+      if (!assignment?.participant_id) {
+        throw new Error(t('medication_distribution_fields_missing'));
+      }
+
+      const payload = {
+        medication_requirement_id: Number(distributionForm.medication_requirement_id),
+        participant_ids: [
+          Number(assignment.participant_id),
+        ],
+        scheduled_for: SecurityUtils.sanitizeInput(distributionForm.scheduled_for),
+        activity_name: SecurityUtils.sanitizeInput(distributionForm.activity_name),
+        dose_amount: SecurityUtils.sanitizeNumber(distributionForm.dose_amount, true),
+        dose_unit: SecurityUtils.sanitizeInput(distributionForm.dose_unit),
+        dose_notes: SecurityUtils.sanitizeInput(distributionForm.dose_notes),
+      };
+
+      const response = await recordMedicationDistribution(payload);
+      if (!response.success) {
+        throw new Error(response.message || t('medication_distribution_fields_missing'));
+      }
+
+      setDistributionForm({
+        medication_requirement_id: '',
+        scheduled_for: '',
+        activity_name: '',
+        dose_amount: '',
+        dose_unit: '',
+        dose_notes: '',
+      });
+      await loadMedicationData();
+    } catch (err) {
+      debugError('Error scheduling distribution:', err);
+      setError(err.message || t('medication_distribution_fields_missing'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleMarkGiven = async (distributionId) => {
+    setSaving(true);
+    try {
+      const response = await markMedicationDistributionAsGiven(distributionId, {
+        status: 'given',
+        administered_at: new Date().toISOString(),
+        witness_name: SecurityUtils.sanitizeInput(witnessNames[distributionId] || ''),
+      });
+
+      if (!response.success) {
+        throw new Error(response.message || t('medication_mark_given'));
+      }
+
+      await loadMedicationData();
+    } catch (err) {
+      debugError('Error marking medication given:', err);
+      setError(err.message || t('medication_mark_given'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return <LoadingSpinner message={t('loading')} />;
+  }
+
+  if (error) {
+    return <ErrorMessage message={error} onRetry={loadMedicationData} />;
+  }
+
+  return (
+    <ScrollView
+      style={commonStyles.container}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+    >
+      <View style={styles.header}>
+        <Text style={styles.title}>{t('medication_management_title')}</Text>
+        <Text style={styles.subtitle}>{t('medication_management_description')}</Text>
+      </View>
+
+      <View style={styles.tabRow}>
+        <Button
+          title={t('medication_planning_tab')}
+          variant={activeTab === TABS.PLANNING ? 'primary' : 'secondary'}
+          onPress={() => setActiveTab(TABS.PLANNING)}
+          style={styles.tabButton}
+        />
+        <Button
+          title={t('medication_dispensing_tab')}
+          variant={activeTab === TABS.DISPENSING ? 'primary' : 'secondary'}
+          onPress={() => setActiveTab(TABS.DISPENSING)}
+          style={styles.tabButton}
+        />
+      </View>
+
+      {activeTab === TABS.PLANNING ? (
+        <View style={styles.section}>
+          <Card style={styles.card}>
+            <Text style={styles.sectionTitle}>{t('medication_requirement_form_title')}</Text>
+            <TextInput
+              style={styles.input}
+              placeholder={t('medication_name_label')}
+              value={requirementForm.medication_name}
+              onChangeText={(value) =>
+                setRequirementForm((prev) => ({ ...prev, medication_name: value }))
+              }
+            />
+            <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+              <View style={styles.suggestionRow}>
+                {suggestions.map((name) => (
+                  <TouchableOpacity
+                    key={`suggestion-${name}`}
+                    style={styles.suggestionChip}
+                    onPress={() =>
+                      setRequirementForm((prev) => ({ ...prev, medication_name: name }))
+                    }
+                  >
+                    <Text style={styles.suggestionText}>{name}</Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
+            </ScrollView>
+            <TextInput
+              style={styles.input}
+              placeholder={t('medication_dosage_label')}
+              value={requirementForm.dosage_instructions}
+              onChangeText={(value) =>
+                setRequirementForm((prev) => ({ ...prev, dosage_instructions: value }))
+              }
+            />
+            <TextInput
+              style={styles.input}
+              placeholder={t('medication_frequency')}
+              value={requirementForm.frequency_text}
+              onChangeText={(value) =>
+                setRequirementForm((prev) => ({ ...prev, frequency_text: value }))
+              }
+            />
+            <TextInput
+              style={styles.input}
+              placeholder={t('medication_route_label')}
+              value={requirementForm.route}
+              onChangeText={(value) =>
+                setRequirementForm((prev) => ({ ...prev, route: value }))
+              }
+            />
+            <TextInput
+              style={styles.input}
+              placeholder={t('medication_start_date_label')}
+              value={requirementForm.start_date}
+              onChangeText={(value) =>
+                setRequirementForm((prev) => ({ ...prev, start_date: value }))
+              }
+            />
+            <TextInput
+              style={styles.input}
+              placeholder={t('medication_end_date_label')}
+              value={requirementForm.end_date}
+              onChangeText={(value) =>
+                setRequirementForm((prev) => ({ ...prev, end_date: value }))
+              }
+            />
+            <Text style={styles.sectionTitle}>{t('select_participant')}</Text>
+            <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+              <View style={styles.participantRow}>
+                {participants.map((participant) => (
+                  <TouchableOpacity
+                    key={`participant-${participant.id}`}
+                    style={[
+                      styles.participantChip,
+                      Number(requirementForm.participant_id) === participant.id &&
+                        styles.participantChipActive,
+                    ]}
+                    onPress={() =>
+                      setRequirementForm((prev) => ({
+                        ...prev,
+                        participant_id: String(participant.id),
+                      }))
+                    }
+                  >
+                    <Text
+                      style={[
+                        styles.participantText,
+                        Number(requirementForm.participant_id) === participant.id &&
+                          styles.participantTextActive,
+                      ]}
+                    >
+                      {participant.firstName || participant.first_name}{' '}
+                      {participant.lastName || participant.last_name}
+                    </Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
+            </ScrollView>
+            <TextInput
+              style={[styles.input, styles.multilineInput]}
+              placeholder={t('medication_general_notes_label')}
+              value={requirementForm.general_notes}
+              onChangeText={(value) =>
+                setRequirementForm((prev) => ({ ...prev, general_notes: value }))
+              }
+              multiline
+            />
+            <Button title={t('medication_save_requirement')} onPress={handleSaveRequirement} />
+          </Card>
+
+          <Card style={styles.card}>
+            <Text style={styles.sectionTitle}>{t('medication_existing_requirements_title')}</Text>
+            {requirements.length === 0 ? (
+              <Text style={styles.emptyText}>{t('medication_requirements_empty')}</Text>
+            ) : (
+              requirements.map((requirement) => (
+                <TouchableOpacity
+                  key={`requirement-${requirement.id}`}
+                  onPress={() => handleSelectRequirement(requirement)}
+                  style={styles.requirementRow}
+                >
+                  <Text style={styles.requirementName}>{requirement.medication_name}</Text>
+                  <Text style={styles.captionText}>
+                    {requirement.frequency_text || t('medication_frequency')}
+                  </Text>
+                </TouchableOpacity>
+              ))
+            )}
+          </Card>
+        </View>
+      ) : (
+        <View style={styles.section}>
+          <Card style={styles.card}>
+            <Text style={styles.sectionTitle}>{t('medication_schedule_section_title')}</Text>
+            <TextInput
+              style={styles.input}
+              placeholder={t('medication_schedule_date')}
+              value={distributionForm.scheduled_for}
+              onChangeText={(value) =>
+                setDistributionForm((prev) => ({ ...prev, scheduled_for: value }))
+              }
+            />
+            <Text style={styles.sectionTitle}>{t('medication')}</Text>
+            <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+              <View style={styles.requirementRow}>
+                {requirementOptions.map((requirement) => (
+                  <TouchableOpacity
+                    key={`dist-${requirement.id}`}
+                    style={[
+                      styles.participantChip,
+                      Number(distributionForm.medication_requirement_id) === requirement.id &&
+                        styles.participantChipActive,
+                    ]}
+                    onPress={() =>
+                      setDistributionForm((prev) => ({
+                        ...prev,
+                        medication_requirement_id: String(requirement.id),
+                      }))
+                    }
+                  >
+                    <Text
+                      style={[
+                        styles.participantText,
+                        Number(distributionForm.medication_requirement_id) === requirement.id &&
+                          styles.participantTextActive,
+                      ]}
+                    >
+                      {requirement.label}
+                    </Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
+            </ScrollView>
+            <TextInput
+              style={styles.input}
+              placeholder={t('medication_schedule_activity')}
+              value={distributionForm.activity_name}
+              onChangeText={(value) =>
+                setDistributionForm((prev) => ({ ...prev, activity_name: value }))
+              }
+            />
+            <TextInput
+              style={styles.input}
+              placeholder={t('medication_default_dose')}
+              value={distributionForm.dose_amount}
+              onChangeText={(value) =>
+                setDistributionForm((prev) => ({ ...prev, dose_amount: value }))
+              }
+            />
+            <TextInput
+              style={styles.input}
+              placeholder={t('medication_default_frequency')}
+              value={distributionForm.dose_unit}
+              onChangeText={(value) =>
+                setDistributionForm((prev) => ({ ...prev, dose_unit: value }))
+              }
+            />
+            <TextInput
+              style={styles.input}
+              placeholder={t('medication_schedule_notes')}
+              value={distributionForm.dose_notes}
+              onChangeText={(value) =>
+                setDistributionForm((prev) => ({ ...prev, dose_notes: value }))
+              }
+            />
+            <Button title={t('medication_schedule_button')} onPress={handleScheduleDistribution} />
+          </Card>
+
+          <Card style={styles.card}>
+            <Text style={styles.sectionTitle}>{t('medication_alerts_heading')}</Text>
+            {distributions.length === 0 ? (
+              <Text style={styles.emptyText}>{t('medication_alerts_empty')}</Text>
+            ) : (
+              distributions.map((distribution) => (
+                <View key={`dist-${distribution.id}`} style={styles.alertRow}>
+                  <Text style={styles.requirementName}>
+                    {DateUtils.formatDateTime(distribution.scheduled_for)}
+                  </Text>
+                  <Text style={styles.captionText}>
+                    {t('medication_default_dose')}: {distribution.dose_amount || '-'}{' '}
+                    {distribution.dose_unit || ''}
+                  </Text>
+                  <TextInput
+                    style={styles.input}
+                    placeholder={t('medication_witness_label')}
+                    value={witnessNames[distribution.id] || ''}
+                    onChangeText={(value) =>
+                      setWitnessNames((prev) => ({ ...prev, [distribution.id]: value }))
+                    }
+                  />
+                  <Button
+                    title={t('medication_mark_given')}
+                    onPress={() => handleMarkGiven(distribution.id)}
+                    disabled={saving}
+                  />
+                </View>
+              ))
+            )}
+          </Card>
+        </View>
+      )}
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  header: {
+    padding: theme.spacing.lg,
+  },
+  title: {
+    ...commonStyles.heading2,
+  },
+  subtitle: {
+    ...commonStyles.caption,
+  },
+  tabRow: {
+    flexDirection: 'row',
+    gap: theme.spacing.sm,
+    paddingHorizontal: theme.spacing.lg,
+    marginBottom: theme.spacing.md,
+  },
+  tabButton: {
+    flex: 1,
+  },
+  section: {
+    paddingHorizontal: theme.spacing.lg,
+    paddingBottom: theme.spacing.xl,
+  },
+  card: {
+    marginBottom: theme.spacing.md,
+  },
+  sectionTitle: {
+    ...commonStyles.sectionTitle,
+    marginBottom: theme.spacing.sm,
+  },
+  input: {
+    ...commonStyles.input,
+    marginBottom: theme.spacing.sm,
+  },
+  multilineInput: {
+    minHeight: theme.spacing.xxl,
+  },
+  suggestionRow: {
+    flexDirection: 'row',
+    gap: theme.spacing.sm,
+    marginBottom: theme.spacing.sm,
+  },
+  suggestionChip: {
+    paddingVertical: theme.spacing.xs,
+    paddingHorizontal: theme.spacing.sm,
+    borderRadius: theme.borderRadius.full,
+    backgroundColor: theme.colors.secondary,
+  },
+  suggestionText: {
+    ...commonStyles.caption,
+  },
+  participantRow: {
+    flexDirection: 'row',
+    gap: theme.spacing.sm,
+    marginBottom: theme.spacing.sm,
+  },
+  participantChip: {
+    paddingVertical: theme.spacing.xs,
+    paddingHorizontal: theme.spacing.sm,
+    borderRadius: theme.borderRadius.full,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.surface,
+  },
+  participantChipActive: {
+    backgroundColor: theme.colors.primary,
+    borderColor: theme.colors.primary,
+  },
+  participantText: {
+    ...commonStyles.caption,
+  },
+  participantTextActive: {
+    color: theme.colors.surface,
+  },
+  requirementRow: {
+    marginBottom: theme.spacing.sm,
+  },
+  requirementName: {
+    ...commonStyles.heading3,
+  },
+  captionText: {
+    ...commonStyles.caption,
+  },
+  emptyText: {
+    ...commonStyles.bodyText,
+    textAlign: 'center',
+  },
+  alertRow: {
+    marginBottom: theme.spacing.lg,
+  },
+});
+
+export default MedicationScreen;

--- a/mobile/src/screens/MeetingPreparationScreen.js
+++ b/mobile/src/screens/MeetingPreparationScreen.js
@@ -1,0 +1,549 @@
+/**
+ * MeetingPreparationScreen
+ *
+ * Mirrors spa/preparation_reunions.js for leaders.
+ * Allows creating and updating meeting preparation details.
+ */
+
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  RefreshControl,
+  TextInput,
+  TouchableOpacity,
+} from 'react-native';
+import {
+  getReunionDates,
+  getReunionPreparation,
+  saveReunionPreparation,
+  getAnimateurs,
+  getMeetingActivities,
+} from '../api/api-endpoints';
+import { translate as t } from '../i18n';
+import DateUtils from '../utils/DateUtils';
+import SecurityUtils from '../utils/SecurityUtils';
+import { Button, Card, ErrorMessage, LoadingSpinner } from '../components';
+import theme, { commonStyles } from '../theme';
+import { debugError } from '../utils/DebugUtils';
+
+const EMPTY_ACTIVITY = {
+  time: '',
+  duration: '',
+  activity: '',
+  responsable: '',
+  materiel: '',
+};
+
+/**
+ * Normalize meeting preparation payload.
+ * @param {object} preparation - Meeting preparation data.
+ * @returns {object} Normalized data.
+ */
+const normalizePreparation = (preparation) => {
+  if (!preparation) {
+    return null;
+  }
+
+  return {
+    date: preparation.date || '',
+    animateur_responsable: preparation.animateur_responsable || '',
+    youth_of_honor: preparation.youth_of_honor || [],
+    endroit: preparation.endroit || '',
+    notes: preparation.notes || '',
+    activities: preparation.activities || [],
+  };
+};
+
+const MeetingPreparationScreen = () => {
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState('');
+  const [availableDates, setAvailableDates] = useState([]);
+  const [selectedDate, setSelectedDate] = useState('');
+  const [customDate, setCustomDate] = useState('');
+  const [animateurs, setAnimateurs] = useState([]);
+  const [activityTemplates, setActivityTemplates] = useState([]);
+  const [formData, setFormData] = useState({
+    date: '',
+    animateur_responsable: '',
+    youth_of_honor: '',
+    endroit: '',
+    notes: '',
+  });
+  const [activities, setActivities] = useState([EMPTY_ACTIVITY]);
+  const [saving, setSaving] = useState(false);
+
+  const honorList = useMemo(() => {
+    return formData.youth_of_honor
+      ? formData.youth_of_honor.split(',').map((name) => name.trim()).filter(Boolean)
+      : [];
+  }, [formData.youth_of_honor]);
+
+  /**
+   * Load preparation data for a meeting date.
+   * @param {string} date - Meeting date.
+   */
+  const loadPreparation = async (date) => {
+    try {
+      const response = await getReunionPreparation(date);
+      if (response.success && response.preparation) {
+        const normalized = normalizePreparation(response.preparation);
+        setFormData({
+          date: normalized.date,
+          animateur_responsable: normalized.animateur_responsable,
+          youth_of_honor: normalized.youth_of_honor.join(', '),
+          endroit: normalized.endroit,
+          notes: normalized.notes,
+        });
+        setActivities(
+          normalized.activities.length > 0 ? normalized.activities : [EMPTY_ACTIVITY]
+        );
+      } else {
+        setFormData((prev) => ({ ...prev, date }));
+        setActivities([EMPTY_ACTIVITY]);
+      }
+    } catch (err) {
+      debugError('Error loading meeting preparation:', err);
+      setError(err.message || t('error_loading_preparation_reunions'));
+    }
+  };
+
+  /**
+   * Load initial meeting preparation data and metadata.
+   */
+  const loadMeetingData = async () => {
+    try {
+      setError('');
+      const [datesResponse, animateursResponse, activitiesResponse] = await Promise.all([
+        getReunionDates(),
+        getAnimateurs(),
+        getMeetingActivities(),
+      ]);
+
+      const dates = datesResponse.success
+        ? datesResponse.dates || datesResponse.data || []
+        : [];
+      const today = DateUtils.formatDate(new Date());
+      const uniqueDates = Array.from(new Set([today, ...dates]));
+      setAvailableDates(uniqueDates);
+      const initialDate = selectedDate || uniqueDates[0];
+      setSelectedDate(initialDate);
+
+      setAnimateurs(
+        animateursResponse.success
+          ? animateursResponse.animateurs || animateursResponse.data || []
+          : []
+      );
+      setActivityTemplates(activitiesResponse.success ? activitiesResponse.data || [] : []);
+
+      await loadPreparation(initialDate);
+    } catch (err) {
+      debugError('Error loading meeting data:', err);
+      setError(err.message || t('error_loading_preparation_reunions'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadMeetingData();
+  }, []);
+
+  useEffect(() => {
+    if (selectedDate) {
+      loadPreparation(selectedDate);
+    }
+  }, [selectedDate]);
+
+  const onRefresh = async () => {
+    setRefreshing(true);
+    await loadMeetingData();
+    setRefreshing(false);
+  };
+
+  /**
+   * Update activity entry in state.
+   * @param {number} index - Activity index.
+   * @param {string} key - Field name.
+   * @param {string} value - Field value.
+   */
+  const updateActivity = (index, key, value) => {
+    setActivities((prev) => {
+      const next = [...prev];
+      next[index] = { ...next[index], [key]: value };
+      return next;
+    });
+  };
+
+  const addActivity = () => {
+    setActivities((prev) => [...prev, EMPTY_ACTIVITY]);
+  };
+
+  const removeActivity = (index) => {
+    setActivities((prev) => prev.filter((_, idx) => idx !== index));
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const payload = {
+        date: SecurityUtils.sanitizeInput(formData.date),
+        animateur_responsable: SecurityUtils.sanitizeInput(formData.animateur_responsable),
+        youth_of_honor: honorList.map((name) => SecurityUtils.sanitizeInput(name)),
+        endroit: SecurityUtils.sanitizeInput(formData.endroit),
+        notes: SecurityUtils.sanitizeInput(formData.notes),
+        activities: activities.map((activity) => ({
+          time: SecurityUtils.sanitizeInput(activity.time),
+          duration: SecurityUtils.sanitizeInput(activity.duration),
+          activity: SecurityUtils.sanitizeInput(activity.activity),
+          responsable: SecurityUtils.sanitizeInput(activity.responsable),
+          materiel: SecurityUtils.sanitizeInput(activity.materiel),
+        })),
+      };
+
+      const response = await saveReunionPreparation(payload);
+      if (!response.success) {
+        throw new Error(response.message || t('error_saving_reunion_preparation'));
+      }
+
+      setSelectedDate(payload.date);
+      await loadMeetingData();
+    } catch (err) {
+      debugError('Error saving meeting preparation:', err);
+      setError(err.message || t('error_saving_reunion_preparation'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDateSubmit = () => {
+    const sanitized = SecurityUtils.sanitizeInput(customDate);
+    if (!sanitized) {
+      setError(t('error_loading_meeting_data'));
+      return;
+    }
+
+    setSelectedDate(sanitized);
+    setCustomDate('');
+  };
+
+  if (loading) {
+    return <LoadingSpinner message={t('loading')} />;
+  }
+
+  if (error) {
+    return <ErrorMessage message={error} onRetry={loadMeetingData} />;
+  }
+
+  return (
+    <ScrollView
+      style={commonStyles.container}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+    >
+      <View style={styles.header}>
+        <Text style={styles.title}>{t('preparation_reunions')}</Text>
+        <Text style={styles.subtitle}>{t('meeting')}</Text>
+      </View>
+
+      <View style={styles.dateSection}>
+        <Text style={styles.sectionTitle}>{t('select_date')}</Text>
+        <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+          <View style={styles.dateChips}>
+            {availableDates.map((date) => (
+              <TouchableOpacity
+                key={date}
+                onPress={() => setSelectedDate(date)}
+                style={[
+                  styles.dateChip,
+                  selectedDate === date && styles.dateChipActive,
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.dateChipText,
+                    selectedDate === date && styles.dateChipTextActive,
+                  ]}
+                >
+                  {DateUtils.formatDate(date)}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        </ScrollView>
+        <View style={styles.customDateRow}>
+          <TextInput
+            style={styles.input}
+            placeholder={t('date')}
+            value={customDate}
+            onChangeText={setCustomDate}
+          />
+          <Button title={t('update')} onPress={handleDateSubmit} />
+        </View>
+      </View>
+
+      <View style={styles.formSection}>
+        <Card style={styles.card}>
+          <Text style={styles.sectionTitle}>{t('meeting')}</Text>
+          <TextInput
+            style={styles.input}
+            placeholder={t('date')}
+            value={formData.date}
+            onChangeText={(value) => setFormData((prev) => ({ ...prev, date: value }))}
+          />
+          <TextInput
+            style={styles.input}
+            placeholder={t('animateur_responsable')}
+            value={formData.animateur_responsable}
+            onChangeText={(value) =>
+              setFormData((prev) => ({ ...prev, animateur_responsable: value }))
+            }
+          />
+          <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+            <View style={styles.animateurRow}>
+              {animateurs.map((animateur) => (
+                <TouchableOpacity
+                  key={animateur.id}
+                  style={[
+                    styles.animateurChip,
+                    formData.animateur_responsable === animateur.full_name &&
+                      styles.animateurChipActive,
+                  ]}
+                  onPress={() =>
+                    setFormData((prev) => ({
+                      ...prev,
+                      animateur_responsable: animateur.full_name,
+                    }))
+                  }
+                >
+                  <Text
+                    style={[
+                      styles.animateurChipText,
+                      formData.animateur_responsable === animateur.full_name &&
+                        styles.animateurChipTextActive,
+                    ]}
+                  >
+                    {animateur.full_name}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          </ScrollView>
+          <TextInput
+            style={styles.input}
+            placeholder={t('meeting_location_placeholder')}
+            value={formData.endroit}
+            onChangeText={(value) => setFormData((prev) => ({ ...prev, endroit: value }))}
+          />
+          <TextInput
+            style={styles.input}
+            placeholder={t('youth_of_honor')}
+            value={formData.youth_of_honor}
+            onChangeText={(value) =>
+              setFormData((prev) => ({ ...prev, youth_of_honor: value }))
+            }
+          />
+          <TextInput
+            style={[styles.input, styles.multilineInput]}
+            placeholder={t('notes')}
+            multiline
+            value={formData.notes}
+            onChangeText={(value) => setFormData((prev) => ({ ...prev, notes: value }))}
+          />
+        </Card>
+      </View>
+
+      <View style={styles.activitiesSection}>
+        <Text style={styles.sectionTitle}>{t('activite_responsable_materiel')}</Text>
+        {activities.map((activity, index) => (
+          <Card key={`activity-${index}`} style={styles.activityCard}>
+            <Text style={styles.activityTitle}>
+              {t('activity')} #{index + 1}
+            </Text>
+            <View style={styles.activityRow}>
+              <TextInput
+                style={[styles.input, styles.halfInput]}
+                placeholder={t('meeting_time')}
+                value={activity.time}
+                onChangeText={(value) => updateActivity(index, 'time', value)}
+              />
+              <TextInput
+                style={[styles.input, styles.halfInput]}
+                placeholder={t('heure_et_duree')}
+                value={activity.duration}
+                onChangeText={(value) => updateActivity(index, 'duration', value)}
+              />
+            </View>
+            <TextInput
+              style={styles.input}
+              placeholder={t('activity')}
+              value={activity.activity}
+              onChangeText={(value) => updateActivity(index, 'activity', value)}
+            />
+            <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+              <View style={styles.templateRow}>
+                {activityTemplates.map((template) => (
+                  <TouchableOpacity
+                    key={`template-${template.id}-${index}`}
+                    style={styles.templateChip}
+                    onPress={() => updateActivity(index, 'activity', template.activity)}
+                  >
+                    <Text style={styles.templateChipText}>{template.activity}</Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
+            </ScrollView>
+            <TextInput
+              style={styles.input}
+              placeholder={t('animateur_responsable')}
+              value={activity.responsable}
+              onChangeText={(value) => updateActivity(index, 'responsable', value)}
+            />
+            <TextInput
+              style={styles.input}
+              placeholder={t('materiel')}
+              value={activity.materiel}
+              onChangeText={(value) => updateActivity(index, 'materiel', value)}
+            />
+            <Button
+              title={t('delete')}
+              variant="danger"
+              onPress={() => removeActivity(index)}
+              disabled={activities.length === 1}
+            />
+          </Card>
+        ))}
+        <Button title={t('Add')} onPress={addActivity} variant="secondary" />
+      </View>
+
+      <View style={styles.saveSection}>
+        <Button title={t('save')} onPress={handleSave} loading={saving} />
+      </View>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  header: {
+    padding: theme.spacing.lg,
+  },
+  title: {
+    ...commonStyles.heading2,
+  },
+  subtitle: {
+    ...commonStyles.caption,
+  },
+  sectionTitle: {
+    ...commonStyles.sectionTitle,
+    marginBottom: theme.spacing.sm,
+  },
+  dateSection: {
+    paddingHorizontal: theme.spacing.lg,
+    paddingBottom: theme.spacing.md,
+  },
+  dateChips: {
+    flexDirection: 'row',
+    gap: theme.spacing.sm,
+    marginBottom: theme.spacing.md,
+  },
+  dateChip: {
+    paddingVertical: theme.spacing.sm,
+    paddingHorizontal: theme.spacing.md,
+    borderRadius: theme.borderRadius.full,
+    backgroundColor: theme.colors.surface,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+  },
+  dateChipActive: {
+    backgroundColor: theme.colors.primary,
+    borderColor: theme.colors.primary,
+  },
+  dateChipText: {
+    ...commonStyles.caption,
+  },
+  dateChipTextActive: {
+    color: theme.colors.surface,
+  },
+  customDateRow: {
+    flexDirection: 'row',
+    gap: theme.spacing.sm,
+    alignItems: 'center',
+  },
+  input: {
+    ...commonStyles.input,
+    marginBottom: theme.spacing.sm,
+  },
+  multilineInput: {
+    minHeight: theme.spacing.xxl,
+  },
+  formSection: {
+    paddingHorizontal: theme.spacing.lg,
+    marginBottom: theme.spacing.md,
+  },
+  card: {
+    marginBottom: theme.spacing.md,
+  },
+  animateurRow: {
+    flexDirection: 'row',
+    gap: theme.spacing.sm,
+    marginBottom: theme.spacing.sm,
+  },
+  animateurChip: {
+    paddingVertical: theme.spacing.xs,
+    paddingHorizontal: theme.spacing.sm,
+    borderRadius: theme.borderRadius.full,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.surface,
+  },
+  animateurChipActive: {
+    backgroundColor: theme.colors.primary,
+    borderColor: theme.colors.primary,
+  },
+  animateurChipText: {
+    ...commonStyles.caption,
+  },
+  animateurChipTextActive: {
+    color: theme.colors.surface,
+  },
+  activitiesSection: {
+    paddingHorizontal: theme.spacing.lg,
+    marginBottom: theme.spacing.md,
+  },
+  activityCard: {
+    marginBottom: theme.spacing.md,
+  },
+  activityTitle: {
+    ...commonStyles.heading3,
+    marginBottom: theme.spacing.sm,
+  },
+  activityRow: {
+    flexDirection: 'row',
+    gap: theme.spacing.sm,
+  },
+  halfInput: {
+    flex: 1,
+  },
+  templateRow: {
+    flexDirection: 'row',
+    gap: theme.spacing.sm,
+    marginBottom: theme.spacing.sm,
+  },
+  templateChip: {
+    paddingVertical: theme.spacing.xs,
+    paddingHorizontal: theme.spacing.sm,
+    borderRadius: theme.borderRadius.full,
+    backgroundColor: theme.colors.secondary,
+  },
+  templateChipText: {
+    ...commonStyles.caption,
+  },
+  saveSection: {
+    paddingHorizontal: theme.spacing.lg,
+    paddingBottom: theme.spacing.xl,
+  },
+});
+
+export default MeetingPreparationScreen;

--- a/mobile/src/screens/NextMeetingScreen.js
+++ b/mobile/src/screens/NextMeetingScreen.js
@@ -1,0 +1,171 @@
+/**
+ * NextMeetingScreen
+ *
+ * Mirrors spa/upcoming_meeting.js for leaders.
+ * Displays the next scheduled meeting preparation details.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, ScrollView, RefreshControl } from 'react-native';
+import { getNextMeetingInfo } from '../api/api-endpoints';
+import { translate as t } from '../i18n';
+import DateUtils from '../utils/DateUtils';
+import { Card, ErrorMessage, LoadingSpinner } from '../components';
+import theme, { commonStyles } from '../theme';
+import { debugError } from '../utils/DebugUtils';
+
+const NextMeetingScreen = () => {
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState('');
+  const [meeting, setMeeting] = useState(null);
+
+  /**
+   * Load the next meeting information.
+   */
+  const loadNextMeeting = async () => {
+    try {
+      setError('');
+      const response = await getNextMeetingInfo();
+      if (response.success) {
+        setMeeting(response.meeting || null);
+      } else {
+        setMeeting(null);
+      }
+    } catch (err) {
+      debugError('Error loading next meeting info:', err);
+      setError(err.message || t('error_loading_upcoming_meeting'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadNextMeeting();
+  }, []);
+
+  const onRefresh = async () => {
+    setRefreshing(true);
+    await loadNextMeeting();
+    setRefreshing(false);
+  };
+
+  if (loading) {
+    return <LoadingSpinner message={t('loading')} />;
+  }
+
+  if (error) {
+    return <ErrorMessage message={error} onRetry={loadNextMeeting} />;
+  }
+
+  return (
+    <ScrollView
+      style={commonStyles.container}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+    >
+      <View style={styles.header}>
+        <Text style={styles.title}>{t('next_meeting')}</Text>
+        <Text style={styles.subtitle}>{t('upcoming_meeting')}</Text>
+      </View>
+
+      {meeting ? (
+        <View style={styles.content}>
+          <Card style={styles.card}>
+            <Text style={styles.sectionTitle}>{t('meeting_date_label')}</Text>
+            <Text style={styles.valueText}>{DateUtils.formatDate(meeting.date)}</Text>
+          </Card>
+
+          <Card style={styles.card}>
+            <Text style={styles.sectionTitle}>{t('meeting_location')}</Text>
+            <Text style={styles.valueText}>{meeting.endroit || t('meeting_location')}</Text>
+          </Card>
+
+          <Card style={styles.card}>
+            <Text style={styles.sectionTitle}>{t('animateur_responsable')}</Text>
+            <Text style={styles.valueText}>
+              {meeting.animateur_responsable || t('animateur_responsable')}
+            </Text>
+          </Card>
+
+          <Card style={styles.card}>
+            <Text style={styles.sectionTitle}>{t('youth_of_honor')}</Text>
+            {meeting.youth_of_honor?.length ? (
+              meeting.youth_of_honor.map((name, index) => (
+                <Text key={`honor-${index}`} style={styles.valueText}>
+                  • {name}
+                </Text>
+              ))
+            ) : (
+              <Text style={styles.valueText}>{t('no_honors_on_this_date')}</Text>
+            )}
+          </Card>
+
+          {meeting.activities?.length ? (
+            <Card style={styles.card}>
+              <Text style={styles.sectionTitle}>{t('activities')}</Text>
+              {meeting.activities.map((activity, index) => (
+                <View key={`activity-${index}`} style={styles.activityRow}>
+                  <Text style={styles.valueText}>
+                    {activity.time} · {activity.activity || t('activity')}
+                  </Text>
+                  {activity.responsable ? (
+                    <Text style={styles.captionText}>{activity.responsable}</Text>
+                  ) : null}
+                </View>
+              ))}
+            </Card>
+          ) : null}
+
+          {meeting.notes ? (
+            <Card style={styles.card}>
+              <Text style={styles.sectionTitle}>{t('notes')}</Text>
+              <Text style={styles.valueText}>{meeting.notes}</Text>
+            </Card>
+          ) : null}
+        </View>
+      ) : (
+        <Card style={styles.card}>
+          <Text style={styles.emptyText}>{t('no_upcoming_meeting')}</Text>
+        </Card>
+      )}
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  header: {
+    padding: theme.spacing.lg,
+  },
+  title: {
+    ...commonStyles.heading2,
+  },
+  subtitle: {
+    ...commonStyles.caption,
+  },
+  content: {
+    paddingHorizontal: theme.spacing.lg,
+    paddingBottom: theme.spacing.xl,
+  },
+  card: {
+    marginBottom: theme.spacing.md,
+  },
+  sectionTitle: {
+    ...commonStyles.sectionTitle,
+    marginBottom: theme.spacing.sm,
+  },
+  valueText: {
+    ...commonStyles.bodyText,
+  },
+  captionText: {
+    ...commonStyles.caption,
+  },
+  activityRow: {
+    marginBottom: theme.spacing.sm,
+  },
+  emptyText: {
+    ...commonStyles.bodyText,
+    textAlign: 'center',
+  },
+});
+
+export default NextMeetingScreen;

--- a/mobile/src/screens/index.js
+++ b/mobile/src/screens/index.js
@@ -15,6 +15,12 @@ export { default as DistrictDashboardScreen } from './DistrictDashboardScreen';
 export { default as ParticipantsScreen } from './ParticipantsScreen';
 export { default as ActivitiesScreen } from './ActivitiesScreen';
 export { default as SettingsScreen } from './SettingsScreen';
+export { default as ManagePointsScreen } from './ManagePointsScreen';
+export { default as AttendanceScreen } from './AttendanceScreen';
+export { default as MeetingPreparationScreen } from './MeetingPreparationScreen';
+export { default as NextMeetingScreen } from './NextMeetingScreen';
+export { default as HonorsScreen } from './HonorsScreen';
+export { default as MedicationScreen } from './MedicationScreen';
 
 // Detail screens
 export { default as ParticipantDetailScreen } from './ParticipantDetailScreen';

--- a/mobile/src/utils/DebugUtils.js
+++ b/mobile/src/utils/DebugUtils.js
@@ -1,0 +1,58 @@
+/**
+ * Debug Utilities for Wampums React Native App
+ *
+ * Provides gated logging helpers that respect CONFIG.FEATURES.DEBUG_LOGGING.
+ */
+
+import CONFIG from '../config';
+
+/**
+ * Log debug information when debug logging is enabled.
+ * @param {...any} args - Values to log.
+ */
+export const debugLog = (...args) => {
+  if (CONFIG.FEATURES.DEBUG_LOGGING) {
+    // eslint-disable-next-line no-console
+    console.log('[Debug]', ...args);
+  }
+};
+
+/**
+ * Log debug warnings when debug logging is enabled.
+ * @param {...any} args - Values to log.
+ */
+export const debugWarn = (...args) => {
+  if (CONFIG.FEATURES.DEBUG_LOGGING) {
+    // eslint-disable-next-line no-console
+    console.warn('[Debug]', ...args);
+  }
+};
+
+/**
+ * Log debug errors when debug logging is enabled.
+ * @param {...any} args - Values to log.
+ */
+export const debugError = (...args) => {
+  if (CONFIG.FEATURES.DEBUG_LOGGING) {
+    // eslint-disable-next-line no-console
+    console.error('[Debug]', ...args);
+  }
+};
+
+/**
+ * Log debug info when debug logging is enabled.
+ * @param {...any} args - Values to log.
+ */
+export const debugInfo = (...args) => {
+  if (CONFIG.FEATURES.DEBUG_LOGGING) {
+    // eslint-disable-next-line no-console
+    console.info('[Debug]', ...args);
+  }
+};
+
+export default {
+  debugLog,
+  debugWarn,
+  debugError,
+  debugInfo,
+};

--- a/mobile/src/utils/index.js
+++ b/mobile/src/utils/index.js
@@ -10,3 +10,4 @@ export { default as DateUtils } from './DateUtils';
 export { default as NumberUtils } from './NumberUtils';
 export { default as CacheManager } from './CacheManager';
 export { default as PermissionUtils } from './PermissionUtils';
+export { default as DebugUtils } from './DebugUtils';


### PR DESCRIPTION
### Motivation
- Provide leaders on mobile the same management workflows available in the web SPA (points, attendance, meeting preparation/next meeting, honors and medication). 
- Surface quick, tile-based navigation from the leader dashboard for easier access to leader tools. 
- Reuse existing backend endpoints and cache/network behavior by wiring legacy and v1 API calls into the mobile client. 
- Add small developer ergonomics improvements (gated debug logging) to aid troubleshooting on-device.

### Description
- Added new React Native screens under `mobile/src/screens/` for `ManagePoints`, `Attendance`, `MeetingPreparation`, `NextMeeting`, `Honors`, and `Medication` with UI, state handling, and API integration. 
- Extended the mobile API client and exports in `mobile/src/api/api-endpoints.js` and new config constants in `mobile/src/config/index.js` to cover legacy endpoints (points, honors, reunion/meeting, medication) and added medication helper functions. 
- Wired screens into navigation by updating `mobile/src/screens/index.js` and `mobile/src/navigation/AppNavigator.js`, and revamped `LeaderDashboardScreen` to show tile-based leader shortcuts. 
- Added `mobile/src/utils/DebugUtils.js` and exported it from `mobile/src/utils/index.js`, updated various screens to use `DebugUtils` and theming utilities for consistent mobile styling.

### Testing
- No automated tests were executed as part of this change (unit/integration test suites were not run). 
- Static checks and runtime validation should be performed in CI or local device/emulator before release. 
- Manual smoke testing is recommended for each new screen (`ManagePoints`, `Attendance`, `MeetingPreparation`, `NextMeeting`, `Honors`, `Medication`) to verify API wiring and navigation. 
- Cache/offline behavior should be validated by toggling network connectivity and confirming queuing/reading from `CacheManager`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ed23c209c8324a4ec8e0bc2a10806)