### PR TITLE
Clear attendance cache when changing dates

### DIFF
--- a/mobile/src/screens/AttendanceScreen.js
+++ b/mobile/src/screens/AttendanceScreen.js
@@ -203,6 +203,9 @@ const AttendanceScreen = () => {
       setError('');
       debugLog(`Loading attendance for date: ${date}`);
 
+      // Clear cache before loading to ensure fresh data
+      await CacheManager.clearAttendanceRelatedCaches();
+
       const [attendanceResponse, guestsResponse] = await Promise.all([
         getAttendance(date),
         getGuestsByDate(date),


### PR DESCRIPTION
Fixed bug where switching dates would show stale cached data. Now clears the attendance cache before loading data for a new date, ensuring fresh data is always fetched from the API when changing dates.

This prevents the scenario where:
1. User marks attendance on date A
2. User switches to date B (loads cached data)
3. User switches back to date A (shows stale data from B)

Now each date change triggers a cache clear for fresh data.