### PR TITLE
Sync mobile app sorting and filtering with web

### DIFF
--- a/mobile/src/config/index.js
+++ b/mobile/src/config/index.js
@@ -159,7 +159,7 @@ const CONFIG = {
     TOUCH_TARGET_SIZE: 44, // Minimum touch target size for accessibility
     ANIMATION_DURATION: 300,
     DEBOUNCE_DELAY: 300,
-    POINTS_QUICK_ACTIONS: [-5, -1, 1, 5],
+    POINTS_QUICK_ACTIONS: [1, 3, 5, -1, -3, -5],
     ATTENDANCE_STATUSES: ['present', 'late', 'absent', 'excused'],
   },
 


### PR DESCRIPTION
- Remove Participants/Groups tabs, show only participants grouped by groups
- Add sorting buttons (by name, by group, by points) using React Native UI
- Add group filter dropdown using @react-native-picker/picker
- Implement sorting logic for first name, group, and points
- Implement group filtering by group ID
- Update point buttons to show 6 buttons: +1, +3, +5, -1, -3, -5
- Fix group selection to award points to all members when group is selected
- Match web app layout exactly with group headers and participant lists
- Update CONFIG.UI.POINTS_QUICK_ACTIONS to reflect new 6-button layout
- Use optimistic updates for instant UI feedback

This implementation mirrors spa/manage_points.js functionality.