### PR TITLE
fix: Add missing carpool API functions to mobile

### DIFF
--- a/mobile/src/api/api-endpoints.js
+++ b/mobile/src/api/api-endpoints.js
@@ -501,6 +501,27 @@ export const getMyChildrenAssignments = async () => {
 };
 
 /**
+ * Update carpool offer
+ */
+export const updateCarpoolOffer = async (offerId, offerData) => {
+  return API.put(`${CONFIG.ENDPOINTS.CARPOOLS}/offers/${offerId}`, offerData);
+};
+
+/**
+ * Cancel carpool offer
+ */
+export const cancelCarpoolOffer = async (offerId, reason = '') => {
+  return API.delete(`${CONFIG.ENDPOINTS.CARPOOLS}/offers/${offerId}`, { reason });
+};
+
+/**
+ * Remove participant assignment from carpool
+ */
+export const removeAssignment = async (assignmentId) => {
+  return API.delete(`${CONFIG.ENDPOINTS.CARPOOLS}/assignments/${assignmentId}`);
+};
+
+/**
  * ============================================================================
  * ATTENDANCE (V1)
  * ============================================================================
@@ -1454,6 +1475,9 @@ export default {
   assignParticipantToCarpool,
   getMyCarpoolOffers,
   getMyChildrenAssignments,
+  updateCarpoolOffer,
+  cancelCarpoolOffer,
+  removeAssignment,
   // Attendance
   getAttendance,
   createAttendance,

--- a/mobile/src/screens/CarpoolScreen.js
+++ b/mobile/src/screens/CarpoolScreen.js
@@ -31,8 +31,6 @@ import { Picker } from '@react-native-picker/picker';
 import {
   getActivity,
   getActivityParticipants,
-} from '../api/api-endpoints';
-import {
   getCarpoolOffers,
   createCarpoolOffer,
   updateCarpoolOffer,


### PR DESCRIPTION
Fixed 500 internal server errors in CarpoolScreen by adding missing carpool API endpoint functions that were present in SPA but not ported to mobile.

Added Functions:
- updateCarpoolOffer(offerId, offerData) - Edit existing offers
- cancelCarpoolOffer(offerId, reason) - Cancel/delete offers
- removeAssignment(assignmentId) - Remove participant assignments

Also consolidated duplicate imports in CarpoolScreen for cleaner code.

This resolves the internal server errors when loading carpool data.