### PR TITLE
fix: Extract date portion before parsing in activity filtering/sorting

### DIFF
--- a/mobile/src/screens/ActivitiesScreen.js
+++ b/mobile/src/screens/ActivitiesScreen.js
@@ -128,19 +128,23 @@ const ActivitiesScreen = () => {
           console.log('Activity has no date:', activity.name);
           return false;
         }
+        // Extract just the date portion (YYYY-MM-DD) from datetime string
+        const dateOnly = activityDate.substring(0, 10);
         // Parse as local date to avoid timezone issues
-        const [year, month, day] = activityDate.split('-').map(Number);
+        const [year, month, day] = dateOnly.split('-').map(Number);
         const localDate = new Date(year, month - 1, day);
         const isUpcoming = localDate >= now;
-        console.log(`${activity.name}: ${activityDate} -> ${localDate} -> ${isUpcoming ? 'UPCOMING' : 'PAST'}`);
+        console.log(`${activity.name}: ${activityDate} -> ${dateOnly} -> ${localDate} -> ${isUpcoming ? 'UPCOMING' : 'PAST'}`);
         return isUpcoming;
       });
     } else if (activeFilter === 'past') {
       filtered = filtered.filter((activity) => {
         const activityDate = activity.date || activity.activity_date;
         if (!activityDate) return false;
+        // Extract just the date portion (YYYY-MM-DD) from datetime string
+        const dateOnly = activityDate.substring(0, 10);
         // Parse as local date to avoid timezone issues
-        const [year, month, day] = activityDate.split('-').map(Number);
+        const [year, month, day] = dateOnly.split('-').map(Number);
         const localDate = new Date(year, month - 1, day);
         return localDate < now;
       });
@@ -157,9 +161,11 @@ const ActivitiesScreen = () => {
 
       if (sortBy === 'date') {
         if (!aDateStr || !bDateStr) return 0;
-        // Parse as local dates
-        const [aYear, aMonth, aDay] = aDateStr.split('-').map(Number);
-        const [bYear, bMonth, bDay] = bDateStr.split('-').map(Number);
+        // Extract date portions and parse as local dates
+        const aDateOnly = aDateStr.substring(0, 10);
+        const bDateOnly = bDateStr.substring(0, 10);
+        const [aYear, aMonth, aDay] = aDateOnly.split('-').map(Number);
+        const [bYear, bMonth, bDay] = bDateOnly.split('-').map(Number);
         const aDate = new Date(aYear, aMonth - 1, aDay);
         const bDate = new Date(bYear, bMonth - 1, bDay);
         return sortOrder === 'asc' ? aDate - bDate : bDate - aDate;
@@ -188,7 +194,8 @@ const ActivitiesScreen = () => {
       count: activities.filter((a) => {
         const dateStr = a.date || a.activity_date;
         if (!dateStr) return false;
-        const [year, month, day] = dateStr.split('-').map(Number);
+        const dateOnly = dateStr.substring(0, 10);
+        const [year, month, day] = dateOnly.split('-').map(Number);
         const localDate = new Date(year, month - 1, day);
         return localDate >= new Date();
       }).length,
@@ -199,7 +206,8 @@ const ActivitiesScreen = () => {
       count: activities.filter((a) => {
         const dateStr = a.date || a.activity_date;
         if (!dateStr) return false;
-        const [year, month, day] = dateStr.split('-').map(Number);
+        const dateOnly = dateStr.substring(0, 10);
+        const [year, month, day] = dateOnly.split('-').map(Number);
         const localDate = new Date(year, month - 1, day);
         return localDate < new Date();
       }).length,
@@ -233,8 +241,9 @@ const ActivitiesScreen = () => {
     const dateStr = activity.date || activity.activity_date;
     if (!dateStr) return null;
 
-    // Parse as local date to avoid timezone issues
-    const [year, month, day] = dateStr.split('-').map(Number);
+    // Extract date portion and parse as local date to avoid timezone issues
+    const dateOnly = dateStr.substring(0, 10);
+    const [year, month, day] = dateOnly.split('-').map(Number);
     const activityDate = new Date(year, month - 1, day);
 
     const now = new Date();
@@ -304,7 +313,8 @@ const ActivitiesScreen = () => {
             const dateStr = activity.date || activity.activity_date;
             const activityDate = dateStr
               ? (() => {
-                  const [year, month, day] = dateStr.split('-').map(Number);
+                  const dateOnly = dateStr.substring(0, 10);
+                  const [year, month, day] = dateOnly.split('-').map(Number);
                   const localDate = new Date(year, month - 1, day);
                   return DateUtils.formatDate(localDate);
                 })()

--- a/mobile/src/screens/CarpoolScreen.js
+++ b/mobile/src/screens/CarpoolScreen.js
@@ -646,8 +646,10 @@ const CarpoolScreen = () => {
   const activityDateString = activity.date || activity.activity_date;
   const activityDateFormatted = activityDateString
     ? (() => {
-        // Parse YYYY-MM-DD as local date (not UTC) to avoid timezone shift
-        const [year, month, day] = activityDateString.split('-').map(Number);
+        // Extract date portion (YYYY-MM-DD) from datetime string
+        const dateOnly = activityDateString.substring(0, 10);
+        // Parse as local date (not UTC) to avoid timezone shift
+        const [year, month, day] = dateOnly.split('-').map(Number);
         const localDate = new Date(year, month - 1, day); // month is 0-indexed
         return DateUtils.formatDate(localDate);
       })()


### PR DESCRIPTION
Root cause: Backend returns activity_date as datetime string with
timezone: "2026-02-06T00:00:00.000Z"

When code tried to split on '-':
  "2026-02-06T00:00:00.000Z".split('-')
  → ["2026", "02", "06T00:00:00.000Z"]
  → Number("06T00:00:00.000Z") = NaN
  → new Date(2026, 1, NaN) = Invalid Date

Fixed by extracting first 10 chars (YYYY-MM-DD) before splitting:
  dateStr.substring(0, 10) → "2026-02-06"
  Then split and parse works correctly.

Applied fix to:
- ActivitiesScreen: filtering, sorting, filter counts, status, display
- CarpoolScreen: activity date formatting

Activities should now display and filter correctly!