### PR TITLE
Fix organization resolution to query org-specific server

### DIFF
--- a/mobile/src/screens/OrganizationSelectScreen.js
+++ b/mobile/src/screens/OrganizationSelectScreen.js
@@ -115,7 +115,8 @@ const OrganizationSelectScreen = ({ navigation, onOrganizationSelected }) => {
       const { fullUrl, hostname } = validation;
 
       // Call API to resolve organization ID using hostname
-      const response = await getOrganizationId(hostname);
+      // Pass fullUrl to query the organization's own server
+      const response = await getOrganizationId(hostname, fullUrl);
 
       if (response.success && response.data?.organization_id) {
         const orgId = response.data.organization_id;


### PR DESCRIPTION
Changes:
- Modified getOrganizationId() to accept organizationUrl parameter
- Function now makes direct axios call to the organization's URL
- This fixes the chicken-and-egg problem where we can't use default API to resolve org-specific endpoints
- Updated OrganizationSelectScreen to pass fullUrl parameter

Before: Queried default API (http://10.0.2.2:3000/api) for org data
After: Queries organization's own server (https://meute6a.app/api)

This resolves the "organization not found" error when users enter their organization URL.