### PR TITLE
Fix 'All groups' filter using sentinel value instead of empty string

### DIFF
--- a/mobile/src/screens/ManagePointsScreen.js
+++ b/mobile/src/screens/ManagePointsScreen.js
@@ -55,13 +55,13 @@ const ManagePointsScreen = () => {
   const [selectedType, setSelectedType] = useState(null);
   const [submitting, setSubmitting] = useState(false);
   const [sortBy, setSortBy] = useState(SORT_TYPES.GROUP);
-  const [filterGroupId, setFilterGroupId] = useState('');
+  const [filterGroupId, setFilterGroupId] = useState('all');
 
   /**
    * Debug filter changes
    */
   useEffect(() => {
-    debugLog('filterGroupId changed:', filterGroupId, 'isEmpty:', filterGroupId === '', 'groups count:', groups.length);
+    debugLog('filterGroupId changed:', filterGroupId, 'isAll:', filterGroupId === 'all', 'groups count:', groups.length);
   }, [filterGroupId]);
 
   /**
@@ -75,7 +75,7 @@ const ManagePointsScreen = () => {
       participantsCount: participants.length,
     });
     // Filter groups if a specific group is selected
-    let filteredGroups = filterGroupId && filterGroupId !== ''
+    let filteredGroups = filterGroupId !== 'all'
       ? groups.filter((g) => g.id === parseInt(filterGroupId))
       : groups;
 
@@ -328,7 +328,7 @@ const ManagePointsScreen = () => {
               }}
               style={styles.picker}
             >
-              <Picker.Item label={t('all_groups')} value="" />
+              <Picker.Item label={t('all_groups')} value="all" />
               {groups.map((group) => (
                 <Picker.Item key={group.id} label={group.name} value={String(group.id)} />
               ))}


### PR DESCRIPTION
Issue: The Picker component on some platforms (especially Android) doesn't reliably fire onValueChange when selecting an item with an empty string value. This caused the "All groups" option to not restore all participants.

Solution:
- Changed filter sentinel value from "" (empty string) to "all"
- Updated initial state: useState('all')
- Updated filter logic: filterGroupId !== 'all'
- Updated Picker.Item: value="all"
- Updated debug logs to reflect new sentinel value

This is more reliable across platforms and follows common form patterns. The debug logs will now show:
- "Filter changed from 13 to all" when selecting "All groups"
- "isAll: true" when all groups are shown