### PR TITLE
Fix response normalization in getOrganizationId

### DIFF
--- a/mobile/src/api/api-endpoints.js
+++ b/mobile/src/api/api-endpoints.js
@@ -119,10 +119,14 @@ export const getOrganizationId = async (hostname, organizationUrl = null) => {
       });
 
       // Normalize response to match our API format
-      if (response.data) {
+      // Backend returns: { success: true, organizationId: 123 }
+      // We need: { success: true, data: { organization_id: 123 } }
+      if (response.data && response.data.organizationId) {
         return {
           success: true,
-          data: response.data,
+          data: {
+            organization_id: response.data.organizationId,
+          },
           message: 'Organization resolved',
         };
       }


### PR DESCRIPTION
The backend returns { success: true, organizationId: 123 } but the
screen expects { success: true, data: { organization_id: 123 } }.

This was causing "organization_resolved" to appear as an error because the condition response.data?.organization_id was failing.

Now properly normalizes camelCase organizationId to snake_case organization_id and wraps it in the expected data structure.