### PR TITLE
Fix parent dashboard routing and permission error messaging

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -665,6 +665,7 @@
   "installment_overview_title": "Payment plan & installments",
   "installment_shortcut_help": "Select an assigned membership to quickly open its plan or payment history.",
   "insufficient_permissions": "Insufficient permissions",
+  "no_permission_for_screen": "You do not have permission for this screen.",
   "insurance_info": "Insurance Information",
   "internal_server_error": "Internal server error",
   "internet": "Internet",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -679,6 +679,7 @@
   "installment_overview_title": "Plan de paiement et versements",
   "installment_shortcut_help": "Choisissez une cotisation assignée pour ouvrir rapidement son plan ou son historique de paiements.",
   "insufficient_permissions": "Permissions insuffisantes",
+  "no_permission_for_screen": "Vous n’avez pas la permission d’accéder à cet écran.",
   "insurance_info": "Informations d’assurance",
   "internal_server_error": "Erreur interne du serveur",
   "internet": "Internet",

--- a/mobile/src/screens/DashboardScreen.js
+++ b/mobile/src/screens/DashboardScreen.js
@@ -33,10 +33,14 @@ const DashboardScreen = () => {
   const loadUserPermissions = async () => {
     try {
       // Get user permissions from storage (already parsed by StorageUtils)
-      const permissions = await StorageUtils.getItem(CONFIG.STORAGE_KEYS.USER_PERMISSIONS);
+      const [permissions, userRoles, userRole] = await Promise.all([
+        StorageUtils.getItem(CONFIG.STORAGE_KEYS.USER_PERMISSIONS),
+        StorageUtils.getItem(CONFIG.STORAGE_KEYS.USER_ROLES),
+        StorageUtils.getItem(CONFIG.STORAGE_KEYS.USER_ROLE),
+      ]);
 
       // Determine which dashboard to show based on permissions
-      const type = getDashboardType(permissions || []);
+      const type = getDashboardType(permissions || [], userRoles || [], userRole || '');
       setDashboardType(type);
     } catch (err) {
       debugError('Error loading user permissions:', err);

--- a/mobile/src/screens/LeaderDashboardScreen.js
+++ b/mobile/src/screens/LeaderDashboardScreen.js
@@ -192,7 +192,11 @@ const LeaderDashboardScreen = () => {
       }
     } catch (err) {
       debugError('Error loading dashboard context:', err);
-      setError(t('error_loading_dashboard'));
+      if (err?.status === 403) {
+        setError(t('no_permission_for_screen'));
+      } else {
+        setError(t('error_loading_dashboard'));
+      }
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
### Motivation

- Parent accounts were being routed to the leader dashboard and shown a vague error instead of the Parent view.  
- The app should route strictly by role when possible so parent-only accounts load the `Parent` dashboard.  
- Error feedback should clearly communicate permission issues (403) to the user.

### Description

- Updated `getDashboardType` in `mobile/src/utils/PermissionUtils.js` to accept `userRoles` and `userRole`, prefer explicit role-based detection (using `ROLE_BUNDLES` and a `PARENT_ROLE_KEYS` set), and fall back to permission-based checks.  
- Updated `mobile/src/screens/DashboardScreen.js` to load `USER_PERMISSIONS`, `USER_ROLES`, and `USER_ROLE` from storage and pass roles into `getDashboardType`.  
- Updated `mobile/src/screens/LeaderDashboardScreen.js` to show a clearer message (`no_permission_for_screen`) when a `403` error occurs, and added the `no_permission_for_screen` key to `lang/en.json` and `lang/fr.json` for translations.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69557d97f1248324b56c8d991da4c772)