### PR TITLE
Port reports center from spa to mobile

### DIFF
--- a/mobile/src/api/api-endpoints.js
+++ b/mobile/src/api/api-endpoints.js
@@ -1278,6 +1278,53 @@ export const getMissingDocumentsReport = async () => {
 };
 
 /**
+ * Get participant progress timeline and participants list
+ */
+export const getParticipantProgressReport = async (participantId = null) => {
+  const params = participantId ? { participant_id: participantId } : {};
+  return API.get('/participant-progress', params);
+};
+
+/**
+ * Get participant age report
+ */
+export const getParticipantAgeReport = async () => {
+  return API.get('/participant-age');
+};
+
+/**
+ * Get finance summary report
+ */
+export const getFinanceReport = async () => {
+  return API.get('/v1/finance/reports/summary');
+};
+
+/**
+ * Get available form types
+ */
+export const getFormTypes = async () => {
+  return API.get('/form-types');
+};
+
+/**
+ * Get form structure for all form types
+ */
+export const getFormStructure = async () => {
+  return API.get('/organization-form-formats');
+};
+
+/**
+ * Get all form submissions
+ * @param {number|null} participantId - Optional participant ID filter
+ * @param {string} formType - Form type to fetch
+ */
+export const getFormSubmissions = async (participantId = null, formType) => {
+  const params = { form_type: formType };
+  if (participantId) params.participant_id = participantId;
+  return API.get('/form-submissions', params);
+};
+
+/**
  * Get mailing list
  */
 export const getMailingList = async () => {
@@ -1664,6 +1711,12 @@ export default {
   getLeaveAloneReport,
   getMediaAuthorizationReport,
   getMissingDocumentsReport,
+  getParticipantProgressReport,
+  getParticipantAgeReport,
+  getFinanceReport,
+  getFormTypes,
+  getFormStructure,
+  getFormSubmissions,
   getMailingList,
   // Resources
   getEquipment,

--- a/mobile/src/utils/PermissionUtils.js
+++ b/mobile/src/utils/PermissionUtils.js
@@ -315,6 +315,51 @@ export async function canManageFundraisers() {
   return hasAnyPermission(['fundraisers.create', 'fundraisers.edit', 'fundraisers.delete'], permissions);
 }
 
+/**
+ * Check if user can view reports
+ * @returns {Promise<boolean>} True if user can view reports
+ */
+export async function canViewReports() {
+  const permissions = await getUserPermissions();
+  return hasPermission('reports.view', permissions);
+}
+
+/**
+ * Check if user can view activities
+ * @returns {Promise<boolean>} True if user can view activities
+ */
+export async function canViewActivities() {
+  const permissions = await getUserPermissions();
+  return hasAnyPermission(['activities.view', 'activities.manage'], permissions);
+}
+
+/**
+ * Check if user can manage activities
+ * @returns {Promise<boolean>} True if user can manage activities
+ */
+export async function canManageActivities() {
+  const permissions = await getUserPermissions();
+  return hasAnyPermission(['activities.create', 'activities.edit', 'activities.delete'], permissions);
+}
+
+/**
+ * Check if user can view carpools
+ * @returns {Promise<boolean>} True if user can view carpools
+ */
+export async function canViewCarpools() {
+  const permissions = await getUserPermissions();
+  return hasAnyPermission(['carpools.view', 'carpools.manage'], permissions);
+}
+
+/**
+ * Check if user can manage carpools
+ * @returns {Promise<boolean>} True if user can manage carpools
+ */
+export async function canManageCarpools() {
+  const permissions = await getUserPermissions();
+  return hasPermission('carpools.manage', permissions);
+}
+
 export default {
   hasPermission,
   hasAnyPermission,
@@ -338,4 +383,9 @@ export default {
   isDistrictAdmin,
   canViewFundraisers,
   canManageFundraisers,
+  canViewReports,
+  canViewActivities,
+  canManageActivities,
+  canViewCarpools,
+  canManageCarpools,
 };


### PR DESCRIPTION
- Add missing canViewReports, canViewActivities, canManageActivities, canViewCarpools, and canManageCarpools functions to mobile PermissionUtils
- Add all missing report API endpoints to mobile api-endpoints.js:
  * getParticipantProgressReport
  * getParticipantAgeReport
  * getFinanceReport
  * getFormTypes
  * getFormStructure
  * getFormSubmissions
- Fix TypeError: canViewReports is not a function error in ReportsScreen
- Ensure all report APIs mirror web SPA functionality

This completes the reports center port to React Native mobile app.