### PR TITLE
Fix broken image paths after directory move

### DIFF
--- a/landing/en/index.html
+++ b/landing/en/index.html
@@ -34,7 +34,7 @@
     />
     <meta
       property="og:image"
-      content="https://wampums.app/images/og-wampums-1200x630.jpg"
+      content="https://wampums.app/assets/images/og-wampums-1200x630.jpg"
     />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -48,7 +48,7 @@
     />
     <meta
       name="twitter:image"
-      content="https://wampums.app/images/og-wampums-1200x630.jpg"
+      content="https://wampums.app/assets/images/og-wampums-1200x630.jpg"
     />
 
     <!-- PWA -->

--- a/landing/index.html
+++ b/landing/index.html
@@ -19,7 +19,7 @@
     <meta property="og:site_name" content="Wampums" />
     <meta
       property="og:image"
-      content="https://wampums.app/images/og-wampums-1200x630.jpg"
+      content="https://wampums.app/assets/images/og-wampums-1200x630.jpg"
     />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -38,7 +38,7 @@
     />
     <meta
       name="twitter:image"
-      content="https://wampums.app/images/og-wampums-1200x630.jpg"
+      content="https://wampums.app/assets/images/og-wampums-1200x630.jpg"
     />
 
     <!-- PWA / UI polish -->

--- a/manifest.json
+++ b/manifest.json
@@ -15,13 +15,13 @@
   "dir": "ltr",
   "icons": [
     {
-      "src": "/images/icon-192x192.png",
+      "src": "/assets/images/icon-192x192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/images/icon-512x512.png",
+      "src": "/assets/images/icon-512x512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any maskable"
@@ -37,7 +37,7 @@
       "url": "/attendance",
       "icons": [
         {
-          "src": "/images/icon-192x192.png",
+          "src": "/assets/images/icon-192x192.png",
           "sizes": "192x192"
         }
       ]
@@ -49,7 +49,7 @@
       "url": "/dashboard",
       "icons": [
         {
-          "src": "/images/icon-192x192.png",
+          "src": "/assets/images/icon-192x192.png",
           "sizes": "192x192"
         }
       ]


### PR DESCRIPTION
Updated hardcoded image references in manifest and landing pages to use the new /assets/images/ path. This fixes broken icons, PWA shortcuts, and social media OG images.

Files updated:
- manifest.json: PWA icons and shortcut icons
- landing/index.html: Open Graph and Twitter meta images
- landing/en/index.html: Open Graph and Twitter meta images