### PR TITLE
Parent dashboard: inline activities & carpool info; fix children loading

### DIFF
--- a/mobile/src/config/index.js
+++ b/mobile/src/config/index.js
@@ -161,6 +161,7 @@ const CONFIG = {
     DEBOUNCE_DELAY: 300,
     POINTS_QUICK_ACTIONS: [1, 3, 5, -1, -3, -5],
     ATTENDANCE_STATUSES: ['present', 'late', 'absent', 'excused'],
+    PARENT_DASHBOARD_MAX_UPCOMING_ACTIVITIES: 5,
   },
 
   // Feature flags


### PR DESCRIPTION
### Motivation
- Parents should not be able to open an upcoming activity for modification from the mobile parent dashboard, and carpool information must be shown alongside each activity.
- The parent dashboard must reliably display the guardian's children (participants) rather than omitting them in some cases.
- Activity and carpool UI should be readable on the dashboard without requiring extra navigation to a detail screen.
- Use configuration and normalized data to avoid hardcoded limits and to handle API payload shape differences.

### Description
- Load children from the dedicated `getParentDashboard` endpoint with a normalized fallback to `getParticipants` using `StorageUtils` when necessary via the new `normalizeDashboardChildren` helper.
- Render upcoming activities inline (no `ActivityDetail` navigation) and attach per-activity carpool assignments by grouping assignments with `mapCarpoolAssignmentsByActivity` and formatting times with `formatOptionalTime`.
- Add `UI.PARENT_DASHBOARD_MAX_UPCOMING_ACTIVITIES` in `mobile/src/config/index.js` and remove an unused `Button` import, plus add small styles for the carpool section (`activityCarpoolSection`, `activityCarpoolTitle`, `carpoolAssignment`).
- Use translation key `select_at_least_one_participant` for the link dialog validation and add `getParentDashboard` usage in API calls where applicable.

### Testing
- No automated tests were executed for this change.
- Manual runtime validation was not recorded in automated logs (only code changes and a commit were created).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955beddcdf48324b7d6d515174939e6)