### PR TITLE
Allow trusted <style> tags in setContent and add missing save_changes translations

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1211,6 +1211,7 @@
   "modify": "Modify",
   "save": "Save",
   "save_badge_progress": "Save Badge Progress",
+  "save_changes": "Save changes",
   "save_payment": "Save payment",
   "save_reminder": "Save reminder",
   "scout_un_jour": "Through One Day Scout",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1245,6 +1245,7 @@
   "modify": "Modifier",
   "save": "Enregistrer",
   "save_badge_progress": "Enregistrer le progrès du badge",
+  "save_changes": "Enregistrer les modifications",
   "save_payment": "Enregistrer le paiement",
   "save_reminder": "Enregistrer le rappel",
   "scout_un_jour": "À travers Scout d’un jour",

--- a/lang/id.json
+++ b/lang/id.json
@@ -1198,6 +1198,7 @@
   "modify": "Memodifikasi",
   "save": "Menyimpan",
   "save_badge_progress": "Simpan Kemajuan Lencana",
+  "save_changes": "Simpan perubahan",
   "save_payment": "Simpan pembayaran",
   "save_reminder": "Simpan pengingat",
   "scout_un_jour": "Melalui One Day Scout",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1173,6 +1173,7 @@
   "modify": "Modifica",
   "save": "Salva",
   "save_badge_progress": "Salva progresso badge",
+  "save_changes": "Salva modifiche",
   "save_payment": "Salvapagamento",
   "save_reminder": "Salva promemoria",
   "scout_un_jour": "Tramite uno scout di un giorno",

--- a/lang/translation.json
+++ b/lang/translation.json
@@ -523,6 +523,7 @@
     "modify": "Modify",
     "save": "Save",
     "save_badge_progress": "Save Badge Progress",
+    "save_changes": "Save changes",
     "scout_un_jour": "Through One Day Scout",
     "scout_un_jour_label": "Scout for a day",
     "search": "Search",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -1188,6 +1188,7 @@
   "modify": "Змінити",
   "save": "Зберегти",
   "save_badge_progress": "Зберегти прогрес значка",
+  "save_changes": "Зберегти зміни",
   "save_payment": "Зберегти оплату",
   "save_reminder": "Зберегти нагадування",
   "scout_un_jour": "Через One Day Scout",

--- a/spa/inventory.js
+++ b/spa/inventory.js
@@ -943,7 +943,7 @@ export class Inventory {
           }
         }
       </style>
-    `);
+    `, { allowStyleTags: true });
   }
 
   renderGalleryView() {

--- a/spa/manage_participants.js
+++ b/spa/manage_participants.js
@@ -200,7 +200,7 @@ export class ManageParticipants {
         }
       </style>
     `;
-    setContent(document.getElementById("app"), content);
+    setContent(document.getElementById("app"), content, { allowStyleTags: true });
   }
 
   renderParticipantRows() {

--- a/spa/utils/DOMUtils.js
+++ b/spa/utils/DOMUtils.js
@@ -18,6 +18,8 @@ import { debugError } from './DebugUtils.js';
  *
  * @param {HTMLElement} element - Target element
  * @param {string} content - HTML content to set (will be sanitized)
+ * @param {Object} [options] - Sanitization options passed to sanitizeHTML
+ * @param {boolean} [options.allowStyleTags=false] - Allow <style> tags for trusted templates
  * @returns {HTMLElement} The element (for chaining)
  *
  * @example
@@ -25,13 +27,13 @@ import { debugError } from './DebugUtils.js';
  * const div = document.getElementById('description');
  * setContent(div, apiResponse.htmlContent);
  */
-export function setContent(element, content) {
+export function setContent(element, content, options = {}) {
   if (!element) {
     debugError('setContent: element is null or undefined');
     return null;
   }
 
-  element.innerHTML = sanitizeHTML(content);
+  element.innerHTML = sanitizeHTML(content, options);
   return element;
 }
 

--- a/spa/utils/SecurityUtils.js
+++ b/spa/utils/SecurityUtils.js
@@ -58,6 +58,7 @@ const ADDITIONAL_ALLOWED_ATTRS = [
  * @param {string} html - The HTML string to sanitize
  * @param {Object} options - Sanitization options
  * @param {boolean} options.stripAll - Strip all HTML tags (default: false)
+ * @param {boolean} options.allowStyleTags - Allow <style> tags for trusted templates (default: false)
  * @returns {string} Sanitized HTML string
  */
 export function sanitizeHTML(html, options = {}) {
@@ -77,6 +78,7 @@ export function sanitizeHTML(html, options = {}) {
     // Use DOMPurify's default ALLOWED_TAGS (don't override)
     // Add application-specific attributes to the defaults
     ADD_ATTR: ADDITIONAL_ALLOWED_ATTRS,
+    ADD_TAGS: options.allowStyleTags ? ['style'] : [],
 
     // Allow data-* attributes (used extensively in the app for state management)
     ALLOW_DATA_ATTR: true,


### PR DESCRIPTION
### Motivation
- Inline `<style>` blocks embedded in page templates were being stripped by the sanitizer, breaking UI elements such as modals and view toggles. 
- Some places that render full-page templates need a safe, opt-in way to include page-scoped styles. 
- Console noise from a missing translation key `save_changes` was being logged for multiple locales. 

### Description
- Added an opt-in `options.allowStyleTags` flag to `sanitizeHTML` to permit `<style>` tags when explicitly requested. 
- Extended `setContent` to accept a third `options` parameter and pass it through to `sanitizeHTML`. 
- Enabled style tag rendering for pages that include inline `<style>` in their templates by calling `setContent(..., { allowStyleTags: true })` in `spa/inventory.js` and `spa/manage_participants.js`. 
- Added the missing `save_changes` translation entry to supported locale files (`lang/en.json`, `lang/fr.json`, `lang/id.json`, `lang/it.json`, `lang/uk.json`, and `lang/translation.json`). 

### Testing
- No automated tests were run for this change. 
- Changes were committed and lint/static checks (if any) were not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69507e0803f48324b76dc2a8f1b0faf3)