### PR TITLE
Fix cache hit logging in mailing list

### DIFF
--- a/mobile/src/screens/FormPermissionsScreen.js
+++ b/mobile/src/screens/FormPermissionsScreen.js
@@ -56,7 +56,7 @@ const FormPermissionsScreen = ({ navigation }) => {
 
       const response = await fetch(`${API.baseURL}/form-permissions`, {
         headers: {
-          Authorization: `Bearer ${await StorageUtils.getToken()}`,
+          Authorization: `Bearer ${await StorageUtils.getJWT()}`,
         },
       });
 
@@ -120,7 +120,7 @@ const FormPermissionsScreen = ({ navigation }) => {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${await StorageUtils.getToken()}`,
+          Authorization: `Bearer ${await StorageUtils.getJWT()}`,
         },
         body: JSON.stringify({
           form_format_id: formFormatId,
@@ -152,7 +152,7 @@ const FormPermissionsScreen = ({ navigation }) => {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${await StorageUtils.getToken()}`,
+          Authorization: `Bearer ${await StorageUtils.getJWT()}`,
         },
         body: JSON.stringify({
           form_format_id: formFormatId,

--- a/mobile/src/screens/GroupParticipantReportScreen.js
+++ b/mobile/src/screens/GroupParticipantReportScreen.js
@@ -63,7 +63,7 @@ const GroupParticipantReportScreen = ({ navigation }) => {
 
   const loadData = async () => {
     try {
-      const token = await StorageUtils.getToken();
+      const token = await StorageUtils.getJWT();
 
       const [participantsResponse, groupsResponse] = await Promise.all([
         fetch(`${API.baseURL}/v1/participants`, {

--- a/mobile/src/screens/MailingListScreen.js
+++ b/mobile/src/screens/MailingListScreen.js
@@ -93,7 +93,7 @@ const MailingListScreen = ({ navigation }) => {
 
   const loadData = async () => {
     try {
-      const token = await StorageUtils.getToken();
+      const token = await StorageUtils.getJWT();
 
       const [mailingResponse, groupsResponse, announcementsResponse] = await Promise.all([
         fetch(`${API.baseURL}/v1/communications/mailing-list`, {
@@ -180,7 +180,7 @@ const MailingListScreen = ({ navigation }) => {
         send_now: !saveAsDraft,
       };
 
-      const token = await StorageUtils.getToken();
+      const token = await StorageUtils.getJWT();
       const response = await fetch(`${API.baseURL}/v1/communications/announcements`, {
         method: 'POST',
         headers: {

--- a/mobile/src/screens/RoleManagementScreen.js
+++ b/mobile/src/screens/RoleManagementScreen.js
@@ -87,7 +87,7 @@ const RoleManagementScreen = ({ navigation }) => {
   const fetchRoles = async () => {
     const response = await fetch(`${API.baseURL}/roles`, {
       headers: {
-        Authorization: `Bearer ${await StorageUtils.getToken()}`,
+        Authorization: `Bearer ${await StorageUtils.getJWT()}`,
         'X-Organization-Id': await StorageUtils.getOrganizationId(),
       },
     });
@@ -103,7 +103,7 @@ const RoleManagementScreen = ({ navigation }) => {
   const fetchUsers = async () => {
     const response = await fetch(`${API.baseURL}/users`, {
       headers: {
-        Authorization: `Bearer ${await StorageUtils.getToken()}`,
+        Authorization: `Bearer ${await StorageUtils.getJWT()}`,
         'X-Organization-Id': await StorageUtils.getOrganizationId(),
       },
     });
@@ -123,7 +123,7 @@ const RoleManagementScreen = ({ navigation }) => {
 
     const response = await fetch(`${API.baseURL}/roles/${roleId}/permissions`, {
       headers: {
-        Authorization: `Bearer ${await StorageUtils.getToken()}`,
+        Authorization: `Bearer ${await StorageUtils.getJWT()}`,
         'X-Organization-Id': await StorageUtils.getOrganizationId(),
       },
     });
@@ -162,7 +162,7 @@ const RoleManagementScreen = ({ navigation }) => {
     try {
       const response = await fetch(`${API.baseURL}/users/${user.id}/roles`, {
         headers: {
-          Authorization: `Bearer ${await StorageUtils.getToken()}`,
+          Authorization: `Bearer ${await StorageUtils.getJWT()}`,
           'X-Organization-Id': await StorageUtils.getOrganizationId(),
         },
       });
@@ -200,7 +200,7 @@ const RoleManagementScreen = ({ navigation }) => {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${await StorageUtils.getToken()}`,
+          Authorization: `Bearer ${await StorageUtils.getJWT()}`,
           'X-Organization-Id': await StorageUtils.getOrganizationId(),
         },
         body: JSON.stringify({ roleIds: selectedUserRoleIds }),

--- a/mobile/src/utils/StorageUtils.js
+++ b/mobile/src/utils/StorageUtils.js
@@ -245,6 +245,23 @@ export const getCurrentUserFromJWT = async () => {
   }
 };
 
+/**
+ * Get organization ID from JWT token
+ * Mirrors backend getOrganizationId functionality
+ */
+export const getOrganizationId = async () => {
+  try {
+    const token = await getJWT();
+    if (!token) return null;
+
+    const decoded = decodeJWT(token);
+    return decoded?.organizationId || null;
+  } catch (error) {
+    debugError('Error getting organization ID from JWT:', error);
+    return null;
+  }
+};
+
 export default {
   setItem,
   getItem,
@@ -259,4 +276,5 @@ export default {
   decodeJWT,
   isJWTExpired,
   getCurrentUserFromJWT,
+  getOrganizationId,
 };


### PR DESCRIPTION
Fixed TypeError: StorageUtils.default.getToken is not a function errors by:
- Replacing all `StorageUtils.getToken()` calls with `StorageUtils.getJWT()`
- Adding missing `getOrganizationId()` helper function to StorageUtils

Updated screens:
- MailingListScreen.js
- FormPermissionsScreen.js
- GroupParticipantReportScreen.js
- RoleManagementScreen.js

Added to StorageUtils.js:
- getOrganizationId() function that extracts organizationId from JWT token