### PR TITLE
fix: Extract data array from API response in activity selection

### DIFF
--- a/mobile/src/screens/CarpoolScreen.js
+++ b/mobile/src/screens/CarpoolScreen.js
@@ -1300,7 +1300,10 @@ const ActivitySelectionView = ({ navigation }) => {
 
       // Import getActivities from api-endpoints
       const { getActivities } = await import('../api/api-endpoints');
-      const allActivities = await getActivities({ forceRefresh: true });
+      const response = await getActivities({ forceRefresh: true });
+
+      // Extract data array from response
+      const allActivities = response.data || [];
 
       // Filter to upcoming activities only
       const now = new Date();


### PR DESCRIPTION
The getActivities() API returns { success: true, data: [...] }, not the array directly. Updated ActivitySelectionView to access response.data to prevent 'filter is not a function' error.

This fixes the TypeError when loading the activity selection screen for carpool coordination.