### PR TITLE
Normalize parent permission slips response and add badge progress quick link

### DIFF
--- a/mobile/src/screens/ParentDashboardScreen.js
+++ b/mobile/src/screens/ParentDashboardScreen.js
@@ -111,6 +111,29 @@ const getTripDirectionLabel = (tripDirection) => {
   }
 };
 
+/**
+ * Normalize permission slip response payloads into an array.
+ * @param {Object} response - API response payload.
+ * @returns {Array<Object>} Normalized permission slip entries.
+ */
+const normalizePermissionSlips = (response) => {
+  const payload = response?.data || response;
+
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+
+  if (Array.isArray(payload?.permission_slips)) {
+    return payload.permission_slips;
+  }
+
+  if (Array.isArray(payload?.data)) {
+    return payload.data;
+  }
+
+  return [];
+};
+
 const ParentDashboardScreen = () => {
   const navigation = useNavigation();
   const [loading, setLoading] = useState(true);
@@ -230,8 +253,9 @@ const ParentDashboardScreen = () => {
           // Collect all unsigned permission slips
           const allUnsigned = [];
           permissionSlipResponses.forEach((response) => {
-            if (response.success && response.data) {
-              const unsigned = response.data.filter((slip) => !slip.signed);
+            if (response.success) {
+              const slips = normalizePermissionSlips(response);
+              const unsigned = slips.filter((slip) => !slip.signed);
               allUnsigned.push(...unsigned);
             }
           });
@@ -647,6 +671,14 @@ const ParentDashboardScreen = () => {
         >
           <Text style={styles.actionButtonText}>
             📄 {t('permission_slip_title')}
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={styles.actionButton}
+          onPress={() => navigation.navigate('BadgeDashboard')}
+        >
+          <Text style={styles.actionButtonText}>
+            🏅 {t('badge_progress')}
           </Text>
         </TouchableOpacity>
         <TouchableOpacity


### PR DESCRIPTION
### Motivation
- Prevent crashes on the parent dashboard caused by unexpected permission slip response shapes that triggered `response.data.filter` TypeErrors.
- Make the parent dashboard more useful by exposing a quick link to the badge progress view (`BadgeDashboard`).
- Harden the dashboard against varying API payload formats by normalizing responses before processing.

### Description
- Add a helper `normalizePermissionSlips(response)` to extract an array of permission slips from multiple payload shapes (`response`, `response.data`, `response.data.permission_slips`).
- Use `normalizePermissionSlips` when aggregating per-child permission slip responses so `.filter` is called on a guaranteed array.  
- Add a new quick action button that navigates parents to `BadgeDashboard` and uses the translation key `badge_progress` for the label.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955dfe84afc832490c2b5450dc3954a)