### PR TITLE
Add mobile notify toggle and localize activity update emails

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1998,5 +1998,20 @@
   "district_management_bundle_administration": "Reporting and administrative read access.",
   "district_management_bundle_parent": "Parent access to child records and carpooling.",
   "district_management_bundle_demoadmin": "Demo administration for read-only environments.",
-  "district_management_bundle_demoparent": "Demo parent read-only bundle."
+  "district_management_bundle_demoparent": "Demo parent read-only bundle.",
+  "activity_notify_updates_label": "Notify parents and leaders about this update",
+  "activity_notify_updates_help": "An email will be sent using each recipient's preferred language or the organization's default.",
+  "activity_update_email_subject": "Activity Updated - {activity}",
+  "activity_update_email_heading": "Activity Updated",
+  "activity_update_email_greeting": "Hello {name},",
+  "activity_update_email_intro": "The details for \"{activity}\" on {date} have been updated.",
+  "activity_update_email_date_label": "Date",
+  "activity_update_email_going_heading": "Going",
+  "activity_update_email_return_heading": "Returning",
+  "activity_update_email_meeting_location": "Meeting Location",
+  "activity_update_email_meeting_time": "Meeting Time",
+  "activity_update_email_departure_time": "Departure Time",
+  "activity_update_email_footer": "Please review the updated information in the Wampums portal.",
+  "activity_update_email_signature": "Best regards,\nWampums Team",
+  "activity_update_email_generic_name": "there"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -2036,5 +2036,20 @@
   "district_management_bundle_administration": "Lecture des rapports et données administratives.",
   "district_management_bundle_parent": "Accès parent aux dossiers des enfants et au covoiturage.",
   "district_management_bundle_demoadmin": "Administration de démonstration en lecture seule.",
-  "district_management_bundle_demoparent": "Rôle parent de démonstration en lecture seule."
+  "district_management_bundle_demoparent": "Rôle parent de démonstration en lecture seule.",
+  "activity_notify_updates_label": "Notifier les parents et animateurs de cette mise à jour",
+  "activity_notify_updates_help": "Un courriel sera envoyé selon la langue préférée de chaque destinataire ou la langue par défaut de l'organisation.",
+  "activity_update_email_subject": "Activité mise à jour - {activity}",
+  "activity_update_email_heading": "Activité mise à jour",
+  "activity_update_email_greeting": "Bonjour {name},",
+  "activity_update_email_intro": "Les détails de « {activity} » prévue le {date} ont été mis à jour.",
+  "activity_update_email_date_label": "Date",
+  "activity_update_email_going_heading": "Aller",
+  "activity_update_email_return_heading": "Retour",
+  "activity_update_email_meeting_location": "Lieu de rencontre",
+  "activity_update_email_meeting_time": "Heure de rencontre",
+  "activity_update_email_departure_time": "Heure de départ",
+  "activity_update_email_footer": "Veuillez consulter les informations mises à jour dans le portail Wampums.",
+  "activity_update_email_signature": "Cordialement,\nÉquipe Wampums",
+  "activity_update_email_generic_name": "à vous"
 }

--- a/mobile/src/screens/ActivityDetailScreen.js
+++ b/mobile/src/screens/ActivityDetailScreen.js
@@ -21,6 +21,7 @@ import {
   TouchableOpacity,
   TextInput,
   Alert,
+  Switch,
 } from 'react-native';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { getActivity, createActivity, updateActivity, deleteActivity } from '../api/api-endpoints';
@@ -39,6 +40,7 @@ const ActivityDetailScreen = () => {
   const [loading, setLoading] = useState(!isNewActivity);
   const [error, setError] = useState(null);
   const [saving, setSaving] = useState(false);
+  const [notifyParticipants, setNotifyParticipants] = useState(true);
 
   // Form state
   const [formData, setFormData] = useState({
@@ -121,6 +123,10 @@ const ActivityDetailScreen = () => {
         }
         return acc;
       }, {});
+
+      if (!isNewActivity) {
+        activityData.notify_participants = notifyParticipants;
+      }
 
       let response;
       if (isNewActivity) {
@@ -293,6 +299,25 @@ const ActivityDetailScreen = () => {
             placeholder={t('enter_location')}
           />
 
+          {!isNewActivity && (
+            <View style={styles.toggleRow}>
+              <View style={styles.toggleText}>
+                <Text style={styles.toggleLabel}>
+                  {t('activity_notify_updates_label')}
+                </Text>
+                <Text style={styles.toggleHelp}>
+                  {t('activity_notify_updates_help')}
+                </Text>
+              </View>
+              <Switch
+                value={notifyParticipants}
+                onValueChange={setNotifyParticipants}
+                trackColor={{ false: theme.colors.borderLight, true: theme.colors.primary }}
+                thumbColor={theme.colors.surface}
+              />
+            </View>
+          )}
+
           <View style={styles.buttonContainer}>
             <Button
               title={isNewActivity ? t('create') : t('save')}
@@ -371,6 +396,25 @@ const styles = StyleSheet.create({
   textArea: {
     minHeight: 100,
     textAlignVertical: 'top',
+  },
+  toggleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginTop: theme.spacing.md,
+  },
+  toggleText: {
+    flex: 1,
+    marginRight: theme.spacing.md,
+  },
+  toggleLabel: {
+    ...commonStyles.bodyText,
+    fontWeight: theme.fontWeight.semibold,
+  },
+  toggleHelp: {
+    ...commonStyles.bodyText,
+    color: theme.colors.textSecondary,
+    marginTop: theme.spacing.xs,
   },
   buttonContainer: {
     marginTop: theme.spacing.lg,

--- a/spa/activities.js
+++ b/spa/activities.js
@@ -305,6 +305,16 @@ export class Activities {
             </div>
           </fieldset>
 
+          ${isEdit ? `
+          <div class="form-group">
+            <label>
+              <input type="checkbox" name="notify_participants" checked>
+              ${translate('activity_notify_updates_label')}
+            </label>
+            <small class="form-help">${translate('activity_notify_updates_help')}</small>
+          </div>
+          ` : ''}
+
           <div class="modal__actions">
             <button type="button" class="button button--secondary" id="cancel-activity-btn">
               ${translate('cancel')}
@@ -358,6 +368,9 @@ export class Activities {
       if (!data.meeting_location_return) data.meeting_location_return = null;
       if (!data.meeting_time_return) data.meeting_time_return = null;
       if (!data.departure_time_return) data.departure_time_return = null;
+      if (isEdit) {
+        data.notify_participants = formData.get('notify_participants') === 'on';
+      }
 
       setButtonLoading(submitButton, true);
 


### PR DESCRIPTION
### Motivation
- Send activity update emails in each recipient's preferred language and avoid sending untranslated automatic messages.  
- Give editors an explicit control to suppress or send notifications via a `notify_participants` flag when editing activities.  
- Improve email safety and clarity by sanitizing dynamic values and formatting dates for locale-aware presentation.  
- Mirror the web UI behavior in the mobile app so activity edits from mobile can opt out of notifications as well.

### Description
- Localized and hardened activity update emails in `utils/carpool-notifications.js` using `getUserEmailLanguage`, `getTranslationsByCode`, `sanitizeInput`, `escapeHtml`, and a `formatEmailDate` helper to build per-recipient subject/body and HTML.  
- Updated the activities API in `routes/activities.js` to accept an optional `notify_participants` flag (defaults to true) and only call `sendActivityUpdateNotifications` when notifications are enabled.  
- Updated the web UI in `spa/activities.js` to render a notify checkbox in the activity edit modal and include `notify_participants` in the update payload.  
- Added matching translation keys to `lang/en.json` and `lang/fr.json`, and added the mobile UI change in `mobile/src/screens/ActivityDetailScreen.js` to show a toggle and send `notify_participants` on updates.

### Testing
- No automated unit or integration tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695596b7fd2c8324b95a375b41294463)