### PR TITLE
fix: Replace API.baseURL with CONFIG.API.BASE_URL in mobile screens

### DIFF
--- a/mobile/src/screens/FormPermissionsScreen.js
+++ b/mobile/src/screens/FormPermissionsScreen.js
@@ -26,8 +26,7 @@ import {
   useToast,
 } from '../components';
 import { isAdmin, isDistrictAdmin } from '../utils/PermissionUtils';
-import { CONFIG } from '../config';
-import { API } from '../api/api-core';
+import CONFIG from '../config';
 import StorageUtils from '../utils/StorageUtils';
 
 const FormPermissionsScreen = ({ navigation }) => {
@@ -54,7 +53,7 @@ const FormPermissionsScreen = ({ navigation }) => {
     try {
       setError('');
 
-      const response = await fetch(`${API.baseURL}/form-permissions`, {
+      const response = await fetch(`${CONFIG.API.BASE_URL}/form-permissions`, {
         headers: {
           Authorization: `Bearer ${await StorageUtils.getJWT()}`,
         },
@@ -116,7 +115,7 @@ const FormPermissionsScreen = ({ navigation }) => {
     try {
       setSaving(true);
 
-      const response = await fetch(`${API.baseURL}/form-permissions`, {
+      const response = await fetch(`${CONFIG.API.BASE_URL}/form-permissions`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
@@ -148,7 +147,7 @@ const FormPermissionsScreen = ({ navigation }) => {
     try {
       setSaving(true);
 
-      const response = await fetch(`${API.baseURL}/form-display-context`, {
+      const response = await fetch(`${CONFIG.API.BASE_URL}/form-display-context`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',

--- a/mobile/src/screens/GroupParticipantReportScreen.js
+++ b/mobile/src/screens/GroupParticipantReportScreen.js
@@ -24,7 +24,7 @@ import {
   EmptyState,
 } from '../components';
 import { canViewReports } from '../utils/PermissionUtils';
-import { API } from '../api/api-core';
+import CONFIG from '../config';
 import StorageUtils from '../utils/StorageUtils';
 import { debugError } from '../utils/DebugUtils';
 
@@ -66,13 +66,13 @@ const GroupParticipantReportScreen = ({ navigation }) => {
       const token = await StorageUtils.getJWT();
 
       const [participantsResponse, groupsResponse] = await Promise.all([
-        fetch(`${API.baseURL}/v1/participants`, {
+        fetch(`${CONFIG.API.BASE_URL}/v1/participants`, {
           headers: { Authorization: `Bearer ${token}` },
         }).catch((err) => {
           debugError('Error loading participants:', err);
           return { ok: false };
         }),
-        fetch(`${API.baseURL}/v1/groups`, {
+        fetch(`${CONFIG.API.BASE_URL}/v1/groups`, {
           headers: { Authorization: `Bearer ${token}` },
         }).catch((err) => {
           debugError('Error loading groups:', err);

--- a/mobile/src/screens/InventoryScreen.js
+++ b/mobile/src/screens/InventoryScreen.js
@@ -35,6 +35,7 @@ import {
 } from '../components';
 import { canViewInventory, canManageInventory } from '../utils/PermissionUtils';
 import { getEquipment } from '../api/api-endpoints';
+import CONFIG from '../config';
 import StorageUtils from '../utils/StorageUtils';
 import { debugLog, debugError } from '../utils/DebugUtils';
 
@@ -216,7 +217,7 @@ const InventoryScreen = ({ navigation }) => {
       };
 
       const token = await StorageUtils.getJWT();
-      const response = await fetch(`${API.baseURL}/v1/resources/equipment`, {
+      const response = await fetch(`${CONFIG.API.BASE_URL}/v1/resources/equipment`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -275,7 +276,7 @@ const InventoryScreen = ({ navigation }) => {
 
       const token = await StorageUtils.getJWT();
       const response = await fetch(
-        `${API.baseURL}/v1/resources/equipment/${editingItem.id}`,
+        `${CONFIG.API.BASE_URL}/v1/resources/equipment/${editingItem.id}`,
         {
           method: 'PUT',
           headers: {
@@ -326,7 +327,7 @@ const InventoryScreen = ({ navigation }) => {
             try {
               const token = await StorageUtils.getJWT();
               const response = await fetch(
-                `${API.baseURL}/v1/resources/equipment/${item.id}`,
+                `${CONFIG.API.BASE_URL}/v1/resources/equipment/${item.id}`,
                 {
                   method: 'DELETE',
                   headers: { Authorization: `Bearer ${token}` },

--- a/mobile/src/screens/MailingListScreen.js
+++ b/mobile/src/screens/MailingListScreen.js
@@ -29,7 +29,7 @@ import {
   useToast,
 } from '../components';
 import { canSendCommunications } from '../utils/PermissionUtils';
-import { API } from '../api/api-core';
+import CONFIG from '../config';
 import StorageUtils from '../utils/StorageUtils';
 import { debugError } from '../utils/DebugUtils';
 
@@ -96,13 +96,13 @@ const MailingListScreen = ({ navigation }) => {
       const token = await StorageUtils.getJWT();
 
       const [mailingResponse, groupsResponse, announcementsResponse] = await Promise.all([
-        fetch(`${API.baseURL}/v1/communications/mailing-list`, {
+        fetch(`${CONFIG.API.BASE_URL}/v1/communications/mailing-list`, {
           headers: { Authorization: `Bearer ${token}` },
         }),
-        fetch(`${API.baseURL}/v1/groups`, {
+        fetch(`${CONFIG.API.BASE_URL}/v1/groups`, {
           headers: { Authorization: `Bearer ${token}` },
         }),
-        fetch(`${API.baseURL}/v1/communications/announcements`, {
+        fetch(`${CONFIG.API.BASE_URL}/v1/communications/announcements`, {
           headers: { Authorization: `Bearer ${token}` },
         }),
       ]);
@@ -181,7 +181,7 @@ const MailingListScreen = ({ navigation }) => {
       };
 
       const token = await StorageUtils.getJWT();
-      const response = await fetch(`${API.baseURL}/v1/communications/announcements`, {
+      const response = await fetch(`${CONFIG.API.BASE_URL}/v1/communications/announcements`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/mobile/src/screens/PermissionSlipSignScreen.js
+++ b/mobile/src/screens/PermissionSlipSignScreen.js
@@ -27,7 +27,7 @@ import {
   useToast,
 } from '../components';
 import DateUtils from '../utils/DateUtils';
-import { API } from '../api/api-core';
+import CONFIG from '../config';
 
 const PermissionSlipSignScreen = ({ route, navigation }) => {
   const { slipId } = route.params;
@@ -48,7 +48,7 @@ const PermissionSlipSignScreen = ({ route, navigation }) => {
       setError('');
       // Public endpoint - no auth required
       const response = await fetch(
-        `${API.baseURL}/v1/resources/permission-slips/${slipId}/view`
+        `${CONFIG.API.BASE_URL}/v1/resources/permission-slips/${slipId}/view`
       );
       const data = await response.json();
 
@@ -87,7 +87,7 @@ const PermissionSlipSignScreen = ({ route, navigation }) => {
       setIsSigning(true);
 
       const response = await fetch(
-        `${API.baseURL}/v1/resources/permission-slips/${slipId}/sign`,
+        `${CONFIG.API.BASE_URL}/v1/resources/permission-slips/${slipId}/sign`,
         {
           method: 'PATCH',
           headers: {

--- a/mobile/src/screens/RoleManagementScreen.js
+++ b/mobile/src/screens/RoleManagementScreen.js
@@ -29,7 +29,7 @@ import {
   Modal,
 } from '../components';
 import { hasPermission, isDistrictAdmin } from '../utils/PermissionUtils';
-import { API } from '../api/api-core';
+import CONFIG from '../config';
 import StorageUtils from '../utils/StorageUtils';
 
 const RoleManagementScreen = ({ navigation }) => {
@@ -85,7 +85,7 @@ const RoleManagementScreen = ({ navigation }) => {
   };
 
   const fetchRoles = async () => {
-    const response = await fetch(`${API.baseURL}/roles`, {
+    const response = await fetch(`${CONFIG.API.BASE_URL}/roles`, {
       headers: {
         Authorization: `Bearer ${await StorageUtils.getJWT()}`,
         'X-Organization-Id': await StorageUtils.getOrganizationId(),
@@ -101,7 +101,7 @@ const RoleManagementScreen = ({ navigation }) => {
   };
 
   const fetchUsers = async () => {
-    const response = await fetch(`${API.baseURL}/users`, {
+    const response = await fetch(`${CONFIG.API.BASE_URL}/users`, {
       headers: {
         Authorization: `Bearer ${await StorageUtils.getJWT()}`,
         'X-Organization-Id': await StorageUtils.getOrganizationId(),
@@ -121,7 +121,7 @@ const RoleManagementScreen = ({ navigation }) => {
       return rolePermissions[roleId];
     }
 
-    const response = await fetch(`${API.baseURL}/roles/${roleId}/permissions`, {
+    const response = await fetch(`${CONFIG.API.BASE_URL}/roles/${roleId}/permissions`, {
       headers: {
         Authorization: `Bearer ${await StorageUtils.getJWT()}`,
         'X-Organization-Id': await StorageUtils.getOrganizationId(),
@@ -160,7 +160,7 @@ const RoleManagementScreen = ({ navigation }) => {
     setSelectedUserId(user.id);
 
     try {
-      const response = await fetch(`${API.baseURL}/users/${user.id}/roles`, {
+      const response = await fetch(`${CONFIG.API.BASE_URL}/users/${user.id}/roles`, {
         headers: {
           Authorization: `Bearer ${await StorageUtils.getJWT()}`,
           'X-Organization-Id': await StorageUtils.getOrganizationId(),
@@ -196,7 +196,7 @@ const RoleManagementScreen = ({ navigation }) => {
     try {
       setSaving(true);
 
-      const response = await fetch(`${API.baseURL}/users/${selectedUserId}/roles`, {
+      const response = await fetch(`${CONFIG.API.BASE_URL}/users/${selectedUserId}/roles`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
Fixed "Cannot read property 'baseURL' of undefined" errors by:
- Importing CONFIG from '../config' instead of API from '../api/api-core'
- Replacing all `API.baseURL` references with `CONFIG.API.BASE_URL`
- Fixed incorrect named imports `{ API }` to use correct config import

Updated screens:
- MailingListScreen.js (2 instances)
- FormPermissionsScreen.js (3 instances)
- GroupParticipantReportScreen.js (2 instances)
- RoleManagementScreen.js (5 instances)
- InventoryScreen.js (3 instances)
- PermissionSlipSignScreen.js (2 instances)

The API object from api-core.js provides methods (get, post, etc.) but doesn't expose a baseURL property. For direct fetch calls, use CONFIG.API.BASE_URL.