### PR TITLE
Add carpool link to parent dashboard activity cards

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1854,6 +1854,7 @@
   "assigned": "Assigned",
   "vehicles": "Vehicles",
   "view_carpools": "View Carpools",
+  "carpool_view_and_assign": "Review offers and assign your children to rides.",
   "edit_activity": "Edit Activity",
   "create_activity": "Create Activity",
   "activity_created_success": "Activity created successfully",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1892,6 +1892,7 @@
   "assigned": "Assignés",
   "vehicles": "Véhicules",
   "view_carpools": "Voir covoiturages",
+  "carpool_view_and_assign": "Voir les offres et assigner vos enfants aux trajets.",
   "edit_activity": "Modifier l'activité",
   "create_activity": "Créer l'activité",
   "activity_created_success": "Activité créée avec succès",

--- a/mobile/src/screens/ParentDashboardScreen.js
+++ b/mobile/src/screens/ParentDashboardScreen.js
@@ -553,6 +553,15 @@ const ParentDashboardScreen = () => {
                     {formatOptionalTime(activity.meeting_time_return)}
                   </Text>
                 )}
+                <TouchableOpacity
+                  style={styles.carpoolLink}
+                  onPress={() => navigation.navigate('Carpool', { activityId: activity.id })}
+                >
+                  <Text style={styles.carpoolLinkTitle}>🚗 {t('view_carpools')}</Text>
+                  <Text style={styles.carpoolLinkSubtitle}>
+                    {t('carpool_view_and_assign')}
+                  </Text>
+                </TouchableOpacity>
                 {activityCarpools.length > 0 && (
                   <View style={styles.activityCarpoolSection}>
                     <Text style={styles.activityCarpoolTitle}>
@@ -836,6 +845,24 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: '#333',
     marginBottom: 6,
+  },
+  carpoolLink: {
+    marginTop: 12,
+    padding: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#007AFF',
+    backgroundColor: '#fff',
+  },
+  carpoolLinkTitle: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#007AFF',
+  },
+  carpoolLinkSubtitle: {
+    fontSize: 12,
+    color: '#666',
+    marginTop: 4,
   },
   carpoolAssignment: {
     marginBottom: 8,


### PR DESCRIPTION
### Motivation
- Parents need a quick way to view carpool offers for a specific activity and assign their children to rides from the mobile app.  
- The parent dashboard previously showed upcoming activities and existing assignments but lacked a CTA to navigate to the activity carpool screen.  
- Add a localized helper so users understand the action is to review offers and assign children.  

### Description
- Add a CTA `TouchableOpacity` to each upcoming activity card in `mobile/src/screens/ParentDashboardScreen.js` that navigates to the `Carpool` screen with `activityId` via `navigation.navigate('Carpool', { activityId: activity.id })`.  
- Add UI styles `carpoolLink`, `carpoolLinkTitle`, and `carpoolLinkSubtitle` to the same screen for consistent touch-target sizing and visual treatment.  
- Add new localized string key `carpool_view_and_assign` to `lang/en.json` and `lang/fr.json` and reuse existing `t('view_carpools')` for the link title.  

### Testing
- No automated tests were run for this change.  
- The change is limited to UI navigation, translation keys, and styles and does not modify backend APIs.  
- Manual runtime verification is recommended (open parent dashboard, tap the carpool CTA, and confirm `Carpool` screen opens with the correct `activityId`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955e12e90f88324876182fe47764fe8)