### PR TITLE
Port fundraisers system to React Native mobile

### DIFF
--- a/mobile/src/api/api-endpoints.js
+++ b/mobile/src/api/api-endpoints.js
@@ -1401,6 +1401,59 @@ export const createPaymentIntent = async (amount, currency = 'cad') => {
 
 /**
  * ============================================================================
+ * FUNDRAISERS
+ * ============================================================================
+ */
+
+/**
+ * Get all fundraisers
+ * @param {boolean} includeArchived - Include archived fundraisers
+ * @returns {Promise} Fundraisers with statistics
+ */
+export const getFundraisers = async (includeArchived = false) => {
+  return API.get('fundraisers', { include_archived: includeArchived });
+};
+
+/**
+ * Get single fundraiser details
+ * @param {number} fundraiserId - Fundraiser ID
+ * @returns {Promise} Fundraiser details
+ */
+export const getFundraiser = async (fundraiserId) => {
+  return API.get(`fundraisers/${fundraiserId}`);
+};
+
+/**
+ * Create a new fundraiser
+ * @param {Object} data - Fundraiser data (name, start_date, end_date, objective)
+ * @returns {Promise} Created fundraiser
+ */
+export const createFundraiser = async (data) => {
+  return API.post('fundraisers', data);
+};
+
+/**
+ * Update fundraiser
+ * @param {number} fundraiserId - Fundraiser ID
+ * @param {Object} data - Updated fundraiser data
+ * @returns {Promise} Updated fundraiser
+ */
+export const updateFundraiser = async (fundraiserId, data) => {
+  return API.put(`fundraisers/${fundraiserId}`, data);
+};
+
+/**
+ * Archive/unarchive a fundraiser
+ * @param {number} fundraiserId - Fundraiser ID
+ * @param {boolean} archived - Archive status
+ * @returns {Promise} Updated fundraiser
+ */
+export const archiveFundraiser = async (fundraiserId, archived) => {
+  return API.put(`fundraisers/${fundraiserId}/archive`, { archived });
+};
+
+/**
+ * ============================================================================
  * TRANSLATIONS
  * ============================================================================
  */
@@ -1582,6 +1635,12 @@ export default {
   registerPushSubscription,
   // Payments
   createPaymentIntent,
+  // Fundraisers
+  getFundraisers,
+  getFundraiser,
+  createFundraiser,
+  updateFundraiser,
+  archiveFundraiser,
   // Translations
   getTranslations,
   saveTranslation,

--- a/mobile/src/screens/FundraisersScreen.js
+++ b/mobile/src/screens/FundraisersScreen.js
@@ -31,7 +31,12 @@ import {
   canViewFundraisers,
   canManageFundraisers,
 } from '../utils/PermissionUtils';
-import API from '../api/api-core';
+import {
+  getFundraisers,
+  createFundraiser,
+  updateFundraiser,
+  archiveFundraiser,
+} from '../api/api-endpoints';
 
 const FundraisersScreen = ({ navigation }) => {
   const [loading, setLoading] = useState(true);
@@ -92,7 +97,7 @@ const FundraisersScreen = ({ navigation }) => {
 
   const loadFundraisers = async () => {
     try {
-      const result = await API.get('/v1/fundraisers', { include_archived: true });
+      const result = await getFundraisers(true);
 
       if (result.success && result.fundraisers) {
         const active = result.fundraisers
@@ -155,10 +160,7 @@ const FundraisersScreen = ({ navigation }) => {
 
       const isArchiving = !fundraiserToArchive.archived;
 
-      const result = await API.put(
-        `/v1/fundraisers/${fundraiserToArchive.id}/archive`,
-        { archived: isArchiving }
-      );
+      const result = await archiveFundraiser(fundraiserToArchive.id, isArchiving);
 
       if (!result.success) {
         throw new Error(
@@ -204,8 +206,8 @@ const FundraisersScreen = ({ navigation }) => {
       };
 
       const result = selectedFundraiser
-        ? await API.put(`/v1/fundraisers/${selectedFundraiser.id}`, payload)
-        : await API.post('/v1/fundraisers', payload);
+        ? await updateFundraiser(selectedFundraiser.id, payload)
+        : await createFundraiser(payload);
 
       if (!result.success) {
         throw new Error(result.message || t('error_saving_fundraiser'));
@@ -307,7 +309,7 @@ const FundraisersScreen = ({ navigation }) => {
             <Text style={commonStyles.buttonText}>{t('view_fundraiser_entries')}</Text>
           </TouchableOpacity>
 
-          {typeof canManageFundraisers === 'function' && canManageFundraisers() && (
+          {canManage && (
             <View style={styles.actionButtons}>
               <TouchableOpacity
                 style={[commonStyles.buttonSecondary, styles.actionButton]}


### PR DESCRIPTION
- Add fundraiser API wrapper functions to mobile/src/api/api-endpoints.js
  * getFundraisers(includeArchived)
  * getFundraiser(fundraiserId)
  * createFundraiser(data)
  * updateFundraiser(fundraiserId, data)
  * archiveFundraiser(fundraiserId, archived)

- Refactor FundraisersScreen to use new API wrapper functions
  * Replace direct API.get/post/put calls with dedicated functions
  * Improve code consistency with SPA implementation
  * Remove dependency on API object, use api-endpoints instead

- Fix permission check bug in renderFundraiserCard
  * Replace incorrect canManageFundraisers() function call
  * Use canManage state variable instead
  * Prevents runtime errors when checking permissions

This completes the fundraisers feature port to React Native with proper API abstraction layer matching the web SPA architecture.