### PR TITLE
feat: Reorganize mobile Settings and AccountInfo screens for better UX

### DIFF
--- a/mobile/src/screens/SettingsScreen.js
+++ b/mobile/src/screens/SettingsScreen.js
@@ -2,8 +2,10 @@
  * Settings Screen
  *
  * App settings including:
+ * - User profile (name, email, password)
  * - Language selection
- * - User profile
+ * - WhatsApp notifications
+ * - Organization switching
  * - App preferences
  * - Logout
  */
@@ -17,40 +19,200 @@ import {
   StyleSheet,
   Alert,
   Switch,
+  RefreshControl,
 } from 'react-native';
 import StorageUtils from '../utils/StorageUtils';
+import SecurityUtils from '../utils/SecurityUtils';
 import { translate as t, changeLanguage, getCurrentLanguage } from '../i18n';
-import { logout, switchOrganization } from '../api/api-endpoints';
+import {
+  logout,
+  switchOrganization,
+  getUserProfile,
+  updateUserProfile,
+  changePassword
+} from '../api/api-endpoints';
 import CacheManager from '../utils/CacheManager';
 import CONFIG from '../config';
-import { Card } from '../components';
+import {
+  Card,
+  FormField,
+  Button,
+  Toast,
+  useToast,
+} from '../components';
 import theme, { commonStyles } from '../theme';
 import { debugLog, debugError } from '../utils/DebugUtils.js';
 
 const SettingsScreen = ({ navigation }) => {
-  const [userName, setUserName] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  // User data
+  const [userData, setUserData] = useState(null);
   const [userRole, setUserRole] = useState('');
   const [organizationUrl, setOrganizationUrl] = useState('');
   const [currentLanguage, setCurrentLanguage] = useState('fr');
   const [pushEnabled, setPushEnabled] = useState(false);
   const [switchingOrg, setSwitchingOrg] = useState(false);
 
+  // Editable profile fields
+  const [fullName, setFullName] = useState('');
+  const [email, setEmail] = useState('');
+  const [languagePreference, setLanguagePreference] = useState('');
+  const [whatsappPhone, setWhatsappPhone] = useState('');
+
+  // Password fields
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+
+  const toast = useToast();
+
   useEffect(() => {
     loadSettings();
   }, []);
 
   const loadSettings = async () => {
-    // Load user data
-    const name = await StorageUtils.getItem(CONFIG.STORAGE_KEYS.USER_FULL_NAME);
-    const role = await StorageUtils.getItem(CONFIG.STORAGE_KEYS.USER_ROLE);
-    const orgUrl = await StorageUtils.getItem('organizationUrl');
+    try {
+      setLoading(true);
 
-    setUserName(name || '');
-    setUserRole(role || '');
-    setOrganizationUrl(orgUrl || t('organization_not_set'));
-    setCurrentLanguage(getCurrentLanguage());
+      // Load user profile from API
+      const response = await getUserProfile();
+      if (response.success) {
+        const data = response.data;
+        setUserData(data);
+        setFullName(data.full_name || '');
+        setEmail(data.email || '');
+        setLanguagePreference(data.language_preference || '');
+        setWhatsappPhone(data.whatsapp_phone_number || '');
+        setUserRole(data.role || '');
+      }
 
-    // TODO: Load push notification preference when implemented
+      // Load local storage data
+      const role = await StorageUtils.getItem(CONFIG.STORAGE_KEYS.USER_ROLE);
+      const orgUrl = await StorageUtils.getItem('organizationUrl');
+
+      setUserRole(role || '');
+      setOrganizationUrl(orgUrl || t('organization_not_set'));
+      setCurrentLanguage(getCurrentLanguage());
+
+      // TODO: Load push notification preference when implemented
+    } catch (error) {
+      debugError('Error loading settings:', error);
+      toast.show(t('error_loading_data') || 'Error loading settings', 'error');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const onRefresh = async () => {
+    setRefreshing(true);
+    await loadSettings();
+    setRefreshing(false);
+  };
+
+  const handleSaveProfile = async () => {
+    // Validate inputs
+    if (!fullName.trim()) {
+      toast.show(t('error_name_required') || 'Name is required', 'error');
+      return;
+    }
+
+    if (!email.trim()) {
+      toast.show(t('error_email_required') || 'Email is required', 'error');
+      return;
+    }
+
+    if (!SecurityUtils.isValidEmail(email)) {
+      toast.show(t('error_email_invalid') || 'Invalid email address', 'error');
+      return;
+    }
+
+    try {
+      setSaving(true);
+      const response = await updateUserProfile({
+        fullName: SecurityUtils.sanitizeInput(fullName.trim()),
+        email: SecurityUtils.sanitizeInput(email.trim()),
+        languagePreference,
+        whatsappPhoneNumber: SecurityUtils.sanitizeInput(whatsappPhone.trim()),
+      });
+
+      if (response.success) {
+        toast.show(t('success_profile_updated') || 'Profile updated successfully', 'success');
+
+        // Update local storage
+        await StorageUtils.setItem(CONFIG.STORAGE_KEYS.USER_FULL_NAME, fullName);
+
+        // If email changed, warn about logout
+        if (email !== userData.email) {
+          Alert.alert(
+            t('email_changed'),
+            t('email_changed_logout_warning') || 'Your email has been updated. You will be logged out for security.',
+            [
+              {
+                text: t('OK'),
+                onPress: handleLogout,
+              },
+            ]
+          );
+        } else {
+          await loadSettings(); // Reload to get fresh data
+        }
+      } else {
+        toast.show(response.message || t('error_save_failed'), 'error');
+      }
+    } catch (err) {
+      debugError('Error saving profile:', err);
+      toast.show(err.message || t('error_save_failed'), 'error');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleChangePassword = async () => {
+    // Validate password inputs
+    if (!currentPassword) {
+      toast.show(t('error_current_password_required') || 'Current password is required', 'error');
+      return;
+    }
+
+    if (!newPassword) {
+      toast.show(t('error_new_password_required') || 'New password is required', 'error');
+      return;
+    }
+
+    if (newPassword.length < 8) {
+      toast.show(t('error_password_too_short') || 'Password must be at least 8 characters', 'error');
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
+      toast.show(t('error_passwords_dont_match') || 'Passwords do not match', 'error');
+      return;
+    }
+
+    try {
+      setSaving(true);
+      const response = await changePassword({
+        currentPassword,
+        newPassword,
+      });
+
+      if (response.success) {
+        toast.show(t('success_password_changed') || 'Password changed successfully', 'success');
+        setCurrentPassword('');
+        setNewPassword('');
+        setConfirmPassword('');
+      } else {
+        toast.show(response.message || t('error_password_change_failed'), 'error');
+      }
+    } catch (err) {
+      debugError('Error changing password:', err);
+      toast.show(err.message || t('error_password_change_failed'), 'error');
+    } finally {
+      setSaving(false);
+    }
   };
 
   const handleLanguageChange = async (lang) => {
@@ -172,118 +334,215 @@ const SettingsScreen = ({ navigation }) => {
   };
 
   return (
-    <ScrollView style={styles.container}>
-      {/* User Profile Section */}
-      <View style={styles.section}>
-        <Text style={styles.sectionTitle}>{t('profile')}</Text>
-        <Card>
-          <Text style={styles.profileName}>{userName}</Text>
-          <Text style={styles.profileRole}>{userRole}</Text>
-        </Card>
-      </View>
+    <View style={styles.container}>
+      <ScrollView
+        style={styles.scrollView}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+      >
+        {/* Profile Section */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>{t('profile')}</Text>
+          <Card>
+            <Text style={styles.profileName}>{fullName || userData?.full_name}</Text>
+            <Text style={styles.profileRole}>{userRole}</Text>
+          </Card>
+        </View>
 
-      {/* Organization Section */}
-      <View style={styles.section}>
-        <Text style={styles.sectionTitle}>{t('organization_current')}</Text>
-        <Card>
-          <View style={styles.settingRow}>
-            <View style={styles.orgInfo}>
-              <Text style={styles.settingLabel}>{t('Organization')}</Text>
-              <Text style={styles.orgUrl}>{organizationUrl}</Text>
+        {/* Profile Information Section */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>{t('profile_information') || 'Profile Information'}</Text>
+
+          <FormField
+            label={t('full_name') || 'Full Name'}
+            value={fullName}
+            onChangeText={setFullName}
+            placeholder={t('enter_full_name') || 'Enter your full name'}
+            required
+          />
+
+          <FormField
+            label={t('email') || 'Email'}
+            value={email}
+            onChangeText={setEmail}
+            placeholder={t('enter_email') || 'Enter your email'}
+            keyboardType="email-address"
+            autoCapitalize="none"
+            required
+            helpText={t('account_info_email_warning') || 'Changing your email will log you out'}
+          />
+
+          <FormField
+            label={t('whatsapp_phone') || 'WhatsApp Phone Number'}
+            value={whatsappPhone}
+            onChangeText={setWhatsappPhone}
+            placeholder={t('enter_whatsapp_phone') || 'Enter WhatsApp number'}
+            keyboardType="phone-pad"
+            helpText={t('account_info_whatsapp_help') || 'For receiving notifications via WhatsApp'}
+          />
+
+          <Button
+            title={t('save_profile') || 'Save Profile'}
+            onPress={handleSaveProfile}
+            loading={saving}
+            style={styles.saveButton}
+          />
+        </View>
+
+        {/* Password Section */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>{t('change_password') || 'Change Password'}</Text>
+
+          <FormField
+            label={t('current_password') || 'Current Password'}
+            value={currentPassword}
+            onChangeText={setCurrentPassword}
+            placeholder={t('enter_current_password') || 'Enter current password'}
+            secureTextEntry
+            required
+          />
+
+          <FormField
+            label={t('new_password') || 'New Password'}
+            value={newPassword}
+            onChangeText={setNewPassword}
+            placeholder={t('enter_new_password') || 'Enter new password (min 8 characters)'}
+            secureTextEntry
+            required
+          />
+
+          <FormField
+            label={t('confirm_password') || 'Confirm New Password'}
+            value={confirmPassword}
+            onChangeText={setConfirmPassword}
+            placeholder={t('confirm_new_password') || 'Confirm new password'}
+            secureTextEntry
+            required
+          />
+
+          <Button
+            title={t('change_password') || 'Change Password'}
+            onPress={handleChangePassword}
+            loading={saving}
+            variant="secondary"
+            style={styles.saveButton}
+          />
+        </View>
+
+        {/* Organization Section */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>{t('organization_current')}</Text>
+          <Card>
+            <View style={styles.settingRow}>
+              <View style={styles.orgInfo}>
+                <Text style={styles.settingLabel}>{t('Organization')}</Text>
+                <Text style={styles.orgUrl}>{organizationUrl}</Text>
+              </View>
             </View>
-          </View>
-          <View style={styles.separator} />
-          <TouchableOpacity
-            style={styles.settingRow}
-            onPress={handleSwitchOrganization}
-            disabled={switchingOrg}
-          >
-            <Text style={[styles.settingLabel, styles.switchOrgText]}>
-              {switchingOrg ? t('organization_switching') : t('organization_switch_organization')}
-            </Text>
-            {!switchingOrg && <Text style={styles.chevron}>›</Text>}
+            <View style={styles.separator} />
+            <TouchableOpacity
+              style={styles.settingRow}
+              onPress={handleSwitchOrganization}
+              disabled={switchingOrg}
+            >
+              <Text style={[styles.settingLabel, styles.switchOrgText]}>
+                {switchingOrg ? t('organization_switching') : t('organization_switch_organization')}
+              </Text>
+              {!switchingOrg && <Text style={styles.chevron}>›</Text>}
+            </TouchableOpacity>
+          </Card>
+          <Text style={styles.settingHelp}>
+            {t('Switching organizations will log you out and require you to log in again')}
+          </Text>
+        </View>
+
+        {/* Language Section */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>{t('language')}</Text>
+          <Card>
+            <TouchableOpacity
+              style={styles.settingRow}
+              onPress={() => handleLanguageChange('en')}
+            >
+              <Text style={styles.settingLabel}>English</Text>
+              {currentLanguage === 'en' && <Text style={styles.checkmark}>✓</Text>}
+            </TouchableOpacity>
+            <View style={styles.separator} />
+            <TouchableOpacity
+              style={styles.settingRow}
+              onPress={() => handleLanguageChange('fr')}
+            >
+              <Text style={styles.settingLabel}>Français</Text>
+              {currentLanguage === 'fr' && <Text style={styles.checkmark}>✓</Text>}
+            </TouchableOpacity>
+          </Card>
+        </View>
+
+        {/* Notifications Section */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>{t('Notifications')}</Text>
+          <Card>
+            <View style={styles.settingRow}>
+              <Text style={styles.settingLabel}>{t('Push Notifications')}</Text>
+              <Switch
+                value={pushEnabled}
+                onValueChange={setPushEnabled}
+                trackColor={{ false: '#E5E5EA', true: '#34C759' }}
+              />
+            </View>
+          </Card>
+          <Text style={styles.settingHelp}>
+            {t('Receive notifications about activities')}
+          </Text>
+        </View>
+
+        {/* App Info Section */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>{t('App Info')}</Text>
+          <Card>
+            <View style={styles.settingRow}>
+              <Text style={styles.settingLabel}>{t('Version')}</Text>
+              <Text style={styles.settingValue}>{CONFIG.APP.VERSION}</Text>
+            </View>
+            <View style={styles.separator} />
+            <View style={styles.settingRow}>
+              <Text style={styles.settingLabel}>{t('Build')}</Text>
+              <Text style={styles.settingValue}>{CONFIG.APP.BUILD_NUMBER}</Text>
+            </View>
+          </Card>
+        </View>
+
+        {/* Account Actions */}
+        <View style={styles.section}>
+          <TouchableOpacity style={styles.logoutButton} onPress={handleLogout}>
+            <Text style={styles.logoutButtonText}>{t('logout')}</Text>
           </TouchableOpacity>
-        </Card>
-        <Text style={styles.settingHelp}>
-          {t('Switching organizations will log you out and require you to log in again')}
-        </Text>
-      </View>
+        </View>
 
-      {/* Language Section */}
-      <View style={styles.section}>
-        <Text style={styles.sectionTitle}>{t('language')}</Text>
-        <Card>
-          <TouchableOpacity
-            style={styles.settingRow}
-            onPress={() => handleLanguageChange('en')}
-          >
-            <Text style={styles.settingLabel}>English</Text>
-            {currentLanguage === 'en' && <Text style={styles.checkmark}>✓</Text>}
-          </TouchableOpacity>
-          <View style={styles.separator} />
-          <TouchableOpacity
-            style={styles.settingRow}
-            onPress={() => handleLanguageChange('fr')}
-          >
-            <Text style={styles.settingLabel}>Français</Text>
-            {currentLanguage === 'fr' && <Text style={styles.checkmark}>✓</Text>}
-          </TouchableOpacity>
-        </Card>
-      </View>
+        <View style={styles.footer}>
+          <Text style={styles.footerText}>
+            {t('Made with')} ❤️ {t('for Scouts')}
+          </Text>
+        </View>
+      </ScrollView>
 
-      {/* Notifications Section */}
-      <View style={styles.section}>
-        <Text style={styles.sectionTitle}>{t('Notifications')}</Text>
-        <Card>
-          <View style={styles.settingRow}>
-            <Text style={styles.settingLabel}>{t('Push Notifications')}</Text>
-            <Switch
-              value={pushEnabled}
-              onValueChange={setPushEnabled}
-              trackColor={{ false: '#E5E5EA', true: '#34C759' }}
-            />
-          </View>
-        </Card>
-        <Text style={styles.settingHelp}>
-          {t('Receive notifications about activities')}
-        </Text>
-      </View>
-
-      {/* App Info Section */}
-      <View style={styles.section}>
-        <Text style={styles.sectionTitle}>{t('App Info')}</Text>
-        <Card>
-          <View style={styles.settingRow}>
-            <Text style={styles.settingLabel}>{t('Version')}</Text>
-            <Text style={styles.settingValue}>{CONFIG.APP.VERSION}</Text>
-          </View>
-          <View style={styles.separator} />
-          <View style={styles.settingRow}>
-            <Text style={styles.settingLabel}>{t('Build')}</Text>
-            <Text style={styles.settingValue}>{CONFIG.APP.BUILD_NUMBER}</Text>
-          </View>
-        </Card>
-      </View>
-
-      {/* Account Actions */}
-      <View style={styles.section}>
-        <TouchableOpacity style={styles.logoutButton} onPress={handleLogout}>
-          <Text style={styles.logoutButtonText}>{t('logout')}</Text>
-        </TouchableOpacity>
-      </View>
-
-      <View style={styles.footer}>
-        <Text style={styles.footerText}>
-          {t('Made with')} ❤️ {t('for Scouts')}
-        </Text>
-      </View>
-    </ScrollView>
+      <Toast
+        visible={toast.toastState.visible}
+        message={toast.toastState.message}
+        type={toast.toastState.type}
+        duration={toast.toastState.duration}
+        onDismiss={toast.hide}
+      />
+    </View>
   );
 };
 
 const styles = StyleSheet.create({
   container: {
-    ...commonStyles.container,
+    flex: 1,
+    backgroundColor: theme.colors.background.primary,
+  },
+  scrollView: {
+    flex: 1,
   },
   section: {
     ...commonStyles.section,
@@ -326,6 +585,9 @@ const styles = StyleSheet.create({
     color: theme.colors.textMuted,
     marginTop: theme.spacing.sm,
     marginHorizontal: theme.spacing.md,
+  },
+  saveButton: {
+    marginTop: theme.spacing.md,
   },
   logoutButton: {
     backgroundColor: theme.colors.error,


### PR DESCRIPTION
SettingsScreen (accessible from dashboard cog) now includes:
- Full profile editing (name, email, WhatsApp phone for notifications)
- Email change with automatic logout warning for security
- Password change functionality
- Language preference selection
- Organization switching
- Push notifications toggle (placeholder)
- App info and logout
- Mobile-first, pleasant UX with form validation and toast notifications

AccountInfoScreen (district-only, in LeaderDashboard admin section):
- Now focused solely on district-level integrations
- Requires communications.send permission
- WhatsApp Baileys integration: connection status, disconnect, web redirect for QR
- Google Workspace chat integration (placeholder for future)
- Stripe payment integration status (placeholder for future)
- Clean mobile-first design with status badges and cards

This separation provides:
1. Personal settings easily accessible to all users
2. Advanced integrations restricted to district admins
3. Better mobile UX with clear information hierarchy
4. Consistent patterns across both screens