### PR TITLE
Add attendance cache invalidation

### DIFF
--- a/mobile/src/screens/AttendanceScreen.js
+++ b/mobile/src/screens/AttendanceScreen.js
@@ -32,6 +32,7 @@ import { Button, ErrorMessage, LoadingSpinner } from '../components';
 import CONFIG from '../config';
 import theme, { commonStyles } from '../theme';
 import { debugError, debugLog } from '../utils/DebugUtils';
+import CacheManager from '../utils/CacheManager';
 
 /**
  * Normalize participant names to handle API variations.
@@ -321,6 +322,9 @@ const AttendanceScreen = () => {
         throw new Error(response.message || t('error_loading_attendance'));
       }
 
+      // Clear attendance cache to ensure fresh data on next load
+      await CacheManager.clearAttendanceRelatedCaches();
+
       setAttendanceMap((prev) => ({ ...prev, [participantId]: status }));
     } catch (err) {
       debugError('Error updating attendance:', err);
@@ -372,6 +376,9 @@ const AttendanceScreen = () => {
         setAttendanceMap(rollbackMap);
         throw new Error(t('error_updating_group_attendance'));
       }
+
+      // Clear attendance cache to ensure fresh data on next load
+      await CacheManager.clearAttendanceRelatedCaches();
     } catch (err) {
       debugError('Error updating group attendance:', err);
       Alert.alert(t('error'), err.message || t('error_updating_group_attendance'));
@@ -406,6 +413,9 @@ const AttendanceScreen = () => {
       if (!response.success) {
         throw new Error(response.message || t('error_saving_guest'));
       }
+
+      // Clear attendance cache to ensure fresh data on next load
+      await CacheManager.clearAttendanceRelatedCaches();
 
       setGuests([...guests, { name: sanitizedName, email: sanitizedEmail, attendance_date: selectedDate }]);
       setGuestName('');

--- a/mobile/src/utils/CacheManager.js
+++ b/mobile/src/utils/CacheManager.js
@@ -437,6 +437,16 @@ class CacheManager {
     console.log('[Cache] Invalidating resource caches...');
     await this.deleteCachedDataByPattern('v1/resources/equipment');
   }
+
+  /**
+   * Clear attendance-related caches
+   * Use after: creating/updating attendance records or guests
+   */
+  async clearAttendanceRelatedCaches() {
+    console.log('[Cache] Invalidating attendance caches...');
+    await this.deleteCachedDataByPattern('v1/attendance');
+    await this.deleteCachedDataByPattern('guests-by-date');
+  }
 }
 
 // Export singleton instance


### PR DESCRIPTION
Added clearAttendanceRelatedCaches() method to CacheManager to clear attendance and guest caches when data is modified.

Cache is now cleared after:
- Creating/updating individual attendance records
- Creating/updating group attendance records
- Adding guests

This ensures the app always shows fresh data after modifications and prevents stale cached empty results from persisting.