### PR TITLE
Fix participant access for multi-role users (district+parent)

### DIFF
--- a/routes/participants.js
+++ b/routes/participants.js
@@ -985,11 +985,14 @@ module.exports = (pool) => {
 
     let params = [id, organizationId];
 
+    // Staff roles (admin, animation, district, unitadmin, demoadmin) can see all participants
     // Parent roles can only see participants they're linked to via user_participants table
-    // All other roles with participants.view permission can see all participants in their organization
-    const isParentRole = hasAnyRole(req, 'parent', 'demoparent');
+    // Check for staff roles FIRST - if user has any staff role, grant full access
+    const staffRoles = ['admin', 'animation', 'district', 'unitadmin', 'demoadmin'];
+    const hasStaffRole = req.userRoles && req.userRoles.some(role => staffRoles.includes(role));
 
-    if (isParentRole) {
+    // Only restrict if user has NO staff roles (i.e., they're only a parent)
+    if (!hasStaffRole) {
       // For parent/demoparent roles, verify they have access to this participant via user_participants
       query += ` AND EXISTS (
         SELECT 1 FROM user_participants up


### PR DESCRIPTION
PROBLEM:
- Users with BOTH district and parent roles could only see their own children
- Previous fix checked: if (isParentRole) -> restrict
- This failed for multi-role users who have ['district', 'parent']
- Since they DO have parent role, they were incorrectly restricted

ROOT CAUSE:
Multi-role support introduced a priority inversion:
- User has roles: ['district', 'parent']
- Old logic: "if user has parent role" -> restrict
- Result: District admin restricted like a parent

SOLUTION:
Check for staff roles FIRST:
- If user has ANY staff role (district, unitadmin, etc.) -> Full access
- Only if user has NO staff roles -> Check parent restriction

Logic flow:
```javascript
// OLD (BROKEN for multi-role)
if (hasAnyRole(req, 'parent', 'demoparent')) {
  // Restrict - WRONG for district+parent users!
}

// NEW (CORRECT for multi-role)
const hasStaffRole = userRoles.some(role => staffRoles.includes(role));
if (!hasStaffRole) {
  // Only restrict if they have NO staff roles
}
```

FIXED ENDPOINTS:
1. GET /api/v1/participants/:id (routes/participants.js)
2. GET /api/form-submission (routes/forms.js)

TECHNICAL DEBT - Role Hardcoding:
Yes, this hardcodes staff role names. This is necessary because:
- Permission system handles: "Can they view participants?" (Yes/No)
- This code handles: "Which participants can they view?" (All vs Linked)
- This is DATA SCOPE, not permission checking
- Future: Add role.data_scope property ('organization' vs 'linked')

The hardcoded roles are ONLY used to determine data visibility scope, NOT to grant/deny permission (that's already handled by middleware).