### PR TITLE
Set login screen language from organization default

### DIFF
--- a/routes/organizations.js
+++ b/routes/organizations.js
@@ -194,18 +194,28 @@ module.exports = (pool, logger) => {
    * @swagger
    * /public/get_organization_id:
    *   get:
-   *     summary: Get current organization ID
-   *     description: Public endpoint to retrieve organization ID from request context
+   *     summary: Get current organization ID and default language
+   *     description: Public endpoint to retrieve organization ID and default language from request context
    *     tags: [Organizations]
    *     responses:
    *       200:
-   *         description: Organization ID retrieved
+   *         description: Organization ID and default language retrieved
    */
   router.get('/get_organization_id', asyncHandler(async (req, res) => {
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
+
+      // Fetch organization default language
+      const orgResult = await pool.query(
+        'SELECT default_language FROM organizations WHERE id = $1',
+        [organizationId]
+      );
+
+      const defaultLanguage = orgResult.rows[0]?.default_language || 'fr';
+
       res.json({
         success: true,
-        organizationId: organizationId
+        organizationId: organizationId,
+        defaultLanguage: defaultLanguage
       });
   }));
 


### PR DESCRIPTION
Update mobile app to fetch and apply the organization's default language before displaying the login screen, ensuring the login UI is displayed in the correct language from the start.

Changes:
- Backend: Modified /public/get_organization_id endpoint to return organization default_language from the organizations table
- Mobile API: Updated getOrganizationId to handle defaultLanguage in response
- Mobile API: Added getOrganizationLanguage function to fetch organization language
- LoginScreen: Added loadOrganizationData to fetch and apply organization language on mount before rendering the login form
- LoginScreen: Added loading state while organization language is being fetched

The login screen now displays in the organization's default language (from the organizations.default_language column) instead of always using the device locale or app default.