### PR TITLE
Enable Register and ResetPassword routes in mobile auth navigator

### DIFF
--- a/mobile/src/navigation/AuthNavigator.js
+++ b/mobile/src/navigation/AuthNavigator.js
@@ -10,12 +10,9 @@
 
 import React from 'react';
 import { createStackNavigator } from '@react-navigation/stack';
-import { LoginScreen } from '../screens';
+import { LoginScreen, RegisterScreen, ResetPasswordScreen } from '../screens';
 import OrganizationSelectScreen from '../screens/OrganizationSelectScreen';
 import { debugLog, debugError } from '../utils/DebugUtils.js';
-// Import future auth screens
-// import RegisterScreen from '../screens/RegisterScreen';
-// import ResetPasswordScreen from '../screens/ResetPasswordScreen';
 
 const Stack = createStackNavigator();
 
@@ -42,9 +39,8 @@ const AuthNavigator = ({ onLogin }) => {
           {(props) => <LoginScreen {...props} onLogin={onLogin} />}
         </Stack.Screen>
 
-        {/* Future auth screens */}
-        {/* <Stack.Screen name="Register" component={RegisterScreen} /> */}
-        {/* <Stack.Screen name="ResetPassword" component={ResetPasswordScreen} /> */}
+        <Stack.Screen name="Register" component={RegisterScreen} />
+        <Stack.Screen name="ResetPassword" component={ResetPasswordScreen} />
       </Stack.Navigator>
     );
   } catch (error) {


### PR DESCRIPTION
### Motivation
- Bring mobile auth flow in line with the web SPA by restoring account creation and password reset navigation from `/spa` to `/mobile` so the login screen links work.
- Ensure users can reach `Register` and `ResetPassword` screens from the auth stack for proper UX.

### Description
- Import `RegisterScreen` and `ResetPasswordScreen` from `mobile/src/screens` into `mobile/src/navigation/AuthNavigator.js`.
- Add `<Stack.Screen name="Register" component={RegisterScreen} />` and `<Stack.Screen name="ResetPassword" component={ResetPasswordScreen} />` to the auth navigator so the login links route correctly.
- Keep `LoginScreen` wrapped to pass `onLogin` while exposing the two new routes directly in the same navigator.
- Modified file: `mobile/src/navigation/AuthNavigator.js`.

### Testing
- No automated tests were executed for this change.
- Manual verification recommended: build/start the mobile app and confirm navigation from the `Login` view to `Register` and `ResetPassword` screens succeeds.
- Linting/type checks were not run as part of this change.
- No runtime issues were observed while applying the change (no app start performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955801f95d48324872009e9971ef580)