### PR TITLE
Fix link navigation by using closest() to handle clicks on child elem…

### DIFF
--- a/spa/router.js
+++ b/spa/router.js
@@ -837,8 +837,10 @@ export function initRouter(app) {
 
     // Handle navigation
     document.addEventListener("click", (e) => {
-        if (e.target.matches("a")) {
-            const url = e.target.getAttribute("href");
+        // Find the closest anchor tag (handles clicks on child elements)
+        const anchor = e.target.closest("a");
+        if (anchor) {
+            const url = anchor.getAttribute("href");
             // Only handle valid internal URLs
             if (url && url !== '#' && url !== '' && !url.startsWith('javascript:')) {
                 e.preventDefault();


### PR DESCRIPTION
…ents

- Change from e.target.matches('a') to e.target.closest('a')
- This handles clicks on child elements like <i> icons and <span> text inside links
- Fixes issue where links with nested elements weren't responding to clicks