### PR TITLE
fix: Use correct permission for participant group/role assignment

### DIFF
--- a/mobile/src/screens/ParticipantsScreen.js
+++ b/mobile/src/screens/ParticipantsScreen.js
@@ -46,8 +46,9 @@ const ParticipantsScreen = () => {
 
   const { showToast, ToastComponent } = useToast();
 
-  // Check for manage permission (for editing)
-  const canManage = hasPermission('participants.manage', userPermissions);
+  // Check for edit permission (for editing group/role assignments)
+  // Uses participants.edit as per backend requirement at routes/participants.js:327
+  const canManage = hasPermission('participants.edit', userPermissions);
 
   // Configure navigation header
   useEffect(() => {


### PR DESCRIPTION
Changed from non-existent 'participants.manage' to 'participants.edit' to align with the official permissions list and backend API requirements.

The backend endpoint (routes/participants.js:327) for updating participant group membership requires 'participants.edit' permission, not 'participants.manage'.

According to attached_assets/permissions_list.sql, the available participant permissions are:
- participants.view (ID 11) - View participant lists and details
- participants.create (ID 12) - Add new participants
- participants.edit (ID 13) - Edit participant information
- participants.delete (ID 14) - Remove participants
- participants.transfer (ID 15) - Transfer participants between groups

The permission 'participants.manage' does not exist in the system.

This fix ensures users with 'participants.edit' permission can now properly assign groups and roles to participants in the mobile app.