### PR TITLE
Carpool: restrict parent participant view, add optimistic assign/remove, and clear caches

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1874,6 +1874,7 @@
   "look_for_ride": "Look for Ride",
   "attention": "Attention",
   "participants_need_rides": "participants need rides",
+  "your_children_need_rides": "Your children needing rides",
   "available_rides": "Available Rides",
   "current_assignments": "Current Assignments",
   "participants_needing_rides": "Participants Needing Rides",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1912,6 +1912,7 @@
   "look_for_ride": "Chercher un trajet",
   "attention": "Attention",
   "participants_need_rides": "participants ont besoin de transport",
+  "your_children_need_rides": "Vos enfants ont besoin de transport",
   "available_rides": "Trajets disponibles",
   "current_assignments": "Assignations actuelles",
   "participants_needing_rides": "Participants nécessitant un transport",

--- a/mobile/src/utils/CacheManager.js
+++ b/mobile/src/utils/CacheManager.js
@@ -353,6 +353,7 @@ class CacheManager {
     }
 
     await this.deleteCachedDataByPattern('v1/carpools/my-offers');
+    await this.deleteCachedDataByPattern('v1/carpools/my-children-assignments');
   }
 
   /**


### PR DESCRIPTION
### Motivation
- Parents should not see the full participant list and must only be able to assign their own children to carpools. 
- Improve UX by applying optimistic updates when adding/removing assignments so the UI updates instantly. 
- Ensure cache consistency by invalidating carpool-related caches after mutations so data refreshes correctly. 
- Keep translations and mobile UI consistent with the parent-facing summary view.

### Description
- Updated `mobile/src/screens/CarpoolScreen.js` to show parents a summary count (`participantsNeedingRides`) and only list the current user's children for assignment while staff still see the full unassigned list. 
- Implemented optimistic assignment and removal flows using `globalOptimisticManager`/`generateOptimisticId` from `mobile/src/utils/OptimisticUpdateManager.js` to update `carpoolOffers` and `participants` immediately and rollback on error. 
- Added cache invalidation calls to `CacheManager.clearCarpoolRelatedCaches(activityId)` after offer create/update/cancel and after assignment add/remove, and updated `mobile/src/utils/CacheManager.js` to also clear `v1/carpools/my-children-assignments`. 
- Added translation keys (`your_children_need_rides`) to `lang/en.json` and `lang/fr.json`, and added a small reliability tweak to resolve `userId` from storage when needed.

### Testing
- No automated tests were executed as part of this change. 
- Existing unit tests for `CacheManager` and optimistic utilities remain (no changes to tests were run). 
- Manual verification recommended on a device/emulator for parent and staff flows to confirm visibility, optimistic updates, and cache refresh after mutations. 
- If CI is available, please run the repo's test suite and mobile linters (not executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955e39c9e508324a18e727bee9da0b3)