### PR TITLE
Fix pages inaccessible due to API configuration

### DIFF
--- a/spa/activities.js
+++ b/spa/activities.js
@@ -100,7 +100,7 @@ export class Activities {
           ` : ''}
         </div>
       </section>
-    `;
+    `);
   }
 
   renderActivityCard(activity) {

--- a/spa/carpool.js
+++ b/spa/carpool.js
@@ -79,7 +79,7 @@ export class CarpoolLanding {
           ${this.renderSkeletonCard(translate("current_assignments"), 2)}
         </div>
       </section>
-    `;
+    `);
   }
 
   /**

--- a/spa/inventory.js
+++ b/spa/inventory.js
@@ -943,7 +943,7 @@ export class Inventory {
           }
         }
       </style>
-    `;
+    `);
   }
 
   renderGalleryView() {

--- a/spa/medication_management.js
+++ b/spa/medication_management.js
@@ -1130,7 +1130,7 @@ export class MedicationManagement {
           </div>
         </div>
       `;
-    }).join("");
+    }).join(""));
   }
 
   /**

--- a/spa/parent_dashboard.js
+++ b/spa/parent_dashboard.js
@@ -726,7 +726,7 @@ renderFormButtons(participant) {
                                 </div>
                                 <div class="statement-lines">${feeLines}</div>
                         </div>
-                `;
+                `);
 
                 document.body.appendChild(modal);
 
@@ -790,7 +790,7 @@ renderFormButtons(participant) {
                                                 </div>
                                         </div>
                                 </div>
-                        `;
+                        `);
 
                         document.body.appendChild(modal);
 

--- a/spa/preparation_reunions.js
+++ b/spa/preparation_reunions.js
@@ -17,7 +17,6 @@ import { FormManager } from "./modules/FormManager.js";
 import { DateManager } from "./modules/DateManager.js";
 import { PrintManager } from "./modules/PrintManager.js";
 import { getActiveSectionConfig, getHonorLabel } from "./utils/meetingSections.js";
-import { escapeHTML } from "./utils/SecurityUtils.js";
 
 export class PreparationReunions {
         constructor(app) {


### PR DESCRIPTION
This commit fixes syntax errors that were preventing several pages from loading:

1. Added missing closing parentheses for setContent() calls in:
   - spa/activities.js:103
   - spa/carpool.js:82
   - spa/inventory.js:946
   - spa/medication_management.js:1133
   - spa/parent_dashboard.js:729, 793

2. Removed duplicate escapeHTML import in:
   - spa/preparation_reunions.js:20

All files were missing the closing parenthesis for setContent() after the template literal backtick, which caused "missing ) after argument list" syntax errors at runtime.

The pattern was:
  setContent(element, `...`);  // Missing closing )

Fixed to:
  setContent(element, `...`));  // Correct