### PR TITLE
fix: enhanced CORS for Replit, Vite dynamic ports, and dev environments

### DIFF
--- a/CORS_CONFIGURATION_GUIDE.md
+++ b/CORS_CONFIGURATION_GUIDE.md
@@ -5,12 +5,39 @@ The Wampums app supports:
 - **Multiple domains** (dynamically created subdomains)
 - **React Native mobile app**
 - **Web browsers** from various subdomains
+- **Development environments** (Replit, Vite, CodeSandbox, etc.)
 
 The CORS configuration is designed to be **flexible yet secure**.
 
 ---
 
-## Configuration
+## Automatic Development Support
+
+**In development mode** (`NODE_ENV !== "production"`), the following are **automatically allowed**:
+
+### ✅ Auto-Allowed in Development:
+- **Localhost with ANY port** (Vite can use random ports)
+  - `http://localhost:5173`, `http://localhost:3000`, `http://localhost:8080`, etc.
+  - `http://127.0.0.1:*`
+
+- **Replit dynamic domains**
+  - `https://projectname-username.replit.dev`
+  - `https://*.repl.co`
+
+- **Other dev environments**
+  - `https://*.codesandbox.io`
+  - `https://*.stackblitz.io`
+  - `https://*.gitpod.io`
+
+- **Local .test domains**
+  - `http://wampums-1.test` (from your config.js)
+  - `http://*.test:*`
+
+**No configuration needed for development!** 🎉
+
+---
+
+## Production Configuration
 
 ### Environment Variable: `ALLOWED_ORIGINS`
 


### PR DESCRIPTION
ENHANCED CORS - Smart development environment support

Additional Issues Fixed:
- Replit uses dynamic domains (projectname-username.replit.dev)
- Vite uses random ports when 5173 is taken (5174, 5175, etc.)
- Other dev tools (CodeSandbox, StackBlitz, Gitpod) need support
- Local .test domains from config.js (wampums-1.test)

Solution - Enhanced Pattern Matching:

1. Port Wildcard Support (NEW) Pattern: localhost:* Matches: localhost:5173, localhost:3000, localhost:8080, etc. Handles Vite's dynamic port allocation

2. Development Auto-Allow (when NODE_ENV !== 'production'): ✅ http://localhost:* (any port) ✅ http://127.0.0.1:* (any port) ✅ https://*.replit.dev (Replit projects) ✅ https://*.repl.co (Replit legacy) ✅ https://*.codesandbox.io ✅ https://*.stackblitz.io ✅ https://*.gitpod.io ✅ http://*.test (local .test domains) ✅ http://*.test:* (.test with ports)

3. Port Wildcard Matching Logic: if (pattern.includes(':*')) { const base = pattern.replace(':*', ''); return origin.startsWith(base + ':'); }

   Examples:
   - Pattern: http://localhost:*
   - Matches: http://localhost:5173 ✅
   - Matches: http://localhost:3000 ✅
   - Matches: http://localhost:9999 ✅

Production Unchanged:
- Still requires explicit ALLOWED_ORIGINS
- Default: https://wampums.app,https://*.wampums.app
- React Native still works (no Origin header)

Development Benefits:
✅ No configuration needed for development
✅ Works on Replit out of the box
✅ Works with Vite on any port
✅ Works in CodeSandbox, StackBlitz, Gitpod
✅ Supports local .test domains

Security Maintained:
- Production still requires explicit patterns
- Dev mode only in NODE_ENV !== 'production'
- All requests still logged
- Blocked requests still monitored

Documentation: CORS_CONFIGURATION_GUIDE.md updated with:
- Automatic development support section
- Port wildcard syntax
- Dev environment examples
- Testing instructions

Testing:
# Replit
https://my-project-user.replit.dev → ✅ ALLOWED (dev mode)

# Vite random port
http://localhost:5174 → ✅ ALLOWED (dev mode)
http://localhost:9999 → ✅ ALLOWED (dev mode)

# Production subdomain
https://org1.wampums.app → ✅ ALLOWED (matches *.wampums.app)

# React Native
(no origin header) → ✅ ALLOWED (always)