### PR TITLE
debug: Add logging to diagnose carpool 500 errors

### DIFF
--- a/mobile/src/screens/CarpoolScreen.js
+++ b/mobile/src/screens/CarpoolScreen.js
@@ -119,6 +119,18 @@ const CarpoolScreen = () => {
 
       const storedUserId = await StorageUtils.getItem(CONFIG.STORAGE_KEYS.USER_ID);
       setUserId(storedUserId);
+
+      // Debug logging for auth/org state
+      const token = await StorageUtils.getJWT();
+      const orgId = await StorageUtils.getItem(CONFIG.STORAGE_KEYS.ORGANIZATION_ID);
+      debugLog('=== CarpoolScreen User Data ===');
+      debugLog('Has JWT token:', !!token);
+      debugLog('Organization ID:', orgId);
+      debugLog('User ID:', storedUserId);
+      debugLog('Permissions:', permissions);
+      debugLog('Has carpools.view:', permissions?.includes('carpools.view'));
+      debugLog('Has carpools.manage:', permissions?.includes('carpools.manage'));
+      debugLog('================================');
     } catch (err) {
       debugError('Error loading user data:', err);
     }
@@ -128,6 +140,15 @@ const CarpoolScreen = () => {
     try {
       setLoading(true);
       setError(null);
+
+      // Debug logging
+      debugLog('=== CarpoolScreen loadData ===');
+      debugLog('route.params:', route.params);
+      debugLog('activityId (raw):', route.params?.activityId);
+      debugLog('activityId (parsed):', activityId);
+      debugLog('activityId type:', typeof activityId);
+      debugLog('activityId isNaN:', isNaN(activityId));
+      debugLog('==============================');
 
       // Load activity, offers, and participants in parallel
       const [activityResponse, offersResponse, participantsResponse] = await Promise.all([


### PR DESCRIPTION
Added comprehensive debug logging to CarpoolScreen to identify the root cause of 500 internal server errors:

- Log route params and activityId (raw, parsed, type, isNaN)
- Log authentication state (JWT token, org ID, user ID)
- Log permissions (including carpools.view/manage checks)

This will help identify if the issue is:
- Invalid activityId (NaN or undefined)
- Missing organization ID
- Missing authentication
- Missing permissions