### PR TITLE
Fix broken equipment and resource dashboard screens

### DIFF
--- a/mobile/src/screens/MaterialManagementScreen.js
+++ b/mobile/src/screens/MaterialManagementScreen.js
@@ -83,7 +83,7 @@ const MaterialManagementScreen = ({ navigation }) => {
 
   const loadData = async () => {
     try {
-      const token = await StorageUtils.getToken();
+      const token = await StorageUtils.getJWT();
 
       const [equipmentResponse, reservationsResponse] = await Promise.all([
         fetch(`${API.baseURL}/v1/resources/equipment`, {
@@ -208,7 +208,7 @@ const MaterialManagementScreen = ({ navigation }) => {
         })),
       };
 
-      const token = await StorageUtils.getToken();
+      const token = await StorageUtils.getJWT();
       const response = await fetch(`${API.baseURL}/v1/resources/equipment/reservations/bulk`, {
         method: 'POST',
         headers: {

--- a/mobile/src/screens/ResourceDashboardScreen.js
+++ b/mobile/src/screens/ResourceDashboardScreen.js
@@ -68,7 +68,7 @@ const ResourceDashboardScreen = ({ navigation }) => {
 
   const loadData = async () => {
     try {
-      const token = await StorageUtils.getToken();
+      const token = await StorageUtils.getJWT();
 
       const [equipmentResponse, reservationsResponse, summaryResponse] = await Promise.all([
         fetch(`${API.baseURL}/v1/resources/equipment`, {
@@ -128,7 +128,7 @@ const ResourceDashboardScreen = ({ navigation }) => {
         quantity_total: parseInt(quickAddData.quantity_total, 10) || 1,
       };
 
-      const token = await StorageUtils.getToken();
+      const token = await StorageUtils.getJWT();
       const response = await fetch(`${API.baseURL}/v1/resources/equipment`, {
         method: 'POST',
         headers: {
@@ -176,7 +176,7 @@ const ResourceDashboardScreen = ({ navigation }) => {
         notes: quickReserveData.notes?.trim() || '',
       };
 
-      const token = await StorageUtils.getToken();
+      const token = await StorageUtils.getJWT();
       const response = await fetch(`${API.baseURL}/v1/resources/equipment/reservations`, {
         method: 'POST',
         headers: {


### PR DESCRIPTION
Fixed TypeError in MaterialManagementScreen and ResourceDashboardScreen where StorageUtils.getToken() was called but the method doesn't exist. The correct method name is getJWT().

Changes:
- MaterialManagementScreen.js: Fixed 2 occurrences of getToken() → getJWT()
- ResourceDashboardScreen.js: Fixed 3 occurrences of getToken() → getJWT()

This resolves the "StorageUtils.default.getToken is not a function" error that was preventing both screens from loading data.