### PR TITLE
fix: Correct API endpoint paths in MailingListScreen

### DIFF
--- a/mobile/src/screens/MailingListScreen.js
+++ b/mobile/src/screens/MailingListScreen.js
@@ -96,13 +96,13 @@ const MailingListScreen = ({ navigation }) => {
       const token = await StorageUtils.getJWT();
 
       const [mailingResponse, groupsResponse, announcementsResponse] = await Promise.all([
-        fetch(`${CONFIG.API.BASE_URL}/v1/communications/mailing-list`, {
+        fetch(`${CONFIG.API.BASE_URL}/mailing-list`, {
           headers: { Authorization: `Bearer ${token}` },
         }),
         fetch(`${CONFIG.API.BASE_URL}/v1/groups`, {
           headers: { Authorization: `Bearer ${token}` },
         }),
-        fetch(`${CONFIG.API.BASE_URL}/v1/communications/announcements`, {
+        fetch(`${CONFIG.API.BASE_URL}/v1/announcements`, {
           headers: { Authorization: `Bearer ${token}` },
         }),
       ]);
@@ -181,7 +181,7 @@ const MailingListScreen = ({ navigation }) => {
       };
 
       const token = await StorageUtils.getJWT();
-      const response = await fetch(`${CONFIG.API.BASE_URL}/v1/communications/announcements`, {
+      const response = await fetch(`${CONFIG.API.BASE_URL}/v1/announcements`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
Fixed JSON parse error by using correct backend endpoint paths:
- Changed `/v1/communications/mailing-list` → `/mailing-list` (legacy endpoint)
- Changed `/v1/communications/announcements` → `/v1/announcements`

The `/v1/communications/*` paths don't exist in the backend. The correct paths are defined in routes/reports.js and routes/announcements.js.