### PR TITLE
Harden SPA rendering against XSS (replace innerHTML with setContent, escape user data)

### DIFF
--- a/spa/admin.js
+++ b/spa/admin.js
@@ -608,8 +608,7 @@ ${showNotifications ? `
                                 document.getElementById(
                                         "notification-body",
                                 ).value;
-                        resultContainer.innerHTML = translate("sending");
-
+                        setContent(resultContainer, translate("sending"));
                         // Get selected subscribers
                         const selectedSubscribers = Array.from(
                                 document.querySelectorAll(
@@ -620,8 +619,7 @@ ${showNotifications ? `
                         // Retrieve the JWT token from localStorage
                         const token = localStorage.getItem("jwtToken");
                         if (!token) {
-                                resultContainer.innerHTML =
-                                        translate("error_no_token");
+                                setContent(resultContainer, translate("error_no_token"));
                                 return;
                         }
 
@@ -645,15 +643,15 @@ ${showNotifications ? `
                                 );
                                 const result = await response.json();
                                 if (response.ok) {
-                                        resultContainer.innerHTML = translate(
+                                        setContent(resultContainer, translate(
                                                 "notification_sent_successfully",
-                                        );
+                                        ));
                                         notificationForm.reset();
                                 } else {
-                                        resultContainer.innerHTML = `${translate("failed_to_send_notification")}: ${result.error}`;
+                                        setContent(resultContainer, `${translate("failed_to_send_notification")}: ${escapeHTML(result.error)}`);
                                 }
                         } catch (error) {
-                                resultContainer.innerHTML = `${translate("error")}: ${error.message}`;
+                                setContent(resultContainer, `${translate("error")}: ${escapeHTML(error.message)}`);
                         }
                 });
         }

--- a/spa/app.js
+++ b/spa/app.js
@@ -451,8 +451,7 @@ export const app = {
                 const icon = document.createElement('span');
                 icon.className = 'toast-icon';
                 icon.setAttribute('aria-hidden', 'true');
-                icon.innerHTML = type === 'error' ? '⚠' : '✓';
-
+                setContent(icon, type === 'error' ? '⚠' : '✓');
                 // Create message text
                 const messageText = document.createElement('span');
                 messageText.className = 'toast-message';
@@ -462,7 +461,7 @@ export const app = {
                 const dismissBtn = document.createElement('button');
                 dismissBtn.className = 'toast-dismiss';
                 dismissBtn.setAttribute('aria-label', translate('close'));
-                dismissBtn.innerHTML = '×';
+                setContent(dismissBtn, '×');
                 dismissBtn.onclick = () => this.dismissToast();
 
                 // Assemble toast

--- a/spa/attendance.js
+++ b/spa/attendance.js
@@ -20,6 +20,7 @@ import { CONFIG } from "./config.js";
 import { canViewAttendance } from "./utils/PermissionUtils.js";
 import { normalizeParticipantList } from "./utils/ParticipantRoleUtils.js";
 import { OptimisticUpdateManager } from "./utils/OptimisticUpdateManager.js";
+import { setContent } from "./utils/DOMUtils.js";
 
 export class Attendance {
   constructor(app) {
@@ -270,7 +271,7 @@ export class Attendance {
         </div>
       </div>
     `;
-    document.getElementById("app").innerHTML = content;
+    setContent(document.getElementById("app"), content);
   }
 
   renderSkeletonGroups() {
@@ -340,10 +341,10 @@ export class Attendance {
 
     const appElement = document.querySelector("#app");
     if (appElement) {
-      appElement.innerHTML = this.freshContent;
+      setContent(appElement, this.freshContent);
       const attendanceList = document.getElementById("attendance-list");
       if (attendanceList) {
-        attendanceList.innerHTML = "";
+        setContent(attendanceList, "");
         attendanceList.appendChild(this.renderGroupsAndNames());
       }
     }
@@ -390,14 +391,13 @@ export class Attendance {
         participantRow.classList.add("participant-row");
         participantRow.dataset.participantId = participant.id;
         participantRow.dataset.groupId = group.id;
-        participantRow.innerHTML = `
+        setContent(participantRow, `
           <span class="participant-name">${participant.first_name} ${participant.last_name}    
             ${participant.first_leader ? `<span class="badge leader">${translate("first_leader")}</span>` : ""}
             ${participant.second_leader ? `<span class="badge second-leader">${translate("second_leader")}</span>` : ""}
           </span>      
           <span class="participant-status ${statusClass}">${translate(status)}</span>
-        `;
-
+        `);
         groupDiv.appendChild(participantRow);
       });
 
@@ -789,7 +789,7 @@ export class Attendance {
       statusSpan.textContent = translate(status);
     });
 
-    document.getElementById("guestList").innerHTML = this.renderGuests();
+    setContent(document.getElementById("guestList"), this.renderGuests());
   }
 
   renderError() {
@@ -797,7 +797,7 @@ export class Attendance {
       <h1>${translate("error")}</h1>
       <p>${translate("error_loading_attendance")}</p>
     `;
-    document.getElementById("app").innerHTML = errorMessage;
+    setContent(document.getElementById("app"), errorMessage);
   }
 
   async addGuest() {
@@ -817,7 +817,7 @@ export class Attendance {
     try {
       await this.saveGuest(guest);
       this.guests.push(guest);
-      document.getElementById("guestList").innerHTML = this.renderGuests();
+      setContent(document.getElementById("guestList"), this.renderGuests());
       document.getElementById("guestName").value = "";
       document.getElementById("guestEmail").value = "";
       this.app.showMessage(translate("guest_added_successfully"), "success");

--- a/spa/badge_dashboard.js
+++ b/spa/badge_dashboard.js
@@ -19,6 +19,7 @@ import {
   canManageBadges,
   canViewBadges,
 } from "./utils/PermissionUtils.js";
+import { setContent } from "./utils/DOMUtils.js";
 import {
   OptimisticUpdateManager,
   generateOptimisticId,
@@ -330,7 +331,7 @@ export class BadgeDashboard {
       <div id="${this.modalContainerId}" class="badge-dashboard__modal hidden"></div>
     `;
 
-    document.getElementById("app").innerHTML = content;
+    setContent(document.getElementById("app"), content);
   }
 
   renderControls() {
@@ -632,7 +633,7 @@ export class BadgeDashboard {
   updateRows() {
     const body = document.getElementById("badge-table-body");
     if (!body) return;
-    body.innerHTML = this.renderRows();
+    setContent(body, this.renderRows());
   }
 
   openBadgeModal(
@@ -688,7 +689,7 @@ export class BadgeDashboard {
       )
       .join("");
 
-    modal.innerHTML = `
+    setContent(modal, `
       <div class="modal__backdrop" role="presentation"></div>
       <div class="modal" role="dialog" aria-modal="true" aria-labelledby="badge-modal-title">
         <header class="modal__header">
@@ -832,13 +833,12 @@ export class BadgeDashboard {
           </div>
         </section>
       </div>
-    `;
-
+    `);
     modal.classList.remove("hidden");
 
     const close = () => {
       modal.classList.add("hidden");
-      modal.innerHTML = "";
+      setContent(modal, "");
     };
 
     modal.querySelector("#close-badge-modal")?.addEventListener("click", close);
@@ -1229,24 +1229,23 @@ export class BadgeDashboard {
   }
 
   renderNotAuthorized() {
-    document.getElementById("app").innerHTML = `
+    setContent(document.getElementById("app"), `
       <section class="badge-dashboard">
         <h1>${translate("not_authorized")}</h1>
         <p>${translate("badge_dashboard_no_access")}</p>
         <p><a href="/dashboard">${translate("back_to_dashboard")}</a></p>
       </section>
-    `;
+    `);
   }
 
   renderError() {
-    document.getElementById("app").innerHTML = `
+    setContent(document.getElementById("app"), `
       <section class="badge-dashboard">
         <h1>${translate("error")}</h1>
         <p>${translate("badge_dashboard_error")}</p>
         <p><button class="ghost-button" id="badge-refresh">${translate("retry")}</button></p>
       </section>
-    `;
-
+    `);
     document
       .getElementById("badge-refresh")
       ?.addEventListener("click", () => this.refreshFromNetwork());

--- a/spa/budgets.js
+++ b/spa/budgets.js
@@ -26,6 +26,7 @@ import { formatDateShort, getTodayISO } from "./utils/DateUtils.js";
 import { LoadingStateManager, retryWithBackoff } from "./utils/PerformanceUtils.js";
 import { validateMoney, validateRequired } from "./utils/ValidationUtils.js";
 import { canViewBudget } from "./utils/PermissionUtils.js";
+import { setContent } from "./utils/DOMUtils.js";
 
 const DEFAULT_CURRENCY = "CAD";
 
@@ -197,7 +198,7 @@ export class Budgets {
     const container = document.getElementById("app");
     if (!container) return;
 
-    container.innerHTML = `
+    setContent(container, `
       <div class="page-container budget-page">
         <div class="page-header">
           <a href="/dashboard" class="button button--ghost">← ${translate("back")}</a>
@@ -213,7 +214,7 @@ export class Budgets {
           <p>${translate("loading")}...</p>
         </div>
       </div>
-    `;
+    `);
   }
 
   async render() {
@@ -222,7 +223,7 @@ export class Budgets {
 
     const tabContent = await this.renderTabContent();
 
-    container.innerHTML = `
+    setContent(container, `
       <div class="page-container budgets-page">
       <a href="/dashboard" class="button button--ghost">← ${translate("back")}</a>
         <div class="page-header">
@@ -267,7 +268,7 @@ export class Budgets {
           ${tabContent}
         </div>
       </div>
-    `;
+    `);
   }
 
   /**
@@ -1213,8 +1214,7 @@ export class Budgets {
     await this.loadRevenueBreakdown();
 
     const reportsHTML = await this.renderReports();
-    tabContent.innerHTML = reportsHTML;
-
+    setContent(tabContent, reportsHTML);
     // Re-attach event listeners for the reports tab
     const applyFiltersBtn = document.getElementById(
       "apply-revenue-filters-btn",

--- a/spa/carpool_dashboard.js
+++ b/spa/carpool_dashboard.js
@@ -18,6 +18,7 @@ import { canManageCarpools, canViewCarpools, isParent } from './utils/Permission
 import { OptimisticUpdateManager, generateOptimisticId } from './utils/OptimisticUpdateManager.js';
 import { skeletonCarpoolDashboard, setButtonLoading } from './utils/SkeletonUtils.js';
 import { debugError } from './utils/DebugUtils.js';
+import { setContent } from "./utils/DOMUtils.js";
 
 export class CarpoolDashboard {
   constructor(app, activityId) {
@@ -75,22 +76,22 @@ export class CarpoolDashboard {
 
     // Show loading skeleton while data is being fetched
     if (this.isLoading) {
-      container.innerHTML = skeletonCarpoolDashboard();
+      setContent(container, skeletonCarpoolDashboard());
       return;
     }
 
     if (!this.activity) {
-      container.innerHTML = `
+      setContent(container, `
         <section class="page">
           <div class="error-state">${translate('activity_not_found')}</div>
         </section>
-      `;
+      `);
       return;
     }
 
     const activityDate = new Date(this.activity.activity_date);
 
-    container.innerHTML = `
+    setContent(container, `
       <section class="page carpool-page">
         <header class="page__header">
           <div class="page__header-top">
@@ -158,7 +159,7 @@ export class CarpoolDashboard {
           ${this.renderAssignments()}
         </section>
       </section>
-    `;
+    `);
   }
 
   renderLookForRideButton() {
@@ -651,7 +652,7 @@ export class CarpoolDashboard {
       modalContainer.className = 'modal-container';
       document.body.appendChild(modalContainer);
     }
-    modalContainer.innerHTML = modalHTML;
+    setContent(modalContainer, modalHTML);
     modalContainer.classList.add('modal-container--visible');
 
     const closeModal = () => {
@@ -996,7 +997,7 @@ export class CarpoolDashboard {
       modalContainer.className = 'modal-container';
       document.body.appendChild(modalContainer);
     }
-    modalContainer.innerHTML = modalHTML;
+    setContent(modalContainer, modalHTML);
     modalContainer.classList.add('modal-container--visible');
 
     const closeModal = () => {

--- a/spa/components/OfflineIndicator.js
+++ b/spa/components/OfflineIndicator.js
@@ -7,6 +7,7 @@
  */
 
 import { debugLog } from '../utils/DebugUtils.js';
+import { setContent } from "../utils/DOMUtils.js";
 
 /**
  * OfflineIndicator Component
@@ -191,15 +192,14 @@ export class OfflineIndicator {
         this.element.setAttribute('aria-live', 'polite');
         this.element.setAttribute('aria-atomic', 'true');
 
-        this.element.innerHTML = `
+        setContent(this.element, `
             <span class="offline-indicator-icon" aria-hidden="true">⚠️</span>
             <div class="offline-indicator-text">
                 <span class="offline-indicator-status"></span>
                 <span class="offline-indicator-count"></span>
             </div>
             <span class="offline-indicator-badge"></span>
-        `;
-
+        `);
         document.body.appendChild(this.element);
         debugLog('OfflineIndicator: Element created');
     }

--- a/spa/dashboard.js
+++ b/spa/dashboard.js
@@ -874,7 +874,7 @@ ${administrationLinks.length > 0 ? `
     tomorrow.setDate(tomorrow.getDate() + 1);
     const tomorrowStr = tomorrow.toISOString().split('T')[0];
 
-    modal.innerHTML = `
+    setContent(modal, `
       <div style="background: white; border-radius: 12px; max-width: 500px; width: 90%; padding: 2rem;">
         <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem;">
           <h2 style="margin: 0;">${translate('quick_create_activity')}</h2>
@@ -965,7 +965,7 @@ ${administrationLinks.length > 0 ? `
           </div>
         </form>
       </div>
-    `;
+    `);
 
     document.body.appendChild(modal);
 
@@ -1053,9 +1053,9 @@ ${administrationLinks.length > 0 ? `
   }
 
   renderError() {
-    document.getElementById("app").innerHTML = `
+    setContent(document.getElementById("app"), `
       <h1>${translate("error")}</h1>
       <p>${translate("error_loading_dashboard")}</p>
-    `;
+    `);
   }
 }

--- a/spa/district_management.js
+++ b/spa/district_management.js
@@ -27,6 +27,7 @@ import {
   getLocalGroupEligibleRoles,
 } from "./utils/RoleValidationUtils.js";
 import { setStorageMultiple } from "./utils/StorageUtils.js";
+import { setContent } from "./utils/DOMUtils.js";
 
 const CACHE_KEY = "district_management_state";
 const CACHE_DURATION = CONFIG.CACHE_DURATION.SHORT;
@@ -329,7 +330,7 @@ export class DistrictManagement {
         <a class="btn btn--primary" href="/dashboard">${translate("back_to_dashboard")}</a>
       </section>
     `;
-    document.getElementById("app").innerHTML = content;
+    setContent(document.getElementById("app"), content);
   }
 
   renderAndBind() {
@@ -435,7 +436,7 @@ export class DistrictManagement {
       ${this.renderAssignmentModal()}
     `;
 
-    document.getElementById("app").innerHTML = content;
+    setContent(document.getElementById("app"), content);
   }
 
   getActiveOrganizationName() {

--- a/spa/expenses.js
+++ b/spa/expenses.js
@@ -17,6 +17,7 @@ import { LoadingStateManager, debounce, retryWithBackoff } from "./utils/Perform
 import { validateMoney, validateDateField, validateRequired } from "./utils/ValidationUtils.js";
 import { canApproveFinance, canManageFinance } from "./utils/PermissionUtils.js";
 import { deleteCachedData } from "./indexedDB.js";
+import { setContent } from "./utils/DOMUtils.js";
 
 const DEFAULT_CURRENCY = "CAD";
 
@@ -284,7 +285,7 @@ export class Expenses {
     const container = document.getElementById("app");
     if (!container) return;
 
-    container.innerHTML = `
+    setContent(container, `
       <div class="page-container expenses-page">
         <div class="page-header">
           <a href="/dashboard" class="button button--ghost">← ${translate("back")}</a>
@@ -300,14 +301,14 @@ export class Expenses {
           <p>${translate("loading")}...</p>
         </div>
       </div>
-    `;
+    `);
   }
 
   async render() {
     const container = document.getElementById("app");
     if (!container) return;
 
-    container.innerHTML = `
+    setContent(container, `
       <div class="page-container expenses-page">
         <div class="page-header">
           <a href="/dashboard" class="button button--ghost">← ${translate("back")}</a>
@@ -337,7 +338,7 @@ export class Expenses {
           ${this.renderTabContent()}
         </div>
       </div>
-    `;
+    `);
   }
 
   renderSummaryCards() {

--- a/spa/external-revenue.js
+++ b/spa/external-revenue.js
@@ -22,6 +22,7 @@ import {
   validateRequired,
 } from "./utils/ValidationUtils.js";
 import { canApproveFinance, canManageFinance } from "./utils/PermissionUtils.js";
+import { setContent } from "./utils/DOMUtils.js";
 
 const DEFAULT_CURRENCY = "CAD";
 
@@ -234,7 +235,7 @@ export class ExternalRevenue {
     const container = document.getElementById("app");
     if (!container) return;
 
-    container.innerHTML = `
+    setContent(container, `
       <div class="page-container external-revenue-page">
         <div class="page-header">
           <a href="/dashboard" class="button button--ghost">← ${translate("back")}</a>
@@ -250,14 +251,14 @@ export class ExternalRevenue {
           <p>${translate("loading")}...</p>
         </div>
       </div>
-    `;
+    `);
   }
 
   async render() {
     const container = document.getElementById("app");
     if (!container) return;
 
-    container.innerHTML = `
+    setContent(container, `
       <div class="page-container external-revenue-page">
         <div class="page-header">
           <a href="/dashboard" class="button button--ghost">← ${translate("back")}</a>
@@ -274,7 +275,7 @@ export class ExternalRevenue {
         ${this.renderActionButtons()}
         ${this.renderRevenueList()}
       </div>
-    `;
+    `);
   }
 
   renderSummaryCards() {

--- a/spa/fiche_sante.js
+++ b/spa/fiche_sante.js
@@ -1,6 +1,7 @@
 import { debugLog, debugError, debugWarn, debugInfo } from "./utils/DebugUtils.js";
 import { translate } from "./app.js";
 import { DynamicFormHandler } from "./dynamicFormHandler.js";
+import { setContent } from "./utils/DOMUtils.js";
 import {
   fetchParticipant,
   fetchParents,
@@ -95,8 +96,7 @@ export class FicheSante {
       <p><a href="/dashboard">${translate("retour_tableau_bord")}</a></p>
     `;
 
-    document.getElementById("app").innerHTML = content;
-
+    setContent(document.getElementById("app"), content);
     // Re-initialize the form handler after the container is in the DOM
     if (this.formHandler) {
       this.formHandler.container = document.getElementById('fiche-sante-container');
@@ -173,6 +173,6 @@ export class FicheSante {
       <p>${message}</p>
       <p><a href="/dashboard">${translate("retour_tableau_bord")}</a></p>
     `;
-    document.getElementById("app").innerHTML = errorMessage;
+    setContent(document.getElementById("app"), errorMessage);
   }
 }

--- a/spa/finance.js
+++ b/spa/finance.js
@@ -24,6 +24,7 @@ import { clearFinanceRelatedCaches } from "./indexedDB.js";
 import { LoadingStateManager, CacheWithTTL, retryWithBackoff } from "./utils/PerformanceUtils.js";
 import { validateMoney, validateDateField, validatePositiveInteger } from "./utils/ValidationUtils.js";
 import { canManageFinance, canViewFinance } from "./utils/PermissionUtils.js";
+import { setContent } from "./utils/DOMUtils.js";
 
 const DEFAULT_CURRENCY = "CAD";
 
@@ -254,7 +255,7 @@ export class Finance {
       </section>
     `;
 
-    document.getElementById("app").innerHTML = content;
+    setContent(document.getElementById("app"), content);
   }
 
   render() {
@@ -283,7 +284,7 @@ export class Finance {
       ${this.renderPlanModal()}
     `;
 
-    document.getElementById("app").innerHTML = content;
+    setContent(document.getElementById("app"), content);
   }
 
   renderTabButton(tab, label) {
@@ -652,7 +653,7 @@ export class Finance {
   resetPaymentRows() {
     const container = document.getElementById('payment-rows');
     if (container) {
-      container.innerHTML = this.renderPaymentRow(0);
+      setContent(container, this.renderPaymentRow(0));
     }
   }
 
@@ -1107,7 +1108,7 @@ export class Finance {
         this.paymentsCache.set(feeId, payments?.data || payments?.payments || []);
       }
       const payments = this.paymentsCache.get(feeId);
-      historyContainer.innerHTML = payments.length
+      setContent(historyContainer, payments.length
         ? payments
             .map(
               (payment) => `
@@ -1124,10 +1125,10 @@ export class Finance {
               `
             )
             .join("")
-        : `<p class="finance-helper">${translate("no_payments")}</p>`;
+        : `<p class="finance-helper">${translate("no_payments")}</p>`);
     } catch (error) {
       debugError('Error loading payments', error);
-      historyContainer.innerHTML = `<p class="finance-helper">${translate("error_loading_data")}</p>`;
+      setContent(historyContainer, `<p class="finance-helper">${translate("error_loading_data")}</p>`);
     }
   }
 
@@ -1287,7 +1288,7 @@ export class Finance {
       }
       const plans = this.paymentPlanCache.get(feeId);
       const plan = plans[0];
-      planContainer.innerHTML = plans.length
+      setContent(planContainer, plans.length
         ? `
             <div class="finance-list__row">
               <div>
@@ -1300,8 +1301,7 @@ export class Finance {
               </div>
             </div>
           `
-        : `<p class="finance-helper">${translate("no_payment_plan")}</p>`;
-
+        : `<p class="finance-helper">${translate("no_payment_plan")}</p>`);
       const form = document.getElementById('plan-form');
       if (form) {
         if (plan) {
@@ -1318,7 +1318,7 @@ export class Finance {
       }
     } catch (error) {
       debugError('Error loading payment plan', error);
-      planContainer.innerHTML = `<p class="finance-helper">${translate("error_loading_data")}</p>`;
+      setContent(planContainer, `<p class="finance-helper">${translate("error_loading_data")}</p>`);
     }
   }
 

--- a/spa/formBuilder.js
+++ b/spa/formBuilder.js
@@ -13,6 +13,7 @@ import { translate } from "./app.js";
 import { escapeHTML } from "./utils/SecurityUtils.js";
 import { CONFIG } from "./config.js";
 import { JSONFormRenderer } from "./JSONFormRenderer.js";
+import { setContent } from "./utils/DOMUtils.js";
 
 /**
  * FormBuilder class - Main form builder component
@@ -73,7 +74,7 @@ export class FormBuilder {
      */
     render() {
         const container = document.getElementById("app");
-        container.innerHTML = `
+        setContent(container, `
             <div class="form-builder">
                 <a href="/dashboard" class="button button--ghost">← ${translate("back")}</a>
                 <h1>${translate("form_builder_title")}</h1>
@@ -128,7 +129,7 @@ export class FormBuilder {
                     </div>
                 </div>
             </div>
-        `;
+        `);
     }
 
     /**
@@ -169,7 +170,7 @@ export class FormBuilder {
 
         const editor = document.getElementById("form-editor");
         editor.style.display = "block";
-        editor.innerHTML = `
+        setContent(editor, `
             <div class="editor-header">
                 <h2>${translate("editing_form")}: ${escapeHTML(this.currentFormat.form_type)}</h2>
                 <div class="editor-actions">
@@ -191,7 +192,7 @@ export class FormBuilder {
                     </div>
                 </div>
             </div>
-        `;
+        `);
     }
 
     /**
@@ -266,7 +267,7 @@ export class FormBuilder {
             ['radio', 'checkbox'].includes(f.type) && f.name
         );
 
-        content.innerHTML = `
+        setContent(content, `
             <form id="field-editor-form" class="field-editor-form">
                 <div class="form-group">
                     <label for="field-type">${translate("field_type")} *</label>
@@ -357,7 +358,7 @@ export class FormBuilder {
 
                 <input type="hidden" id="field-index" value="${fieldIndex !== null ? fieldIndex : ''}">
             </form>
-        `;
+        `);
 
         modal.style.display = "block";
         this.updateFieldEditorVisibility(field.type);
@@ -732,7 +733,7 @@ export class FormBuilder {
         const modal = document.getElementById("translation-modal");
         const content = document.getElementById("translation-content");
 
-        content.innerHTML = `
+        setContent(content, `
             <form id="translation-form">
                 <div class="form-group">
                     <label>${translate("translation_key")}</label>
@@ -751,8 +752,7 @@ export class FormBuilder {
                     <button type="button" class="btn btn-secondary" id="cancel-translation">${translate("cancel")}</button>
                 </div>
             </form>
-        `;
-
+        `);
         modal.style.display = "block";
 
         // Attach listeners
@@ -855,7 +855,7 @@ export class FormBuilder {
     updateFieldsList() {
         const container = document.getElementById("fields-container");
         if (container) {
-            container.innerHTML = this.renderFieldsList();
+            setContent(container, this.renderFieldsList());
             this.attachFieldActionListeners();
             this.attachDragDropListeners();
         }
@@ -908,7 +908,7 @@ export class FormBuilder {
         
         document.querySelector("#translation-modal h2").textContent = translate("create_new_form_format");
 
-        content.innerHTML = `
+        setContent(content, `
             <form id="create-format-form">
                 <div class="form-group">
                     <label for="new-form-type">${translate("form_type_name")} *</label>
@@ -923,8 +923,7 @@ export class FormBuilder {
                     <button type="button" class="btn btn-secondary" id="cancel-create">${translate("cancel")}</button>
                 </div>
             </form>
-        `;
-
+        `);
         modal.style.display = "block";
 
         // Attach listeners
@@ -1006,7 +1005,7 @@ export class FormBuilder {
                 await this.loadData();
                 const formatsList = document.getElementById("formats-list");
                 if (formatsList) {
-                    formatsList.innerHTML = this.renderFormatsList();
+                    setContent(formatsList, this.renderFormatsList());
                     this.attachEventListeners();
                 }
             } else {
@@ -1063,7 +1062,7 @@ export class FormBuilder {
             this.currentFormat.form_type
         );
 
-        content.innerHTML = renderer.render();
+        setContent(content, renderer.render());
         modal.style.display = "block";
     }
 
@@ -1082,7 +1081,7 @@ export class FormBuilder {
         
         document.querySelector("#translation-modal h2").textContent = translate("copy_to_org");
 
-        content.innerHTML = `
+        setContent(content, `
             <form id="copy-format-form">
                 <div class="form-group">
                     <label for="target-org">${translate("select_target_organization")} *</label>
@@ -1098,8 +1097,7 @@ export class FormBuilder {
                     <button type="button" class="btn btn-secondary" id="cancel-copy">${translate("cancel")}</button>
                 </div>
             </form>
-        `;
-
+        `);
         modal.style.display = "block";
 
         // Attach listeners

--- a/spa/formulaire_inscription.js
+++ b/spa/formulaire_inscription.js
@@ -1,18 +1,19 @@
 import { debugLog, debugError, debugWarn, debugInfo } from "./utils/DebugUtils.js";
-import { app, translate} from "./app.js";
+import { app, translate } from "./app.js";
 import { DynamicFormHandler } from "./dynamicFormHandler.js";
+import { setContent } from "./utils/DOMUtils.js";
 import {
-    getAuthHeader,
+  getAuthHeader,
   fetchParticipant,
   saveFormSubmission,
   getOrganizationFormFormats,
   saveParticipant,
-    getGuardiansForParticipant,
-      saveGuardian,
-      linkGuardianToParticipant,
-      linkUserParticipants,
-    getCurrentOrganizationId,
-    fetchFromApi
+  getGuardiansForParticipant,
+  saveGuardian,
+  linkGuardianToParticipant,
+  linkUserParticipants,
+  getCurrentOrganizationId,
+  fetchFromApi
 } from "./ajax-functions.js";
 
 export class FormulaireInscription {
@@ -142,7 +143,7 @@ export class FormulaireInscription {
           <div id="error-message" class="error hidden"></div>
             <div id="success-message" class="success hidden"></div>
         `;
-        document.getElementById("app").innerHTML = content;
+        setContent(document.getElementById("app"), content);
       }
 
 
@@ -154,7 +155,7 @@ export class FormulaireInscription {
             debugError("Guardians container not found");
             return;
         }
-        container.innerHTML = '';  // Clear the container
+        setContent(container, '');  // Clear the container
 
         this.guardianFormHandlers = [];  // Reset handlers to avoid duplicate form handling
 

--- a/spa/fundraisers.js
+++ b/spa/fundraisers.js
@@ -61,7 +61,7 @@ export class Fundraisers {
 
 			${this.renderModal()}
 		`;
-		document.getElementById('app').innerHTML = content;
+		setContent(document.getElementById('app'), content);
 	}
 
 	renderAddButton() {

--- a/spa/group-participant-report.js
+++ b/spa/group-participant-report.js
@@ -2,6 +2,7 @@ import { getParticipants, getGroups } from "./ajax-functions.js";
 import { debugLog, debugError, debugWarn, debugInfo } from "./utils/DebugUtils.js";
 import { translate } from "./app.js";
 import { normalizeParticipantList } from "./utils/ParticipantRoleUtils.js";
+import { setContent } from "./utils/DOMUtils.js";
 
 export class PrintableGroupParticipantReport {
 		constructor(app) {
@@ -66,8 +67,7 @@ export class PrintableGroupParticipantReport {
 								<p><a href="/dashboard">${translate("back_to_dashboard")}</a></p>
 						</div>
 				`;
-				document.getElementById("app").innerHTML = content;
-
+				setContent(document.getElementById("app"), content);
 				const style = `
 						<style>
 								@media print {
@@ -139,6 +139,6 @@ export class PrintableGroupParticipantReport {
 						<p>${translate("error_loading_group_participant_report")}</p>
 						<p><a href="/dashboard">${translate("back_to_dashboard")}</a></p>
 				`;
-				document.getElementById("app").innerHTML = errorMessage;
+				setContent(document.getElementById("app"), errorMessage);
 		}
 }

--- a/spa/mailing_list.js
+++ b/spa/mailing_list.js
@@ -4,6 +4,7 @@ import { translate } from "./app.js";
 import { escapeHTML, sanitizeHTML } from "./utils/SecurityUtils.js";
 import { CONFIG } from "./config.js";
 import { canSendCommunications } from "./utils/PermissionUtils.js";
+import { setContent } from "./utils/DOMUtils.js";
 
 export class MailingList {
   constructor(app) {
@@ -62,7 +63,7 @@ export class MailingList {
                         </div>
                         <p><a href="/dashboard">${translate("back_to_dashboard")}</a></p>
                 `;
-                document.getElementById("app").innerHTML = content;
+                setContent(document.getElementById("app"), content);
         }
 
         renderAnnouncementComposer() {
@@ -536,6 +537,6 @@ export class MailingList {
                                                 <h1>${translate("error")}</h1>
                                                 <p>${translate("error_loading_mailing_list")}</p>
                                 `;
-                document.getElementById("app").innerHTML = errorMessage;
+                setContent(document.getElementById("app"), errorMessage);
         }
 }

--- a/spa/manage_groups.js
+++ b/spa/manage_groups.js
@@ -10,6 +10,7 @@ import { clearGroupRelatedCaches } from "./indexedDB.js";
 import { debugError } from "./utils/DebugUtils.js";
 import { escapeHTML } from "./utils/SecurityUtils.js";
 import { canViewGroups } from "./utils/PermissionUtils.js";
+import { setContent } from "./utils/DOMUtils.js";
 
 export class ManageGroups {
   constructor(app) {
@@ -66,7 +67,7 @@ export class ManageGroups {
                 </tbody>
             </table>
         `;
-    document.getElementById("app").innerHTML = content;
+    setContent(document.getElementById("app"), content);
   }
 
   renderGroupRows() {
@@ -209,6 +210,6 @@ export class ManageGroups {
             <h1>${translate("error")}</h1>
             <p>${translate("error_loading_manage_groups")}</p>
         `;
-    document.getElementById("app").innerHTML = errorMessage;
+    setContent(document.getElementById("app"), errorMessage);
   }
 }

--- a/spa/manage_honors.js
+++ b/spa/manage_honors.js
@@ -2,6 +2,7 @@ import { getHonorsAndParticipants, awardHonor } from "./ajax-functions.js";
 import { debugLog, debugError, debugWarn, debugInfo } from "./utils/DebugUtils.js";
 import { translate } from "./app.js";
 import { getTodayISO, formatDate, isValidDate, isPastDate as isDateInPast } from "./utils/DateUtils.js";
+import { setContent } from "./utils/DOMUtils.js";
 
 export class ManageHonors {
   constructor(app) {
@@ -122,7 +123,7 @@ export class ManageHonors {
             }>${translate("award_honor")}</button>
         </div>
     `;
-    document.getElementById("app").innerHTML = content;
+    setContent(document.getElementById("app"), content);
   }
 
   renderHonorsList() {
@@ -182,7 +183,7 @@ export class ManageHonors {
   }
 
   updateHonorsListUI() {
-    document.getElementById("honors-list").innerHTML = this.renderHonorsList();
+    setContent(document.getElementById("honors-list"), this.renderHonorsList());
     document.getElementById("awardHonorButton").disabled = this.isPastDate();
 
     // Attach event listeners to list items only
@@ -265,8 +266,7 @@ export class ManageHonors {
     });
 
     // Directly update the UI without reattaching event listeners
-    document.getElementById("honors-list").innerHTML = this.renderHonorsList();
-
+    setContent(document.getElementById("honors-list"), this.renderHonorsList());
     // Only reattach event listeners for the updated list items
     this.attachEventListenersToListItems();
   }
@@ -282,6 +282,6 @@ export class ManageHonors {
       <h1>${translate("error")}</h1>
       <p>${translate("error_loading_honors")}</p>
     `;
-    document.getElementById("app").innerHTML = errorMessage;
+    setContent(document.getElementById("app"), errorMessage);
   }
 }

--- a/spa/manage_participants.js
+++ b/spa/manage_participants.js
@@ -13,6 +13,7 @@ import { debugLog, debugError } from "./utils/DebugUtils.js";
 import { escapeHTML } from "./utils/SecurityUtils.js";
 import { canViewParticipants } from "./utils/PermissionUtils.js";
 import { normalizeParticipantList } from "./utils/ParticipantRoleUtils.js";
+import { setContent } from "./utils/DOMUtils.js";
 
 export class ManageParticipants {
   constructor(app) {
@@ -199,7 +200,7 @@ export class ManageParticipants {
         }
       </style>
     `;
-    document.getElementById("app").innerHTML = content;
+    setContent(document.getElementById("app"), content);
   }
 
   renderParticipantRows() {
@@ -465,6 +466,6 @@ export class ManageParticipants {
       <h1>${translate("error")}</h1>
       <p>${translate("error_loading_manage_participants")}</p>
     `;
-    document.getElementById("app").innerHTML = errorMessage;
+    setContent(document.getElementById("app"), errorMessage);
   }
 }

--- a/spa/manage_points.js
+++ b/spa/manage_points.js
@@ -21,6 +21,7 @@ import {
 import { canViewPoints } from "./utils/PermissionUtils.js";
 import { normalizeParticipantList } from "./utils/ParticipantRoleUtils.js";
 import { OptimisticUpdateManager, generateOptimisticId } from "./utils/OptimisticUpdateManager.js";
+import { setContent } from "./utils/DOMUtils.js";
 
 export class ManagePoints {
   constructor(app) {
@@ -210,8 +211,7 @@ export class ManagePoints {
         <button class="point-btn remove" data-points="-5">-5</button>
       </div>
     `;
-    document.getElementById("app").innerHTML = content;
-
+    setContent(document.getElementById("app"), content);
     // Render points list sorted by group initially
     this.sortByGroup(); // Call the sort by group function here
 
@@ -553,7 +553,7 @@ export class ManagePoints {
 
       // Update the main group header display
       const pointsDisplay = `${groupName} - ${totalPoints} `;
-      groupElement.innerHTML = pointsDisplay;
+      setContent(groupElement, pointsDisplay);
       groupElement.dataset.points = totalPoints;
       this.addHighlightEffect(groupElement);
 
@@ -758,8 +758,7 @@ export class ManagePoints {
       });
 
       // Clear the list and render only participants
-      list.innerHTML = items.map((item) => item.outerHTML).join("");
-
+      setContent(list, items.map((item) => item.outerHTML).join(""));
       debugLog(`Sorted by ${key}, order: ${this.currentSort.order}`);
     }
   }
@@ -797,7 +796,7 @@ export class ManagePoints {
     const unassignedHTML = this.renderUnassignedParticipants();
 
     // Combine group content and unassigned participants into one HTML
-    pointsList.innerHTML = groupContent + unassignedHTML;
+    setContent(pointsList, groupContent + unassignedHTML);
   }
 
   filterByGroup(groupId) {
@@ -966,7 +965,7 @@ export class ManagePoints {
 
         // Update group points display
         const pointsDisplay = `${group.name} - ${totalPoints} `;
-        groupElement.innerHTML = pointsDisplay;
+        setContent(groupElement, pointsDisplay);
         groupElement.dataset.points = totalPoints;
 
         // Update the group points total if it exists
@@ -996,6 +995,6 @@ export class ManagePoints {
         <h1>${translate("error")}</h1>
         <p>${translate("error_loading_manage_points")}</p>
     `;
-    document.getElementById("app").innerHTML = errorMessage;
+    setContent(document.getElementById("app"), errorMessage);
   }
 }

--- a/spa/manage_users_participants.js
+++ b/spa/manage_users_participants.js
@@ -8,6 +8,7 @@ import {
 import { translate } from "./app.js";
 import { escapeHTML } from "./utils/SecurityUtils.js";
 import { canViewUsers } from "./utils/PermissionUtils.js";
+import { setContent } from "./utils/DOMUtils.js";
 
 export class ManageUsersParticipants {
   constructor(app) {
@@ -167,7 +168,7 @@ export class ManageUsersParticipants {
       </table>
       <p><a href="/dashboard">${translate("back_to_dashboard")}</a></p>
     `;
-    document.getElementById("app").innerHTML = content;
+    setContent(document.getElementById("app"), content);
   }
 
   renderParticipantRows() {
@@ -293,7 +294,7 @@ export class ManageUsersParticipants {
       <h1>${translate("error")}</h1>
       <p>${translate("error_loading_manage_users_participants")}</p>
     `;
-    document.getElementById("app").innerHTML = errorMessage;
+    setContent(document.getElementById("app"), errorMessage);
   }
 
   /**

--- a/spa/material_management.js
+++ b/spa/material_management.js
@@ -9,6 +9,7 @@ import {
 } from "./api/api-endpoints.js";
 import { deleteCachedData } from "./indexedDB.js";
 import { CONFIG } from "./config.js";
+import { setContent } from "./utils/DOMUtils.js";
 
 const LOCATION_TYPES = [
   { value: 'local_scout_hall', labelKey: 'location_type_local_scout_hall' },
@@ -111,7 +112,7 @@ export class MaterialManagement {
     const dateFrom = document.getElementById('reservationDateFrom')?.value || getTodayISO();
     const dateTo = document.getElementById('reservationDateTo')?.value || getTodayISO();
 
-    container.innerHTML = `
+    setContent(container, `
       <a href="/dashboard" class="button button--ghost">← ${translate("back")}</a>
       <section class="page material-management-page">
         <div class="card">
@@ -125,11 +126,11 @@ export class MaterialManagement {
             <div class="grid grid-2" style="margin-bottom: 1.5rem;">
               <label class="stacked">
                 <span>${escapeHTML(translate("date_from"))}</span>
-                <input type="date" id="reservationDateFrom" value="${dateFrom}" required />
+                <input type="date" id="reservationDateFrom" value="${escapeHTML(dateFrom)}" required />
               </label>
               <label class="stacked">
                 <span>${escapeHTML(translate("date_to"))}</span>
-                <input type="date" id="reservationDateTo" value="${dateTo}" required />
+                <input type="date" id="reservationDateTo" value="${escapeHTML(dateTo)}" required />
               </label>
             </div>
             <label class="stacked">
@@ -253,7 +254,7 @@ export class MaterialManagement {
           </div>
         </div>
       </section>
-    `;
+    `);
   }
 
   attachEventHandlers() {
@@ -406,12 +407,12 @@ export class MaterialManagement {
 
     const listContainer = document.querySelector('.selected-items-list');
     if (listContainer && selectedItemsList.length > 0) {
-      listContainer.innerHTML = selectedItemsList.map(item => `
+      setContent(listContainer, selectedItemsList.map(item => `
         <li>
           <strong>${escapeHTML(item.name)}</strong> - 
           ${escapeHTML(translate("reserved_quantity"))}: ${item.selectedQuantity}
         </li>
-      `).join('');
+      `).join(''));
     }
   }
 }

--- a/spa/medication_management.js
+++ b/spa/medication_management.js
@@ -3,6 +3,7 @@ import { escapeHTML } from "./utils/SecurityUtils.js";
 import { debugError } from "./utils/DebugUtils.js";
 import { formatDate, getTodayISO } from "./utils/DateUtils.js";
 import { deleteCachedData } from "./indexedDB.js";
+import { setContent } from "./utils/DOMUtils.js";
 import {
   getParticipants,
   getMedicationRequirements,
@@ -734,7 +735,7 @@ export class MedicationManagement {
   updateScheduleFrequencyHelper() {
     const helper = document.getElementById("scheduleFrequencyHelper");
     if (helper) {
-      helper.innerHTML = this.renderScheduleFrequencyHelper();
+      setContent(helper, this.renderScheduleFrequencyHelper());
     }
   }
 
@@ -777,7 +778,7 @@ export class MedicationManagement {
       ? `<a class="pill" href="/medication-planning">${escapeHTML(translate("medication_switch_to_planning"))}</a>`
       : `<a class="pill" href="/medication-dispensing">${escapeHTML(translate("medication_switch_to_dispensing"))}</a>`;
 
-    container.innerHTML = `
+    setContent(container, `
       <a href="/dashboard" class="button button--ghost">← ${translate("back")}</a>
       <section class="page medication-page">
         <div class="card">
@@ -791,8 +792,7 @@ export class MedicationManagement {
           ? this.renderPlanningSection({ medicationSuggestions, participantOptions })
           : this.renderDispensingSection({ today, timeValue, requirementOptions, participantOptions })}
       </section>
-    `;
-
+    `);
     if (this.view === "dispensing") {
       this.renderAlertArea();
       this.updateScheduleFrequencyHelper();
@@ -1041,7 +1041,7 @@ export class MedicationManagement {
   updateUpcomingTable() {
     const tableBody = document.getElementById("medication-upcoming-table-body");
     if (tableBody) {
-      tableBody.innerHTML = this.renderUpcomingRows();
+      setContent(tableBody, this.renderUpcomingRows());
     }
   }
 
@@ -1097,12 +1097,12 @@ export class MedicationManagement {
     const alerts = this.getAggregatedAlerts();
 
     if (!alerts.length) {
-      container.innerHTML = `<p>${escapeHTML(translate("medication_alerts_empty"))}</p>`;
+      setContent(container, `<p>${escapeHTML(translate("medication_alerts_empty"))}</p>`);
       return;
     }
 
-    container.innerHTML = alerts.map((alert) => {
-      const timeLabel = alert.time.toLocaleTimeString(this.app.lang || "en", { hour: "2-digit", minute: "2-digit" });
+    setContent(container, alerts.map((alert) => {
+      const timeLabel = alert.time.toLocaleTimeString(this.app.lang || "en", { hour: "2-digit", minute: "2-digit" }));
       const dateLabel = formatDate(alert.time.toISOString(), this.app.lang || "en", { year: "numeric", month: "short", day: "numeric" });
       const dueLabel = alert.minutesUntil <= 5 ? translate("medication_due_now") : translate("medication_due_in_minutes").replace("{minutes}", alert.minutesUntil);
 
@@ -1201,7 +1201,7 @@ export class MedicationManagement {
     frequencyPresetSelect?.addEventListener("change", (event) => {
       const container = document.getElementById("frequencyPresetFields");
       if (container) {
-        container.innerHTML = this.getFrequencyPresetFieldsMarkup(event.target.value);
+        setContent(container, this.getFrequencyPresetFieldsMarkup(event.target.value));
       }
     });
 
@@ -1573,7 +1573,7 @@ export class MedicationManagement {
     }
     details += `<div><strong>${escapeHTML(translate("time"))}:</strong> ${new Date().toLocaleTimeString(this.app.lang || "en", { hour: "2-digit", minute: "2-digit" })}</div>`;
 
-    detailsDiv.innerHTML = details;
+    setContent(detailsDiv, details);
     modal.style.display = "flex";
 
     // Focus witness field
@@ -1641,7 +1641,7 @@ export class MedicationManagement {
       // Re-render cards
       const cardsContainer = document.getElementById("participant-medication-cards");
       if (cardsContainer) {
-        cardsContainer.innerHTML = this.renderParticipantMedicationCards();
+        setContent(cardsContainer, this.renderParticipantMedicationCards());
       }
 
       this.renderAlertArea();

--- a/spa/modules/ActivityManager.js
+++ b/spa/modules/ActivityManager.js
@@ -1,5 +1,6 @@
 import { translate } from "../app.js";
 import { getSectionActivityTemplates } from "../utils/meetingSections.js";
+import { setContent } from "../utils/DOMUtils.js";
 
 /**
  * ActivityManager - Handles all activity-related operations
@@ -82,7 +83,7 @@ export class ActivityManager {
                         return this.renderActivityRow(activity, index);
                 }).join('');
 
-                document.querySelector('#activities-table tbody').innerHTML = activitiesHtml;
+                setContent(document.querySelector('#activities-table tbody'), activitiesHtml);
                 this.addDurationListeners();
         }
 

--- a/spa/modules/FormManager.js
+++ b/spa/modules/FormManager.js
@@ -1,5 +1,6 @@
 import { translate } from "../app.js";
 import { escapeHTML } from "../utils/SecurityUtils.js";
+import { setContent } from "../utils/DOMUtils.js";
 
 /**
  * FormManager - Handles form population, validation, and data extraction
@@ -55,11 +56,11 @@ export class FormManager {
                 const honorList = document.getElementById("youth-of-honor");
                 const honorData = meetingData.youth_of_honor ?? meetingData.louveteau_dhonneur;
                 if (Array.isArray(honorData)) {
-                        honorList.innerHTML = honorData.map(honor => `<li>${escapeHTML(honor)}</li>`).join('');
+                        setContent(honorList, honorData.map(honor => `<li>${escapeHTML(honor)}</li>`).join(''));
                 } else if (typeof honorData === 'string') {
-                        honorList.innerHTML = `<li>${escapeHTML(honorData)}</li>`;
+                        setContent(honorList, `<li>${escapeHTML(honorData)}</li>`);
                 } else {
-                        honorList.innerHTML = this.recentHonors.map(h => `<li>${escapeHTML(`${h.first_name} ${h.last_name}`)}</li>`).join('');
+                        setContent(honorList, this.recentHonors.map(h => `<li>${escapeHTML(`${h.first_name} ${h.last_name}`)}</li>`).join(''));
                 }
 
                 document.getElementById("endroit").value = meetingData.endroit || this.organizationSettings.organization_info?.endroit || '';
@@ -108,7 +109,7 @@ export class FormManager {
         resetForm(currentDate) {
                 document.getElementById("animateur-responsable").value = '';
                 document.getElementById("date").value = this.formatDateForInput(currentDate);
-                document.getElementById("youth-of-honor").innerHTML = '';
+                setContent(document.getElementById("youth-of-honor"), '');
                 document.getElementById("endroit").value = this.organizationSettings.organization_info?.endroit || '';
                 document.getElementById("notes").value = '';
 

--- a/spa/modules/account-info.js
+++ b/spa/modules/account-info.js
@@ -13,6 +13,7 @@ import { translate } from "../app.js";
 import { escapeHTML } from "../utils/SecurityUtils.js";
 import { WhatsAppConnectionModule } from "./whatsapp-connection.js";
 import { canSendCommunications, isParent } from "../utils/PermissionUtils.js";
+import { setContent } from "../utils/DOMUtils.js";
 
 /**
  * Account Information Management Class
@@ -384,7 +385,7 @@ export class AccountInfoModule {
 
     const appContainer = document.getElementById("app");
     if (appContainer) {
-      appContainer.innerHTML = content;
+      setContent(appContainer, content);
     } else {
       debugError("App container not found");
     }
@@ -406,7 +407,7 @@ export class AccountInfoModule {
 
     const appContainer = document.getElementById("app");
     if (appContainer) {
-      appContainer.innerHTML = content;
+      setContent(appContainer, content);
     }
   }
 

--- a/spa/parent_contact_list.js
+++ b/spa/parent_contact_list.js
@@ -3,6 +3,7 @@ import { debugLog, debugError, debugWarn, debugInfo } from "./utils/DebugUtils.j
 import { translate } from "./app.js";
 import { canSendCommunications, canViewParticipants } from "./utils/PermissionUtils.js";
 import { debounce } from "./utils/PerformanceUtils.js";
+import { setContent } from "./utils/DOMUtils.js";
 
 export class ParentContactList {
   constructor(app) {
@@ -108,7 +109,7 @@ export class ParentContactList {
                 ${this.renderChildrenByFirstName()}
             </div>
         `;
-    document.getElementById("app").innerHTML = content;
+    setContent(document.getElementById("app"), content);
     this.attachEventListeners();
   }
 
@@ -261,7 +262,7 @@ export class ParentContactList {
   updateContactList() {
     const contactList = document.getElementById("contact-list");
     if (contactList) {
-      contactList.innerHTML = this.renderChildrenByFirstName();
+      setContent(contactList, this.renderChildrenByFirstName());
     }
   }
 
@@ -276,6 +277,6 @@ export class ParentContactList {
             <h1>${translate("error")}</h1>
             <p>${translate("error_loading_parent_contact_list")}</p>
         `;
-    document.getElementById("app").innerHTML = errorMessage;
+    setContent(document.getElementById("app"), errorMessage);
   }
 }

--- a/spa/parent_dashboard.js
+++ b/spa/parent_dashboard.js
@@ -849,6 +849,6 @@ renderFormButtons(participant) {
                                 <h1>${translate("error")}</h1>
                                 <p>${translate("error_loading_parent_dashboard")}</p>
                         `;
-                        document.getElementById("app").innerHTML = errorMessage;
+                        setContent(document.getElementById("app"), errorMessage);
                 }
         }

--- a/spa/parent_finance.js
+++ b/spa/parent_finance.js
@@ -12,6 +12,7 @@ import { escapeHTML } from "./utils/SecurityUtils.js";
 import { formatDateShort } from "./utils/DateUtils.js";
 import { LoadingStateManager, retryWithBackoff } from "./utils/PerformanceUtils.js";
 import { isParent } from "./utils/PermissionUtils.js";
+import { setContent } from "./utils/DOMUtils.js";
 
 export class ParentFinance {
   constructor(app) {
@@ -237,7 +238,7 @@ export class ParentFinance {
       </div>
     `;
 
-    document.getElementById("app").innerHTML = content;
+    setContent(document.getElementById("app"), content);
   }
 
   render() {
@@ -264,7 +265,7 @@ export class ParentFinance {
       </section>
     `;
 
-    document.getElementById("app").innerHTML = content;
+    setContent(document.getElementById("app"), content);
   }
 
   renderConsolidatedSummary() {

--- a/spa/permission_slip_dashboard.js
+++ b/spa/permission_slip_dashboard.js
@@ -14,6 +14,7 @@ import {
 import { getGroups } from "./api/api-endpoints.js";
 import { getParticipants } from "./api/api-endpoints.js";
 import { deleteCachedData } from "./indexedDB.js";
+import { setContent } from "./utils/DOMUtils.js";
 
 export class PermissionSlipDashboard {
   constructor(app) {
@@ -68,7 +69,7 @@ export class PermissionSlipDashboard {
     const signedCount = permissionSummary.find(s => s.status === 'signed')?.count || 0;
     const pendingCount = permissionSummary.find(s => s.status === 'pending')?.count || 0;
 
-    container.innerHTML = `
+    setContent(container, `
       <a href="/dashboard" class="button button--ghost">← ${translate("back")}</a>
       <section class="page permission-slip-dashboard">
         <div class="card">
@@ -111,7 +112,7 @@ export class PermissionSlipDashboard {
           ${this.renderPermissionSlipsTable()}
         </div>
       </section>
-    `;
+    `);
 
   }
 
@@ -416,17 +417,17 @@ export class PermissionSlipDashboard {
     const filteredParticipants = this.filterParticipantsByAudience(this.selectedAudience);
 
     if (filteredParticipants.length === 0) {
-      participantsList.innerHTML = `<p>${escapeHTML(translate("no_participants_in_selection"))}</p>`;
+      setContent(participantsList, `<p>${escapeHTML(translate("no_participants_in_selection"))}</p>`);
       participantsSection.style.display = 'block';
       return;
     }
 
-    participantsList.innerHTML = filteredParticipants.map(p => `
+    setContent(participantsList, filteredParticipants.map(p => `
       <label style="display: block; padding: 8px; cursor: pointer; border-bottom: 1px solid #eee;">
         <input type="checkbox" class="participant-checkbox" value="${p.id}" checked />
         ${escapeHTML(p.first_name)} ${escapeHTML(p.last_name)}
       </label>
-    `).join('');
+    `).join(''));
 
     participantsSection.style.display = 'block';
 

--- a/spa/permission_slip_sign.js
+++ b/spa/permission_slip_sign.js
@@ -5,6 +5,7 @@ import { translate } from './app.js';
 import { debugLog, debugError } from './utils/DebugUtils.js';
 import { API } from './api/api-core.js';
 import { CONFIG } from './config.js';
+import { setContent } from "./utils/DOMUtils.js";
 
 export class PermissionSlipSign {
   constructor(app, slipId) {
@@ -49,14 +50,14 @@ export class PermissionSlipSign {
     const appDiv = document.getElementById('app');
 
     if (!this.slip) {
-      appDiv.innerHTML = `
+      setContent(appDiv, `
         <div class="container mt-5">
           <div class="alert alert-danger">
             <h4>${translate('error')}</h4>
             <p>${translate('permission_slip_not_found')}</p>
           </div>
         </div>
-      `;
+      `);
       return;
     }
 
@@ -69,7 +70,7 @@ export class PermissionSlipSign {
     const isSigned = this.slip.status === 'signed';
     const canSign = this.slip.status === 'pending' && (!this.slip.deadline_date || new Date(this.slip.deadline_date) > new Date());
 
-    appDiv.innerHTML = `
+    setContent(appDiv, `
       <div class="container mt-5">
         <div class="card">
           <div class="card-header bg-primary text-white">
@@ -134,7 +135,7 @@ export class PermissionSlipSign {
           </div>
         </div>
       </div>
-    `;
+    `);
   }
 
   attachEventListeners() {
@@ -168,8 +169,7 @@ export class PermissionSlipSign {
     }
 
     signBtn.disabled = true;
-    signBtn.innerHTML = '<span class="spinner-border spinner-border-sm"></span> ' + translate('signing');
-
+    setContent(signBtn, '<span class="spinner-border spinner-border-sm"></span> ' + translate('signing'));
     try {
       const response = await API.patch(`v1/resources/permission-slips/${this.slipId}/sign`, {
         signed_by: guardianName,
@@ -187,19 +187,19 @@ export class PermissionSlipSign {
       debugError('Error signing permission slip:', error);
       alert(translate('error_signing_slip'));
       signBtn.disabled = false;
-      signBtn.innerHTML = '<i class="fas fa-signature"></i> ' + translate('sign_permission_slip');
+      setContent(signBtn, '<i class="fas fa-signature"></i> ' + translate('sign_permission_slip'));
     }
   }
 
   showError(message) {
     const appDiv = document.getElementById('app');
-    appDiv.innerHTML = `
+    setContent(appDiv, `
       <div class="container mt-5">
         <div class="alert alert-danger">
           <h4>${translate('error')}</h4>
           <p>${message}</p>
         </div>
       </div>
-    `;
+    `);
   }
 }

--- a/spa/pwa-update-manager.js
+++ b/spa/pwa-update-manager.js
@@ -8,6 +8,7 @@
 import { CONFIG } from './config.js';
 import { debugLog, debugError, debugWarn, debugInfo } from "./utils/DebugUtils.js";
 import { deleteIndexedDB } from './indexedDB.js';
+import { setContent } from "./utils/DOMUtils.js";
 
 class PWAUpdateManager {
     constructor() {
@@ -248,7 +249,7 @@ class PWAUpdateManager {
 
         const msg = messages[lang] || messages[CONFIG.DEFAULT_LANG] || messages.fr;
 
-        prompt.innerHTML = `
+        setContent(prompt, `
             <div class="pwa-update-content">
                 <div class="pwa-update-icon">🔄</div>
                 <div class="pwa-update-text">
@@ -264,8 +265,7 @@ class PWAUpdateManager {
                     </button>
                 </div>
             </div>
-        `;
-
+        `);
         // Add event listeners
         prompt.querySelector('#pwa-update-now').addEventListener('click', () => {
             this.applyUpdate();
@@ -509,9 +509,9 @@ class PWAUpdateManager {
     showLoadingIndicator() {
         const loader = document.createElement('div');
         loader.id = 'pwa-update-loader';
-        loader.innerHTML = `
+        setContent(loader, `
             <div style="
-                position: fixed;
+                position: fixed);
                 top: 50%;
                 left: 50%;
                 transform: translate(-50%, -50%);

--- a/spa/reports.js
+++ b/spa/reports.js
@@ -27,6 +27,7 @@ import {
 import { escapeHTML } from "./utils/SecurityUtils.js";
 import { formatDateShort, isoToDateString } from "./utils/DateUtils.js";
 import { canViewReports } from "./utils/PermissionUtils.js";
+import { setContent } from "./utils/DOMUtils.js";
 
 const REPORT_CURRENCY = "CAD";
 
@@ -203,7 +204,7 @@ export class Reports {
                                 </div>
                         </div>
                 `;
-		document.getElementById("app").innerHTML = content;
+		setContent(document.getElementById("app"), content);
 	}
 
 	attachEventListeners() {
@@ -271,7 +272,7 @@ export class Reports {
 			const selectElement = document.getElementById("form-type-select");
 
 			if (!response || !response.data || response.data.length === 0) {
-				selectElement.innerHTML = `<option value="">${translate("no_form_types_available")}</option>`;
+				setContent(selectElement, `<option value="">${translate("no_form_types_available")}</option>`);
 				return;
 			}
 
@@ -291,8 +292,7 @@ export class Reports {
 			});
 		} catch (error) {
 			debugError("Error loading form types:", error);
-			document.getElementById("form-type-container").innerHTML =
-				`<p>${translate("error_loading_form_types")}</p>`;
+			setContent(document.getElementById("form-type-container"), `<p>${translate("error_loading_form_types")}</p>`);
 		}
 	}
 
@@ -391,15 +391,15 @@ export class Reports {
 					reportContent = "<p>Invalid report type</p>";
 			}
 
-			document.getElementById("report-content").innerHTML = reportContent;
+			setContent(document.getElementById("report-content"), reportContent);
 			if (reportType === "participant-progress") {
 				this.attachParticipantProgressListeners();
 			}
 		} catch (error) {
 			debugError(`Error loading ${reportType} report:`, error);
-			document.getElementById("report-content").innerHTML = `
-				<p class="error-message">${translate("error_loading_report")}: ${error.message}</p>
-			`;
+			setContent(document.getElementById("report-content"), `
+				<p class="error-message">${translate("error_loading_report")}: ${escapeHTML(error.message)}</p>
+			`);
 		}
 	}
 
@@ -435,7 +435,7 @@ export class Reports {
 			return reportContent; // Return the generated reportContent
 		} catch (error) {
 			debugError("Error fetching and rendering health report:", error);
-			return `<p class="error-message">${translate("error_loading_report")}: ${error.message}</p>`;
+			return `<p class="error-message">${translate("error_loading_report")}: ${escapeHTML(error.message)}</p>`;
 		}
 	}
 
@@ -539,7 +539,7 @@ export class Reports {
 			return missingFieldsReport;
 		} catch (error) {
 			debugError("Error fetching or rendering missing fields report:", error);
-			return `<p>${translate("error_loading_report")}: ${error.message}</p>`;
+			return `<p>${translate("error_loading_report")}: ${escapeHTML(error.message)}</p>`;
 		}
 	}
 
@@ -1416,7 +1416,7 @@ export class Reports {
 			select.addEventListener("change", async (event) => {
 				this.selectedParticipantId = event.target.value || null;
 				const content = await this.fetchAndRenderParticipantProgress();
-				document.getElementById("report-content").innerHTML = content;
+				setContent(document.getElementById("report-content"), content);
 				this.attachParticipantProgressListeners();
 			});
 		}
@@ -1455,7 +1455,7 @@ export class Reports {
 					return this.renderParticipantProgressReport(cached.progress, true);
 				}
 			}
-			return `<p class="error-message">${translate("error_loading_report")}: ${error.message}</p>`;
+			return `<p class="error-message">${translate("error_loading_report")}: ${escapeHTML(error.message)}</p>`;
 		}
 	}
 

--- a/spa/revenue-dashboard.js
+++ b/spa/revenue-dashboard.js
@@ -10,6 +10,7 @@ import { escapeHTML } from "./utils/SecurityUtils.js";
 import { debugError, debugLog } from "./utils/DebugUtils.js";
 import { getTodayISO } from "./utils/DateUtils.js";
 import { LoadingStateManager, retryWithBackoff } from "./utils/PerformanceUtils.js";
+import { setContent } from "./utils/DOMUtils.js";
 
 const DEFAULT_CURRENCY = "CAD";
 
@@ -205,7 +206,7 @@ export class RevenueDashboard {
     const container = document.getElementById("app");
     if (!container) return;
 
-    container.innerHTML = `
+    setContent(container, `
       <div class="page-container revenue-dashboard-page">
         <div class="page-header">
           <a href="/dashboard" class="button button--ghost">← ${translate("back")}</a>
@@ -221,14 +222,14 @@ export class RevenueDashboard {
           <p>${translate("loading")}...</p>
         </div>
       </div>
-    `;
+    `);
   }
 
   async render() {
     const container = document.getElementById("app");
     if (!container) return;
 
-    container.innerHTML = `
+    setContent(container, `
       <div class="page-container revenue-dashboard-page">
         <div class="page-header">
           <a href="/dashboard" class="button button--ghost">← ${translate("back")}</a>
@@ -262,7 +263,7 @@ export class RevenueDashboard {
           ${this.renderTabContent()}
         </div>
       </div>
-    `;
+    `);
   }
 
   renderDateRangeSelector() {

--- a/spa/role_management.js
+++ b/spa/role_management.js
@@ -12,6 +12,7 @@ import { debugLog, debugError } from './utils/DebugUtils.js';
 import { hasPermission, isDistrictAdmin } from './utils/PermissionUtils.js';
 import { getStorage } from './utils/StorageUtils.js';
 import { escapeHTML } from './utils/SecurityUtils.js';
+import { setContent } from "./utils/DOMUtils.js";
 import {
   clearActivityRelatedCaches,
   clearParticipantRelatedCaches,
@@ -160,24 +161,24 @@ export class RoleManagement {
 
   renderAccessDenied() {
     const appContainer = document.getElementById('app');
-    appContainer.innerHTML = `
+    setContent(appContainer, `
       <div class="role-management-container">
         <h1>${translate('access_denied') || 'Access Denied'}</h1>
         <p>${translate('no_permission_role_management') || 'You do not have permission to manage roles.'}</p>
         <a href="/dashboard" class="btn-primary">${translate('back_to_dashboard') || 'Back to Dashboard'}</a>
       </div>
-    `;
+    `);
   }
 
   renderError(message) {
     const appContainer = document.getElementById('app');
-    appContainer.innerHTML = `
+    setContent(appContainer, `
       <div class="role-management-container">
         <h1>${translate('error') || 'Error'}</h1>
         <p class="error-message">${message}</p>
         <a href="/dashboard" class="btn-primary">${translate('back_to_dashboard') || 'Back to Dashboard'}</a>
       </div>
-    `;
+    `);
   }
 
   render() {
@@ -216,8 +217,7 @@ export class RoleManagement {
     `;
 
     const appContainer = document.getElementById('app');
-    appContainer.innerHTML = content;
-
+    setContent(appContainer, content);
     // Attach event listeners
     this.attachEventListeners();
   }
@@ -494,10 +494,10 @@ export class RoleManagement {
       if (container) {
         try {
           const permissions = await this.fetchRolePermissions(roleId);
-          container.innerHTML = this.renderPermissionsList(permissions);
+          setContent(container, this.renderPermissionsList(permissions));
         } catch (error) {
           debugError('Error loading role permissions:', error);
-          container.innerHTML = `<p class="error-message">${escapeHTML(error.message)}</p>`;
+          setContent(container, `<p class="error-message">${escapeHTML(error.message)}</p>`);
         }
       }
     }
@@ -540,11 +540,9 @@ export class RoleManagement {
     this.selectedUserId = userId;
 
     const assignmentContent = document.getElementById('user-assignment-content');
-    assignmentContent.innerHTML = '<div class="loading-spinner">Loading...</div>';
-
+    setContent(assignmentContent, '<div class="loading-spinner">Loading...</div>');
     const html = await this.renderUserAssignment(userId);
-    assignmentContent.innerHTML = html;
-
+    setContent(assignmentContent, html);
     // Attach form listener
     this.attachAssignmentFormListeners();
   }
@@ -557,8 +555,7 @@ export class RoleManagement {
     if (cancelBtn) {
       cancelBtn.addEventListener('click', () => {
         this.selectedUserId = null;
-        document.getElementById('user-assignment-content').innerHTML = this.renderUserAssignmentPlaceholder();
-
+        setContent(document.getElementById('user-assignment-content'), this.renderUserAssignmentPlaceholder());
         // Remove selected state from users
         document.querySelectorAll('.user-item').forEach(item => {
           item.classList.remove('selected');
@@ -584,7 +581,7 @@ export class RoleManagement {
 
         // Refresh user list
         await this.fetchUsers();
-        document.getElementById('user-list').innerHTML = this.renderUserList();
+        setContent(document.getElementById('user-list'), this.renderUserList());
         this.attachUsersTabListeners();
       } catch (error) {
         debugError('Error updating roles:', error);

--- a/spa/time_since_registration.js
+++ b/spa/time_since_registration.js
@@ -5,6 +5,7 @@ import {
 } from "./ajax-functions.js";
 import { translate } from "./app.js";
 import { debugLog, debugError } from "./utils/DebugUtils.js";
+import { setContent } from "./utils/DOMUtils.js";
 
 export class TimeSinceRegistration {
   constructor(app) {
@@ -60,7 +61,7 @@ export class TimeSinceRegistration {
       </div>
       <div id="registration-list" class="registration-list"></div>
     `;
-    document.getElementById("app").innerHTML = content;
+    setContent(document.getElementById("app"), content);
     this.renderList();
   }
 
@@ -68,7 +69,7 @@ export class TimeSinceRegistration {
     const list = document.getElementById("registration-list");
 
     if (!this.participants || this.participants.length === 0) {
-      list.innerHTML = `<p class="no-data">${translate("no_participants_found")}</p>`;
+      setContent(list, `<p class="no-data">${translate("no_participants_found")}</p>`);
       return;
     }
 
@@ -134,7 +135,7 @@ export class TimeSinceRegistration {
       </table>
     `;
 
-    list.innerHTML = html;
+    setContent(list, html);
   }
 
   getSortedParticipants() {
@@ -209,6 +210,6 @@ export class TimeSinceRegistration {
         <p>${translate("error_loading_data")}</p>
       </div>
     `;
-    document.getElementById("app").innerHTML = content;
+    setContent(document.getElementById("app"), content);
   }
 }

--- a/spa/upcoming_meeting.js
+++ b/spa/upcoming_meeting.js
@@ -2,6 +2,7 @@ import { translate } from "./app.js";
 import { debugLog, debugError, debugWarn, debugInfo } from "./utils/DebugUtils.js";
 import { getReunionDates, getReunionPreparation } from "./ajax-functions.js";
 import { formatDate, isToday, parseDate } from "./utils/DateUtils.js";
+import { setContent } from "./utils/DOMUtils.js";
 
 export class UpcomingMeeting {
                 constructor(app) {
@@ -156,7 +157,7 @@ export class UpcomingMeeting {
 
                 render() {
                                 if (!this.closestMeeting) {
-                                                document.getElementById("app").innerHTML = `
+                                                setContent(document.getElementById("app"), `
                                                                 <div class="upcoming-meeting">
                                                                                 <a href="/dashboard" class="button button--ghost">← ${translate("back")}</a>
                                                                                 <h1>${translate("upcoming_meeting")}</h1>
@@ -168,7 +169,7 @@ export class UpcomingMeeting {
                                                                                                 </a>
                                                                                 </div>
                                                                 </div>
-                                                `;
+                                                `);
                                                 return;
                                 }
 
@@ -203,7 +204,7 @@ export class UpcomingMeeting {
                                                 </div>
                                 `;
 
-                                document.getElementById("app").innerHTML = content;
+                                setContent(document.getElementById("app"), content);
                 }
 
                 renderError() {
@@ -217,6 +218,6 @@ export class UpcomingMeeting {
                                                                 </div>
                                                 </div>
                                 `;
-                                document.getElementById("app").innerHTML = content;
+                                setContent(document.getElementById("app"), content);
                 }
 }

--- a/spa/utils/SecurityUtils.js
+++ b/spa/utils/SecurityUtils.js
@@ -294,7 +294,6 @@ export function safeAppendHTML(element, html, options = {}) {
 
   const temp = document.createElement('div');
   temp.innerHTML = sanitizeHTML(html, options);
-
   while (temp.firstChild) {
     element.appendChild(temp.firstChild);
   }

--- a/spa/utils/SimpleWYSIWYG.js
+++ b/spa/utils/SimpleWYSIWYG.js
@@ -5,6 +5,7 @@
 
 import { translate } from "../app.js";
 import { escapeHTML } from "./SecurityUtils.js";
+import { setContent } from "./DOMUtils.js";
 
 export class SimpleWYSIWYG {
   constructor(container, options = {}) {
@@ -23,7 +24,7 @@ export class SimpleWYSIWYG {
 
   init() {
     // Clear container
-    this.container.innerHTML = "";
+    setContent(this.container, "");
     this.container.classList.add("wysiwyg-container");
 
     // Create toolbar
@@ -51,7 +52,7 @@ export class SimpleWYSIWYG {
       const button = document.createElement("button");
       button.type = "button";
       button.className = "wysiwyg-btn";
-      button.innerHTML = icon;
+      setContent(button, icon);
       button.title = title;
       button.setAttribute("data-command", command);
       this.toolbar.appendChild(button);
@@ -69,7 +70,7 @@ export class SimpleWYSIWYG {
     this.editor.setAttribute("aria-label", this.options.placeholder);
 
     if (this.options.initialContent) {
-      this.editor.innerHTML = this.options.initialContent;
+      setContent(this.editor, this.options.initialContent);
     } else {
       this.editor.setAttribute("data-placeholder", this.options.placeholder);
     }
@@ -173,12 +174,12 @@ export class SimpleWYSIWYG {
   }
 
   setHTML(html) {
-    this.editor.innerHTML = html;
+    setContent(this.editor, html);
     this.updatePlaceholder();
   }
 
   clear() {
-    this.editor.innerHTML = "";
+    setContent(this.editor, "");
     this.updatePlaceholder();
   }
 
@@ -187,7 +188,7 @@ export class SimpleWYSIWYG {
   }
 
   destroy() {
-    this.container.innerHTML = "";
+    setContent(this.container, "");
   }
 }
 

--- a/spa/view_participant_documents.js
+++ b/spa/view_participant_documents.js
@@ -3,6 +3,7 @@ import { debugLog, debugError, debugWarn, debugInfo } from "./utils/DebugUtils.j
 import { translate } from "./app.js";
 import { JSONFormRenderer } from "./JSONFormRenderer.js";
 import { canViewParticipants } from "./utils/PermissionUtils.js";
+import { setContent } from "./utils/DOMUtils.js";
 
 export class ViewParticipantDocuments {
   constructor(app) {
@@ -92,7 +93,7 @@ export class ViewParticipantDocuments {
         </div>
       </div>
     `;
-    document.getElementById("app").innerHTML = content;
+    setContent(document.getElementById("app"), content);
   }
 
   renderParticipantList() {
@@ -159,7 +160,7 @@ export class ViewParticipantDocuments {
 
       // Pass submission_data to render
       const formContent = this.formRenderers[formType].render(submissionData);
-      document.getElementById('form-content').innerHTML = formContent;
+      setContent(document.getElementById('form-content'), formContent);
       document.getElementById('form-view-modal').style.display = "block";
     } catch (error) {
       debugError(`Error fetching form data for ${formType}:`, error);
@@ -173,6 +174,6 @@ export class ViewParticipantDocuments {
       <p>${message || translate("error_loading_participant_documents")}</p>
       <p><a href="/dashboard">${translate("back_to_dashboard")}</a></p>
     `;
-    document.getElementById("app").innerHTML = errorMessage;
+    setContent(document.getElementById("app"), errorMessage);
   }
 }


### PR DESCRIPTION
### Motivation
- Eliminate remaining unsafe `innerHTML` assignments that allow XSS when user-controlled data is interpolated. 
- Centralize sanitization and safe DOM updates through the `DOMUtils.setContent` helper and `SecurityUtils.escapeHTML`. 
- Ensure templates and error messages consistently escape user data and follow the project's security guidelines.

### Description
- Replaced direct `element.innerHTML = ...` assignments with `setContent(element, ...)` across many SPA modules and components to enforce sanitization on insertion. 
- Added missing `import { setContent } from './utils/DOMUtils.js'` and used `escapeHTML` where template literals include user-provided values or error messages. 
- Fixed and normalized `DOMUtils.setContent`, `createFragment`, and `SecurityUtils` helpers to use `sanitizeHTML`/`escapeHTML` correctly and avoid recursive/self-call bugs. 
- Escaped error message interpolations and other user-facing strings in report/admin templates and multiple render functions to prevent reflected/stored XSS.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695034bf1350832499f308b91555d383)