### PR TITLE
Fix router intercepting button clicks and breaking tab navigation

### DIFF
--- a/spa/router.js
+++ b/spa/router.js
@@ -837,6 +837,11 @@ export function initRouter(app) {
 
     // Handle navigation
     document.addEventListener("click", (e) => {
+        // Skip if the click target is a button or inside a button
+        if (e.target.closest("button")) {
+            return;
+        }
+
         // Find the closest anchor tag (handles clicks on child elements)
         const anchor = e.target.closest("a");
         if (anchor) {


### PR DESCRIPTION
The router's link click handler was catching button clicks due to using e.target.closest("a") without first checking if the click originated from a button. This caused tab navigation buttons (which use data-tab attributes) to be incorrectly intercepted as navigation links.

Added a check to skip button clicks before searching for anchor tags, allowing buttons to handle their own click events properly.

Fixes: Tab navigation in /finance, /budgets, and other pages with tabs