### PR TITLE
Fix permission slip access and dashboard visibility

### DIFF
--- a/mobile/src/api/api-endpoints.js
+++ b/mobile/src/api/api-endpoints.js
@@ -1055,9 +1055,52 @@ export const createEquipmentReservation = async (reservationData) => {
 
 /**
  * Get permission slips
+ * @param {Object} params - Query parameters (e.g., meeting_date, participant_id)
+ * @param {Object} cacheOptions - Cache options (forceRefresh)
  */
-export const getPermissionSlips = async () => {
-  return API.get(`${CONFIG.ENDPOINTS.RESOURCES}/permission-slips`);
+export const getPermissionSlips = async (params = {}, cacheOptions = {}) => {
+  return API.get(`${CONFIG.ENDPOINTS.RESOURCES}/permission-slips`, params, cacheOptions);
+};
+
+/**
+ * Create or update a permission slip
+ * @param {Object} payload - Permission slip data
+ */
+export const savePermissionSlip = async (payload) => {
+  return API.post(`${CONFIG.ENDPOINTS.RESOURCES}/permission-slips`, payload);
+};
+
+/**
+ * Archive a permission slip
+ * @param {number} id - Permission slip ID
+ */
+export const archivePermissionSlip = async (id) => {
+  return API.patch(`${CONFIG.ENDPOINTS.RESOURCES}/permission-slips/${id}/archive`, {});
+};
+
+/**
+ * Capture signature for a permission slip
+ * @param {number} id - Permission slip ID
+ * @param {Object} payload - Signature data
+ */
+export const signPermissionSlip = async (id, payload) => {
+  return API.patch(`${CONFIG.ENDPOINTS.RESOURCES}/permission-slips/${id}/sign`, payload);
+};
+
+/**
+ * Send emails to parents for permission slips
+ * @param {Object} payload - Email payload (activity_title, meeting_date)
+ */
+export const sendPermissionSlipEmails = async (payload) => {
+  return API.post(`${CONFIG.ENDPOINTS.RESOURCES}/permission-slips/send-emails`, payload);
+};
+
+/**
+ * Send reminder emails to parents for unsigned permission slips
+ * @param {Object} payload - Reminder payload (activity_title, meeting_date)
+ */
+export const sendPermissionSlipReminders = async (payload) => {
+  return API.post(`${CONFIG.ENDPOINTS.RESOURCES}/permission-slips/send-reminders`, payload);
 };
 
 /**
@@ -1065,6 +1108,15 @@ export const getPermissionSlips = async () => {
  */
 export const viewPermissionSlip = async (id) => {
   return API.public(`${CONFIG.ENDPOINTS.RESOURCES}/permission-slips/${id}/view`);
+};
+
+/**
+ * Get dashboard snapshot for resources and approvals
+ * @param {Object} params - Query parameters (e.g., meeting_date)
+ * @param {Object} cacheOptions - Cache options (forceRefresh)
+ */
+export const getResourceDashboard = async (params = {}, cacheOptions = {}) => {
+  return API.get(`${CONFIG.ENDPOINTS.RESOURCES}/status/dashboard`, params, cacheOptions);
 };
 
 /**

--- a/mobile/src/screens/LeaderDashboardScreen.js
+++ b/mobile/src/screens/LeaderDashboardScreen.js
@@ -444,7 +444,7 @@ const LeaderDashboardScreen = () => {
           iconFamily: 'Ionicons',
           iconName: 'documents-outline',
           screen: 'PermissionSlips',
-          permissions: ['permission_slips.view', 'permission_slips.manage'],
+          permissions: ['communications.send', 'participants.view'],
         },
       ].filter(canAccessAction),
     },
@@ -474,7 +474,7 @@ const LeaderDashboardScreen = () => {
           iconFamily: 'Ionicons',
           iconName: 'clipboard-outline',
           screen: 'PermissionSlips',
-          permissions: ['permission_slips.view', 'permission_slips.manage'],
+          permissions: ['communications.send', 'participants.view'],
         },
         {
           key: 'fundraisers',


### PR DESCRIPTION
Fixes two issues preventing permission slips access in mobile app:

1. Add missing API functions to mobile/src/api/api-endpoints.js:
   - getResourceDashboard: Get dashboard snapshot for resources
   - savePermissionSlip: Create/update permission slips
   - archivePermissionSlip: Archive permission slips
   - signPermissionSlip: Sign permission slips
   - sendPermissionSlipEmails: Send emails to parents
   - sendPermissionSlipReminders: Send reminder emails
   - Update getPermissionSlips to accept params like web version

2. Fix permission names in LeaderDashboardScreen.js:
   - Change 'permission_slips.view' and 'permission_slips.manage'
   - To 'communications.send' and 'participants.view'
   - Matches web SPA permissions and PermissionSlipsScreen requirements

Resolves error: "getResourceDashboard is not a function" and makes permission slip creation visible to users with proper permissions.