### PR TITLE
fix: Add getParticipantsWithDocuments API function for mobile

### DIFF
--- a/mobile/src/api/api-endpoints.js
+++ b/mobile/src/api/api-endpoints.js
@@ -1345,6 +1345,36 @@ export const getParticipantAgeReport = async () => {
 };
 
 /**
+ * Get participants with documents info
+ * Returns participants with their form/document completion status
+ */
+export const getParticipantsWithDocuments = async () => {
+  const response = await API.get('/participant-details');
+  const settingsResponse = await getOrganizationSettings();
+
+  const settings = settingsResponse?.data || {};
+  const formTypes = Object.keys(settings)
+    .filter(key => key.endsWith('_structure'))
+    .map(key => key.replace('_structure', ''));
+
+  const participants = (response?.data?.participants || response?.participants || []).map(participant => {
+    formTypes.forEach(formType => {
+      participant[`has_${formType}`] = Boolean(participant[`has_${formType}`]);
+    });
+    return participant;
+  });
+
+  return {
+    ...response,
+    participants,
+    data: {
+      ...(response?.data || {}),
+      participants
+    }
+  };
+};
+
+/**
  * Get finance summary report
  */
 export const getFinanceReport = async () => {


### PR DESCRIPTION
Fixes error in Participant Documents screen:
- Error: "getParticipantsWithDocuments is not a function (it is undefined)"
- API Error: 500 "Failed to fetch form format"

Added getParticipantsWithDocuments function to mobile/src/api/api-endpoints.js that mirrors the web SPA implementation. This function:
- Fetches participant details from /participant-details endpoint
- Gets organization settings to extract form types
- Maps participants with document completion status flags
- Returns formatted response with participants data

Resolves ParticipantDocumentsScreen.js import error and allows viewing participant document/form completion status.