### PR TITLE
Migrate badge images to new system

### DIFF
--- a/migrations/20251227_add_badge_template_images.sql
+++ b/migrations/20251227_add_badge_template_images.sql
@@ -1,0 +1,85 @@
+-- Migration: Add image support to badge_templates
+-- Description: Adds image column to badge_templates table and populates existing badges with images
+-- Author: Claude
+-- Date: 2025-12-27
+
+-- ==========================================
+-- UP MIGRATION
+-- ==========================================
+
+-- Add image column to badge_templates
+ALTER TABLE badge_templates
+ADD COLUMN IF NOT EXISTS image VARCHAR(255);
+
+-- Update existing badge templates with images based on their names
+-- These map to the traditional "territoires" from the old system
+
+-- Kaa (Débrouillard comme Kaa)
+UPDATE badge_templates
+SET image = 'kaa.webp'
+WHERE image IS NULL
+  AND (
+    LOWER(name) LIKE '%kaa%'
+    OR LOWER(template_key) LIKE '%kaa%'
+    OR LOWER(translation_key) LIKE '%kaa%'
+  );
+
+-- Baloo (Vrai comme Baloo)
+UPDATE badge_templates
+SET image = 'baloo.webp'
+WHERE image IS NULL
+  AND (
+    LOWER(name) LIKE '%baloo%'
+    OR LOWER(template_key) LIKE '%baloo%'
+    OR LOWER(translation_key) LIKE '%baloo%'
+  );
+
+-- Rikki Tikki Tavi (Respectueux comme Rikki Tikki Tavi)
+UPDATE badge_templates
+SET image = 'rikki.webp'
+WHERE image IS NULL
+  AND (
+    LOWER(name) LIKE '%rikki%'
+    OR LOWER(template_key) LIKE '%rikki%'
+    OR LOWER(translation_key) LIKE '%rikki%'
+  );
+
+-- Bagheera (Dynamique comme Bagheera)
+UPDATE badge_templates
+SET image = 'bagheera.webp'
+WHERE image IS NULL
+  AND (
+    LOWER(name) LIKE '%bagheera%'
+    OR LOWER(template_key) LIKE '%bagheera%'
+    OR LOWER(translation_key) LIKE '%bagheera%'
+  );
+
+-- Ferao (Heureux comme Ferao)
+UPDATE badge_templates
+SET image = 'ferao.webp'
+WHERE image IS NULL
+  AND (
+    LOWER(name) LIKE '%ferao%'
+    OR LOWER(template_key) LIKE '%ferao%'
+    OR LOWER(translation_key) LIKE '%ferao%'
+  );
+
+-- Frère Gris (Solidaire comme Frère Gris)
+UPDATE badge_templates
+SET image = 'frereGris.webp'
+WHERE image IS NULL
+  AND (
+    LOWER(name) LIKE '%frere%gris%'
+    OR LOWER(name) LIKE '%frèregris%'
+    OR LOWER(template_key) LIKE '%frere%gris%'
+    OR LOWER(translation_key) LIKE '%frere%gris%'
+  );
+
+-- Add comment to the column for documentation
+COMMENT ON COLUMN badge_templates.image IS 'Filename of badge image (stored in /images/ directory). Example: kaa.webp';
+
+-- ==========================================
+-- DOWN MIGRATION (for rollback)
+-- ==========================================
+-- Note: To rollback this migration, run:
+-- ALTER TABLE badge_templates DROP COLUMN IF EXISTS image;

--- a/migrations/README_BADGE_IMAGES.md
+++ b/migrations/README_BADGE_IMAGES.md
@@ -1,0 +1,135 @@
+# Badge Image Migration
+
+## Overview
+
+This migration adds image support to the badge_templates table, allowing badge images to be displayed in the web interface.
+
+## What Changed
+
+### Database Changes
+
+1. **Added `image` column** to `badge_templates` table
+   - Type: `VARCHAR(255)`
+   - Nullable: Yes
+   - Description: Stores the filename of the badge image (e.g., "kaa.webp")
+
+2. **Auto-populated existing badges** with images based on their names:
+   - Kaa → `kaa.webp`
+   - Baloo → `baloo.webp`
+   - Rikki Tikki Tavi → `rikki.webp`
+   - Bagheera → `bagheera.webp`
+   - Ferao → `ferao.webp`
+   - Frère Gris → `frereGris.webp`
+
+### Code Changes
+
+#### Backend (`routes/badges.js`)
+- Updated all badge template queries to include the `image` field
+- Modified endpoints:
+  - `/api/badge-progress`
+  - `/api/pending-badges`
+  - `/api/badge-summary`
+  - `/api/badge-history`
+  - `/api/badge-system-settings`
+  - `/api/current-stars`
+
+#### Frontend
+- **`spa/badge_dashboard.js`**:
+  - Updated `getBadgeImage()` to prioritize template images over old territoires system
+  - Added image field to badge records during buildRecords()
+  - Badge chips now display images from templates
+
+- **`spa/badge_form.js`**:
+  - Already supported template images, ensured compatibility
+
+## Running the Migration
+
+### Method 1: Using psql (Recommended)
+
+```bash
+# Set your database connection string
+export DATABASE_URL="postgresql://username:password@host:port/database"
+
+# Run the migration
+psql "$DATABASE_URL" -f migrations/20251227_add_badge_template_images.sql
+```
+
+### Method 2: Using node-pg-migrate
+
+```bash
+# If you prefer to use node-pg-migrate, convert this to a JS migration:
+npm run migrate:create add_badge_template_images
+
+# Then copy the SQL content into the up() and down() functions
+```
+
+## Verification
+
+After running the migration, verify it worked:
+
+```sql
+-- Check that the column was added
+SELECT column_name, data_type
+FROM information_schema.columns
+WHERE table_name = 'badge_templates' AND column_name = 'image';
+
+-- Check that existing badges have images
+SELECT id, name, image
+FROM badge_templates
+WHERE image IS NOT NULL;
+```
+
+## Rollback
+
+If you need to rollback this migration:
+
+```sql
+ALTER TABLE badge_templates DROP COLUMN IF EXISTS image;
+```
+
+## Image Files
+
+The migration expects badge images to be located in `/images/` directory:
+
+```
+/images/
+  ├── kaa.webp
+  ├── baloo.webp
+  ├── rikki.webp
+  ├── bagheera.webp
+  ├── ferao.webp
+  └── frereGris.webp
+```
+
+These images already exist in the project. PNG versions are also available.
+
+## Backward Compatibility
+
+The system maintains backward compatibility:
+
+1. If a badge template doesn't have an image, the frontend falls back to the old `territoires` system
+2. Old organization_settings with `badge_system.territoires` will still work
+3. No existing functionality is broken
+
+## Future Considerations
+
+- When creating new badge templates, you can now set the `image` field
+- Images should be stored in `/images/` directory
+- Recommended format: WebP for better compression
+- Fallback to PNG is also supported
+
+## Testing
+
+1. **Login to the application**
+2. **Navigate to Badge Dashboard** (`/badge-dashboard`)
+3. **Verify that badge images appear** next to badge names
+4. **Check badge form** - images should display in the badge grid
+5. **Create a new badge template** with an image and verify it displays
+
+## Questions?
+
+If you encounter issues:
+- Check that the images exist in `/images/` directory
+- Verify the migration ran successfully (check the database)
+- Check browser console for any image loading errors
+- Ensure API responses include the `image` field

--- a/routes/badges.js
+++ b/routes/badges.js
@@ -38,7 +38,7 @@ const getLevelCount = (levels, levelCount) => {
 async function fetchTemplate(client, templateId, organizationId) {
   if (!templateId) return null;
   const templateResult = await client.query(
-    `SELECT id, name, template_key, translation_key, section, level_count, levels
+    `SELECT id, name, template_key, translation_key, section, level_count, levels, image
      FROM badge_templates
      WHERE id = $1 AND organization_id = $2`,
     [templateId, organizationId]
@@ -126,12 +126,13 @@ module.exports = (pool, logger) => {
       }
 
       const result = await pool.query(
-        `SELECT bp.*, 
+        `SELECT bp.*,
                 bt.name AS badge_name,
                 bt.template_key,
                 bt.translation_key,
                 bt.section AS badge_section,
                 bt.level_count,
+                bt.image,
                 COALESCE(bt.levels, '[]'::jsonb) AS template_levels
          FROM badge_progress bp
          JOIN badge_templates bt ON bp.badge_template_id = bt.id
@@ -164,13 +165,14 @@ module.exports = (pool, logger) => {
       const organizationId = await getOrganizationId(req, pool);
 
       const result = await pool.query(
-        `SELECT bp.*, 
-                p.first_name, 
+        `SELECT bp.*,
+                p.first_name,
                 p.last_name,
                 bt.name AS badge_name,
                 bt.translation_key,
                 bt.section AS badge_section,
                 bt.level_count,
+                bt.image,
                 COALESCE(bt.levels, '[]'::jsonb) AS template_levels
          FROM badge_progress bp
          JOIN participants p ON bp.participant_id = p.id
@@ -519,6 +521,7 @@ module.exports = (pool, logger) => {
                 bt.translation_key,
                 bt.section AS badge_section,
                 bt.level_count,
+                bt.image,
                 COALESCE(bt.levels, '[]'::jsonb) AS template_levels
          FROM badge_progress bp
          JOIN participants p ON bp.participant_id = p.id
@@ -569,6 +572,7 @@ module.exports = (pool, logger) => {
                 bt.translation_key,
                 bt.section AS badge_section,
                 bt.level_count,
+                bt.image,
                 COALESCE(bt.levels, '[]'::jsonb) AS template_levels
          FROM badge_progress bp
          JOIN badge_templates bt ON bp.badge_template_id = bt.id
@@ -624,7 +628,7 @@ module.exports = (pool, logger) => {
           template = await fetchTemplate(client, templateId, organizationId);
         } else if (territoireName) {
           const templateResult = await client.query(
-            `SELECT id, name, template_key, translation_key, section, level_count, levels
+            `SELECT id, name, template_key, translation_key, section, level_count, levels, image
              FROM badge_templates
              WHERE organization_id = $1 AND (name = $2 OR template_key = lower(regexp_replace($2, '[^a-z0-9]+', '_', 'g')))
              LIMIT 1`,
@@ -695,7 +699,7 @@ module.exports = (pool, logger) => {
           [organizationId]
         ),
         pool.query(
-          `SELECT id, name, template_key, translation_key, section, level_count, levels, created_at, updated_at
+          `SELECT id, name, template_key, translation_key, section, level_count, levels, image, created_at, updated_at
            FROM badge_templates
            WHERE organization_id = $1
            ORDER BY section, name`,

--- a/spa/badge_dashboard.js
+++ b/spa/badge_dashboard.js
@@ -189,6 +189,7 @@ export class BadgeDashboard {
           section: template?.section || entry.badge_section || participant.section,
           levelCount,
           levels: Array.isArray(templateLevels) ? templateLevels : [],
+          image: template?.image || entry.image,
           statuses: new Set(),
           entries: [],
         });
@@ -420,7 +421,7 @@ export class BadgeDashboard {
       .join("");
 
     const stars = this.renderBadgeStars(participantId, badge);
-    const badgeImage = this.getBadgeImage(badge.name);
+    const badgeImage = this.getBadgeImage(badge.name, badge);
 
     return `
       <div class="badge-chip-compact" data-participant-id="${participantId}" data-badge-name="${badge.name}" data-template-id="${badge.id || ""}">
@@ -1094,15 +1095,21 @@ export class BadgeDashboard {
     this.openBadgeModal(participantId, null, false, null, true);
   }
 
-  getBadgeImage(badgeName) {
-    if (!this.badgeSettings?.territoires) return null;
+  getBadgeImage(badgeName, badge = null) {
+    // First try to get image from the badge template (new system)
+    if (badge?.image) {
+      return `/images/${badge.image}`;
+    }
 
-    const territoire = this.badgeSettings.territoires.find(
-      (t) => t.name.toLowerCase() === badgeName.toLowerCase(),
-    );
+    // Fallback to old system (territoires in badgeSettings)
+    if (this.badgeSettings?.territoires) {
+      const territoire = this.badgeSettings.territoires.find(
+        (t) => t.name.toLowerCase() === badgeName.toLowerCase(),
+      );
 
-    if (territoire && territoire.image) {
-      return `/images/${territoire.image}`;
+      if (territoire && territoire.image) {
+        return `/images/${territoire.image}`;
+      }
     }
 
     return null;

--- a/spa/badge_form.js
+++ b/spa/badge_form.js
@@ -320,7 +320,7 @@ export class BadgeForm {
 
         return `
                 <div class="badge-item">
-                    ${imageName ? `<img src="/images/${imageName}" alt="${this.getTemplateLabel(template)}">` : ""}
+                    ${imageName ? `<img src="/images/${imageName}" alt="${this.getTemplateLabel(template)}" class="badge-image">` : ""}
                     <h3>${this.getTemplateLabel(template)}</h3>
                     <div class="stars">
                         ${this.renderStars(approvedLevels, pendingLevels, levelCount)}


### PR DESCRIPTION
This commit migrates badge images from the old organization_settings system to the new badge_templates table structure.

Changes:
- Added image column to badge_templates table
- Updated all badge API endpoints to return image field
- Modified frontend to display images from templates
- Maintained backward compatibility with old territoires system
- Auto-populates existing badges with images based on their names

Migration:
- Run migrations/20251227_add_badge_template_images.sql
- See migrations/README_BADGE_IMAGES.md for details

Images supported:
- kaa.webp (Débrouillard comme Kaa)
- baloo.webp (Vrai comme Baloo)
- rikki.webp (Respectueux comme Rikki Tikki Tavi)
- bagheera.webp (Dynamique comme Bagheera)
- ferao.webp (Heureux comme Ferao)
- frereGris.webp (Solidaire comme Frère Gris)