### PR TITLE
Fix Participant List to assign groups and roles

### DIFF
--- a/mobile/src/api/api-endpoints.js
+++ b/mobile/src/api/api-endpoints.js
@@ -304,6 +304,29 @@ export const deleteParticipant = async (id) => {
 };
 
 /**
+ * Update participant's group membership and roles
+ * @param {number} participantId - Participant ID
+ * @param {number|null} groupId - Group ID (null to remove from group)
+ * @param {boolean} firstLeader - Whether participant is first leader
+ * @param {boolean} secondLeader - Whether participant is second leader
+ * @param {string|null} roles - Additional roles (comma-separated)
+ */
+export const updateParticipantGroup = async (
+  participantId,
+  groupId,
+  firstLeader = false,
+  secondLeader = false,
+  roles = null
+) => {
+  return API.patch(`${CONFIG.ENDPOINTS.PARTICIPANTS}/${participantId}/group-membership`, {
+    group_id: groupId,
+    first_leader: firstLeader,
+    second_leader: secondLeader,
+    roles,
+  });
+};
+
+/**
  * ============================================================================
  * GUARDIANS / PARENTS
  * ============================================================================
@@ -1745,6 +1768,7 @@ export default {
   createParticipant,
   updateParticipant,
   deleteParticipant,
+  updateParticipantGroup,
   // Guardians / Parents
   getAllGuardians,
   getGuardians,

--- a/mobile/src/screens/ParticipantsScreen.js
+++ b/mobile/src/screens/ParticipantsScreen.js
@@ -2,7 +2,7 @@
  * Participants Screen
  *
  * Mirrors spa/manage_participants.js functionality
- * Shows list of all participants with search and filter
+ * Allows inline assignment of groups and roles to participants
  * For admin and leader users
  */
 
@@ -10,28 +10,25 @@ import React, { useState, useEffect, useCallback } from 'react';
 import {
   View,
   Text,
-  FlatList,
+  ScrollView,
   StyleSheet,
   RefreshControl,
+  TextInput,
   TouchableOpacity,
 } from 'react-native';
+import { Picker } from '@react-native-picker/picker';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
-import { getParticipants, getGroups } from '../api/api-endpoints';
+import { getParticipants, getGroups, updateParticipantGroup } from '../api/api-endpoints';
 import { translate as t } from '../i18n';
-import DateUtils from '../utils/DateUtils';
 import {
-  ListItem,
-  FilterBar,
   LoadingState,
   ErrorState,
   EmptyState,
-  NoResults,
   useToast,
-  ConfirmModal,
 } from '../components';
 import { hasPermission } from '../utils/PermissionUtils';
 import StorageUtils from '../utils/StorageUtils';
-import { debugError } from '../utils/DebugUtils';
+import { debugLog, debugError } from '../utils/DebugUtils';
 import theme from '../theme';
 import CONFIG from '../config';
 
@@ -42,12 +39,8 @@ const ParticipantsScreen = () => {
   const [error, setError] = useState(null);
   const [participants, setParticipants] = useState([]);
   const [groups, setGroups] = useState([]);
-  const [searchQuery, setSearchQuery] = useState('');
-  const [activeFilter, setActiveFilter] = useState('all');
-  const [sortBy, setSortBy] = useState('name');
-  const [sortOrder, setSortOrder] = useState('asc');
   const [userPermissions, setUserPermissions] = useState([]);
-  const [deleteTarget, setDeleteTarget] = useState(null);
+  const [updatingParticipant, setUpdatingParticipant] = useState(null);
 
   const { showToast, ToastComponent } = useToast();
 
@@ -58,18 +51,9 @@ const ParticipantsScreen = () => {
   useEffect(() => {
     navigation.setOptions({
       headerShown: true,
-      title: t('manage_names') || 'Participants',
-      headerRight: () =>
-        canManage ? (
-          <TouchableOpacity
-            onPress={() => navigation.navigate('ParticipantDetail', { id: 'new' })}
-            style={{ paddingRight: 16 }}
-          >
-            <Text style={{ fontSize: 28, color: theme.colors.primary }}>+</Text>
-          </TouchableOpacity>
-        ) : null,
+      title: t('manage_participants') || 'Assign Groups and Roles',
     });
-  }, [navigation, canManage]);
+  }, [navigation]);
 
   useEffect(() => {
     loadUserPermissions();
@@ -111,6 +95,7 @@ const ParticipantsScreen = () => {
         setGroups(groupsResponse.data || groupsResponse.groups || []);
       }
     } catch (err) {
+      debugError('Error loading data:', err);
       setError(err);
     } finally {
       setLoading(false);
@@ -123,83 +108,118 @@ const ParticipantsScreen = () => {
     setRefreshing(false);
   };
 
-  // Filter and sort participants
-  const filteredParticipants = participants
-    .filter((p) => {
-      // Filter by group
-      if (activeFilter !== 'all' && p.group_id !== parseInt(activeFilter)) {
-        return false;
+  const handleGroupChange = async (participantId, groupId) => {
+    if (!canManage) return;
+
+    const participant = participants.find((p) => p.id === participantId);
+    if (!participant) return;
+
+    try {
+      setUpdatingParticipant(participantId);
+
+      const groupIdValue = groupId === 'none' ? null : parseInt(groupId, 10);
+
+      const result = await updateParticipantGroup(
+        participantId,
+        groupIdValue,
+        false, // Reset leader status when changing groups
+        false, // Reset second leader status when changing groups
+        null   // Reset additional roles when changing groups
+      );
+
+      if (result.success) {
+        showToast(t('group_updated_successfully') || 'Group updated', 'success');
+        await loadData();
+      } else {
+        throw new Error(result.message || t('error_updating_group') || 'Error updating group');
       }
+    } catch (err) {
+      debugError('Error updating group:', err);
+      showToast(err.message || t('error_updating_group') || 'Error updating group', 'error');
+    } finally {
+      setUpdatingParticipant(null);
+    }
+  };
 
-      // Filter by search query
-      if (searchQuery.trim()) {
-        const query = searchQuery.toLowerCase();
-        return (
-          p.first_name?.toLowerCase().includes(query) ||
-          p.last_name?.toLowerCase().includes(query)
-        );
+  const handleRoleChange = async (participantId, role) => {
+    if (!canManage) return;
+
+    const participant = participants.find((p) => p.id === participantId);
+    if (!participant || !participant.group_id) {
+      showToast(t('assign_group_before_role') || 'Assign a group first', 'error');
+      return;
+    }
+
+    try {
+      setUpdatingParticipant(participantId);
+
+      const isLeader = role === 'leader';
+      const isSecondLeader = role === 'second_leader';
+
+      const result = await updateParticipantGroup(
+        participantId,
+        participant.group_id,
+        isLeader,
+        isSecondLeader,
+        participant.roles || null
+      );
+
+      if (result.success) {
+        showToast(t('role_updated_successfully') || 'Role updated', 'success');
+        await loadData();
+      } else {
+        throw new Error(result.message || t('error_updating_role') || 'Error updating role');
       }
+    } catch (err) {
+      debugError('Error updating role:', err);
+      showToast(err.message || t('error_updating_role') || 'Error updating role', 'error');
+    } finally {
+      setUpdatingParticipant(null);
+    }
+  };
 
-      return true;
-    })
-    .sort((a, b) => {
-      let aVal, bVal;
+  const handleRolesChange = async (participantId, roles) => {
+    if (!canManage) return;
 
-      switch (sortBy) {
-        case 'name':
-          aVal = `${a.last_name} ${a.first_name}`.toLowerCase();
-          bVal = `${b.last_name} ${b.first_name}`.toLowerCase();
-          break;
-        case 'age':
-          aVal = DateUtils.calculateAge(a.birthdate) || 0;
-          bVal = DateUtils.calculateAge(b.birthdate) || 0;
-          break;
-        case 'group':
-          aVal = a.group_name || '';
-          bVal = b.group_name || '';
-          break;
-        default:
-          return 0;
+    const participant = participants.find((p) => p.id === participantId);
+    if (!participant || !participant.group_id) {
+      showToast(t('assign_group_before_role') || 'Assign a group first', 'error');
+      return;
+    }
+
+    try {
+      setUpdatingParticipant(participantId);
+
+      const isLeader = participant.first_leader || false;
+      const isSecondLeader = participant.second_leader || false;
+
+      const result = await updateParticipantGroup(
+        participantId,
+        participant.group_id,
+        isLeader,
+        isSecondLeader,
+        roles.trim() || null
+      );
+
+      if (result.success) {
+        showToast(t('role_updated_successfully') || 'Roles updated', 'success');
+        await loadData();
+      } else {
+        throw new Error(result.message || t('error_updating_role') || 'Error updating roles');
       }
+    } catch (err) {
+      debugError('Error updating roles:', err);
+      showToast(err.message || t('error_updating_role') || 'Error updating roles', 'error');
+    } finally {
+      setUpdatingParticipant(null);
+    }
+  };
 
-      const comparison = aVal > bVal ? 1 : aVal < bVal ? -1 : 0;
-      return sortOrder === 'desc' ? -comparison : comparison;
-    });
-
-  // Prepare filter options
-  const filterOptions = [
-    { key: 'all', label: t('all_groups') || 'All', count: participants.length },
-    ...groups.map((group) => ({
-      key: String(group.id),
-      label: group.name,
-      count: participants.filter((p) => p.group_id === group.id).length,
-    })),
-  ];
-
-  const sortOptions = [
-    { key: 'name', label: t('name') || 'Name' },
-    { key: 'age', label: t('age') || 'Age' },
-    { key: 'group', label: t('group') || 'Group' },
-  ];
-
-  // Render function for FlatList
-  const renderParticipantItem = useCallback(({ item: participant }) => (
-    <ListItem
-      title={`${participant.first_name} ${participant.last_name}`}
-      subtitle={[
-        participant.group_name,
-        `${DateUtils.calculateAge(participant.birthdate)} ${t('years') || 'years'}`,
-      ]
-        .filter(Boolean)
-        .join(' • ')}
-      leftIcon="👤"
-      onPress={() =>
-        navigation.navigate('ParticipantDetail', { id: participant.id })
-      }
-    />
-  ), [navigation]);
-
-  const keyExtractor = useCallback((item) => item.id.toString(), []);
+  const getCurrentRole = (participant) => {
+    if (participant.first_leader) return 'leader';
+    if (participant.second_leader) return 'second_leader';
+    return 'none';
+  };
 
   // Loading state
   if (loading) {
@@ -217,9 +237,7 @@ const ParticipantsScreen = () => {
       <EmptyState
         icon="👥"
         title={t('no_participants') || 'No Participants'}
-        message={t('add_first_participant') || 'Add your first participant to get started.'}
-        actionLabel={canManage ? (t('add_participant') || 'Add Participant') : undefined}
-        onAction={canManage ? () => navigation.navigate('ParticipantDetail', { id: 'new' }) : undefined}
+        message={t('add_first_participant') || 'Add participants to assign them to groups and roles.'}
       />
     );
   }
@@ -228,58 +246,109 @@ const ParticipantsScreen = () => {
     <View style={styles.container}>
       {ToastComponent}
 
-      <FilterBar
-        searchValue={searchQuery}
-        onSearchChange={setSearchQuery}
-        searchPlaceholder={t('search_participants') || 'Search participants...'}
-        filterOptions={filterOptions.map(f => ({
-          label: f.label,
-          value: f.key,
-          active: f.key === activeFilter
-        }))}
-        onFilterToggle={(value) => setActiveFilter(value)}
-        showFilters={groups.length > 0}
-      />
+      <ScrollView
+        style={styles.scrollView}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+      >
+        {/* Header Row */}
+        <View style={styles.headerRow}>
+          <Text style={[styles.headerCell, styles.nameColumn]}>{t('name') || 'Name'}</Text>
+          <Text style={[styles.headerCell, styles.groupColumn]}>{t('group') || 'Group'}</Text>
+          <Text style={[styles.headerCell, styles.roleColumn]}>{t('role') || 'Role'}</Text>
+          <Text style={[styles.headerCell, styles.additionalRolesColumn]}>
+            {t('additional_roles') || 'Additional Roles'}
+          </Text>
+        </View>
 
-      {filteredParticipants.length === 0 ? (
-        <NoResults
-          searchTerm={searchQuery}
-          onClear={() => {
-            setSearchQuery('');
-            setActiveFilter('all');
-          }}
-        />
-      ) : (
-        <FlatList
-          data={filteredParticipants}
-          renderItem={renderParticipantItem}
-          keyExtractor={keyExtractor}
-          refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
-          contentContainerStyle={styles.listContent}
-          initialNumToRender={15}
-          maxToRenderPerBatch={10}
-          windowSize={10}
-        />
+        {/* Participant Rows */}
+        {participants.map((participant) => {
+          const isUpdating = updatingParticipant === participant.id;
+          const hasGroup = participant.group_id != null;
+
+          return (
+            <View key={participant.id} style={styles.row}>
+              {/* Name */}
+              <View style={[styles.cell, styles.nameColumn]}>
+                <Text style={styles.nameText} numberOfLines={2}>
+                  {participant.first_name} {participant.last_name}
+                </Text>
+              </View>
+
+              {/* Group Picker */}
+              <View style={[styles.cell, styles.groupColumn]}>
+                <View style={[styles.pickerContainer, isUpdating && styles.updating]}>
+                  <Picker
+                    selectedValue={participant.group_id?.toString() || 'none'}
+                    onValueChange={(value) => handleGroupChange(participant.id, value)}
+                    enabled={canManage && !isUpdating}
+                    style={styles.picker}
+                  >
+                    <Picker.Item label={t('no_group') || 'No Group'} value="none" />
+                    {groups.map((group) => (
+                      <Picker.Item
+                        key={group.id}
+                        label={group.name}
+                        value={group.id.toString()}
+                      />
+                    ))}
+                  </Picker>
+                </View>
+              </View>
+
+              {/* Role Picker */}
+              <View style={[styles.cell, styles.roleColumn]}>
+                <View style={[styles.pickerContainer, isUpdating && styles.updating]}>
+                  <Picker
+                    selectedValue={getCurrentRole(participant)}
+                    onValueChange={(value) => handleRoleChange(participant.id, value)}
+                    enabled={canManage && !isUpdating && hasGroup}
+                    style={styles.picker}
+                  >
+                    <Picker.Item label={t('none') || 'None'} value="none" />
+                    <Picker.Item label={t('leader') || 'Leader'} value="leader" />
+                    <Picker.Item
+                      label={t('second_leader') || 'Second Leader'}
+                      value="second_leader"
+                    />
+                  </Picker>
+                </View>
+              </View>
+
+              {/* Additional Roles */}
+              <View style={[styles.cell, styles.additionalRolesColumn]}>
+                <TextInput
+                  style={[
+                    styles.input,
+                    !hasGroup && styles.disabled,
+                    isUpdating && styles.updating,
+                  ]}
+                  value={participant.roles || ''}
+                  onChangeText={(text) => {
+                    // Update local state immediately
+                    setParticipants((prev) =>
+                      prev.map((p) =>
+                        p.id === participant.id ? { ...p, roles: text } : p
+                      )
+                    );
+                  }}
+                  onBlur={() => handleRolesChange(participant.id, participant.roles || '')}
+                  placeholder={t('additional_roles') || 'Additional roles'}
+                  editable={canManage && !isUpdating && hasGroup}
+                  multiline={false}
+                />
+              </View>
+            </View>
+          );
+        })}
+      </ScrollView>
+
+      {!canManage && (
+        <View style={styles.footer}>
+          <Text style={styles.footerText}>
+            {t('view_only_mode') || 'You have view-only access'}
+          </Text>
+        </View>
       )}
-
-      <ConfirmModal
-        visible={!!deleteTarget}
-        onClose={() => setDeleteTarget(null)}
-        onConfirm={async () => {
-          // Delete logic would go here
-          showToast(t('participant_deleted') || 'Participant deleted', 'success');
-          setDeleteTarget(null);
-          await loadData();
-        }}
-        title={t('confirm_delete') || 'Delete Participant?'}
-        message={
-          deleteTarget
-            ? t('confirm_delete_participant_message') ||
-              `Are you sure you want to delete ${deleteTarget.first_name} ${deleteTarget.last_name}?`
-            : ''
-        }
-        confirmStyle="danger"
-      />
     </View>
   );
 };
@@ -289,8 +358,96 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: theme.colors.background,
   },
-  listContent: {
-    paddingBottom: theme.spacing.xl,
+  scrollView: {
+    flex: 1,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    backgroundColor: theme.colors.surfaceVariant,
+    paddingVertical: theme.spacing.sm,
+    paddingHorizontal: theme.spacing.xs,
+    borderBottomWidth: 2,
+    borderBottomColor: theme.colors.border,
+  },
+  headerCell: {
+    fontWeight: '600',
+    fontSize: 12,
+    color: theme.colors.textSecondary,
+    textTransform: 'uppercase',
+  },
+  row: {
+    flexDirection: 'row',
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.border,
+    paddingVertical: theme.spacing.xs,
+    paddingHorizontal: theme.spacing.xs,
+    minHeight: 60,
+    alignItems: 'center',
+  },
+  cell: {
+    paddingHorizontal: theme.spacing.xs,
+    justifyContent: 'center',
+  },
+  nameColumn: {
+    flex: 2,
+    minWidth: 100,
+  },
+  groupColumn: {
+    flex: 2,
+    minWidth: 120,
+  },
+  roleColumn: {
+    flex: 2,
+    minWidth: 120,
+  },
+  additionalRolesColumn: {
+    flex: 2,
+    minWidth: 120,
+  },
+  nameText: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: theme.colors.text,
+  },
+  pickerContainer: {
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    borderRadius: theme.borderRadius.sm,
+    backgroundColor: theme.colors.surface,
+    height: 44,
+    justifyContent: 'center',
+  },
+  picker: {
+    height: 44,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    borderRadius: theme.borderRadius.sm,
+    backgroundColor: theme.colors.surface,
+    paddingHorizontal: theme.spacing.sm,
+    paddingVertical: theme.spacing.xs,
+    fontSize: 14,
+    color: theme.colors.text,
+    height: 44,
+  },
+  disabled: {
+    backgroundColor: theme.colors.surfaceVariant,
+    color: theme.colors.textSecondary,
+  },
+  updating: {
+    opacity: 0.5,
+  },
+  footer: {
+    padding: theme.spacing.md,
+    backgroundColor: theme.colors.surfaceVariant,
+    borderTopWidth: 1,
+    borderTopColor: theme.colors.border,
+  },
+  footerText: {
+    fontSize: 12,
+    color: theme.colors.textSecondary,
+    textAlign: 'center',
   },
 });
 


### PR DESCRIPTION
Updated mobile ParticipantsScreen to match SPA functionality for assigning groups and roles to participants inline, rather than just displaying a list.

Changes:
- Added updateParticipantGroup API function to mobile/src/api/api-endpoints.js
- Completely rewrote ParticipantsScreen to display table-like layout
- Added inline group selection with Picker
- Added inline role selection (leader, second leader, none) with Picker
- Added additional roles text input field
- Disabled role/additional roles fields until group is assigned
- Shows loading states during updates
- Proper permission checks (participants.manage)
- Updated screen title to use 'manage_participants' translation key

This aligns the mobile app with spa/manage_participants.js functionality.

Fixes mobile issue where "Participant List" was just a read-only list instead of allowing group and role assignment.