### PR TITLE
fix: Add missing getActivities export to api-endpoints.js

### DIFF
--- a/spa/api/api-endpoints.js
+++ b/spa/api/api-endpoints.js
@@ -1696,6 +1696,16 @@ export async function getActivitesRencontre() {
 }
 
 /**
+ * Get all activities for the organization
+ * @param {Object} params - Query parameters (e.g., { upcoming_only: true })
+ * @param {Object} cacheOptions - Cache options (e.g., { forceRefresh: true })
+ * @returns {Promise<Object>} Response with activities array
+ */
+export async function getActivities(params = {}, cacheOptions = {}) {
+    return API.get('v1/activities', params, cacheOptions);
+}
+
+/**
  * Save reminder
  */
 export async function saveReminder(reminderData) {


### PR DESCRIPTION
The material_management.js SPA was importing getActivities from api-endpoints.js but the function wasn't exported, causing a runtime error: 'The requested module does not provide an export named getActivities'

Added getActivities function that calls the v1/activities endpoint with support for query parameters and cache options.