### PR TITLE
fix: Transform getOrganizationFormFormats response correctly

### DIFF
--- a/mobile/src/api/api-endpoints.js
+++ b/mobile/src/api/api-endpoints.js
@@ -1429,12 +1429,36 @@ export const getParentContactList = async ({ forceRefresh = false } = {}) => {
 /**
  * Get organization form formats
  * @param {string} context - Optional context filter (participant, organization, admin_panel, public, form_builder)
+ * @returns {Promise<Object>} Form formats object with form types as keys
  */
 export const getOrganizationFormFormats = async (context = null) => {
-  const url = context 
+  const url = context
     ? `${CONFIG.ENDPOINTS.FORMS}/organization-form-formats?context=${context}`
     : `${CONFIG.ENDPOINTS.FORMS}/organization-form-formats`;
-  return API.get(url);
+
+  const response = await API.get(url);
+
+  if (!response.success || !response.data) {
+    return null;
+  }
+
+  const formFormats = {};
+
+  // Check if response.data is an array
+  if (Array.isArray(response.data)) {
+    // Transform array format to object format
+    for (const format of response.data) {
+      formFormats[format.form_type] = format.form_structure;
+    }
+  } else {
+    // response.data is an object, extract form_structure from each form type
+    for (const [formType, formatData] of Object.entries(response.data)) {
+      // If formatData has a form_structure property, use it; otherwise use formatData directly
+      formFormats[formType] = formatData.form_structure || formatData;
+    }
+  }
+
+  return formFormats;
 };
 
 /**


### PR DESCRIPTION
Fixes Participant Documents screen error:
- Error: 500 "Failed to fetch form format"
- ParticipantDocumentsScreen was calling Object.keys() on raw API response

Root cause: The mobile getOrganizationFormFormats function was returning the raw API response { success: true, data: {...} } instead of transforming it to return just the form formats object.

Updated mobile/src/api/api-endpoints.js getOrganizationFormFormats to:
- Check if response is successful and has data
- Transform response.data (array or object) into formFormats object
- Return formFormats with form types as keys and structures as values
- Matches web SPA implementation exactly

This allows ParticipantDocumentsScreen to correctly extract form types using Object.keys(formFormatsResponse) as expected.