### PR TITLE
feat: Add permission-based honors management with feature parity

### DIFF
--- a/mobile/src/config/index.js
+++ b/mobile/src/config/index.js
@@ -98,6 +98,11 @@ const CONFIG = {
     PUSH_SUBSCRIPTION: '/v1/push-subscription',
     FORMS: '/api',
 
+    // Honors endpoints (v1 - permission-based)
+    HONORS: '/v1/honors',
+    AWARD_HONOR: '/v1/honors',
+    HONORS_HISTORY: '/v1/honors/history',
+
     // Legacy endpoints
     INITIAL_DATA: '/initial-data',
     NEWS: '/news',
@@ -108,10 +113,7 @@ const CONFIG = {
     POINTS_REPORT: '/points-report',
     POINTS_LEADERBOARD: '/points-leaderboard',
     BADGE_SUMMARY: '/badge-summary',
-    HONORS: '/honors',
-    AWARD_HONOR: '/award-honor',
     HONORS_REPORT: '/honors-report',
-    HONORS_HISTORY: '/honors-history',
     FUNDRAISERS: '/fundraisers',
     CALENDARS: '/calendars',
     REUNION_PREPARATION: '/reunion-preparation',

--- a/mobile/src/utils/PermissionUtils.js
+++ b/mobile/src/utils/PermissionUtils.js
@@ -387,6 +387,33 @@ export async function canManageCarpools() {
   return hasPermission('carpools.manage', permissions);
 }
 
+/**
+ * Check if user can view honors
+ * @returns {Promise<boolean>} True if user can view honors
+ */
+export async function canViewHonors() {
+  const permissions = await getUserPermissions();
+  return hasAnyPermission(['honors.view', 'honors.create', 'honors.manage'], permissions);
+}
+
+/**
+ * Check if user can award honors (create honors)
+ * @returns {Promise<boolean>} True if user can award honors
+ */
+export async function canAwardHonors() {
+  const permissions = await getUserPermissions();
+  return hasAnyPermission(['honors.create', 'honors.manage'], permissions);
+}
+
+/**
+ * Check if user can manage honors
+ * @returns {Promise<boolean>} True if user can manage honors
+ */
+export async function canManageHonors() {
+  const permissions = await getUserPermissions();
+  return hasPermission('honors.manage', permissions);
+}
+
 export default {
   hasPermission,
   hasAnyPermission,
@@ -415,4 +442,7 @@ export default {
   canManageActivities,
   canViewCarpools,
   canManageCarpools,
+  canViewHonors,
+  canAwardHonors,
+  canManageHonors,
 };

--- a/routes/honors.js
+++ b/routes/honors.js
@@ -2,7 +2,8 @@
  * Honors Routes
  *
  * Handles honor awards, history, and reporting
- * All endpoints in this module are prefixed with /api
+ * Modern endpoints use /api/v1/ prefix with permission-based auth
+ * Legacy endpoints remain for backward compatibility
  *
  * @module routes/honors
  */
@@ -12,7 +13,8 @@ const router = express.Router();
 
 // Import utilities and middleware
 const { getCurrentOrganizationId, verifyJWT, handleOrganizationResolutionError, verifyOrganizationMembership, getPointSystemRules } = require('../utils/api-helpers');
-const { success, error: errorResponse } = require('../middleware/response');
+const { authenticate, requirePermission, blockDemoRoles, getOrganizationId } = require('../middleware/auth');
+const { success, error: errorResponse, asyncHandler } = require('../middleware/response');
 
 /**
  * Export route factory function
@@ -23,11 +25,15 @@ const { success, error: errorResponse } = require('../middleware/response');
  * @returns {Router} Express router with honors routes
  */
 module.exports = (pool, logger) => {
+  // ==========================================
+  // MODERN V1 ENDPOINTS (Permission-based)
+  // ==========================================
+
   /**
    * @swagger
-   * /api/honors:
+   * /api/v1/honors:
    *   get:
-   *     summary: Get honors and participants
+   *     summary: Get honors and participants (v1)
    *     description: Retrieve all honors and participants for management interface
    *     tags: [Honors]
    *     security:
@@ -41,6 +47,281 @@ module.exports = (pool, logger) => {
    *     responses:
    *       200:
    *         description: Honors and participants retrieved
+   */
+  router.get('/v1/honors',
+    authenticate,
+    requirePermission('honors.view'),
+    asyncHandler(async (req, res) => {
+      const organizationId = await getOrganizationId(req, pool);
+      const requestedDate = req.query.date;
+
+      // Get participants
+      const participantsResult = await pool.query(
+        `SELECT p.id as participant_id, p.first_name, p.last_name,
+                pg.group_id, g.name as group_name, pg.first_leader, pg.second_leader
+         FROM participants p
+         JOIN participant_organizations po ON p.id = po.participant_id
+         LEFT JOIN participant_groups pg ON p.id = pg.participant_id AND pg.organization_id = $1
+         LEFT JOIN groups g ON pg.group_id = g.id
+         WHERE po.organization_id = $1
+         ORDER BY g.name, p.first_name`,
+        [organizationId]
+      );
+
+      // Get honors
+      const honorsResult = await pool.query(
+        `SELECT h.id, h.participant_id, h.date::text as date, h.reason
+         FROM honors h
+         JOIN participants p ON h.participant_id = p.id
+         JOIN participant_organizations po ON p.id = po.participant_id
+         WHERE po.organization_id = $1
+         ORDER BY h.date DESC`,
+        [organizationId]
+      );
+
+      // Get available dates (dates with honors)
+      const datesResult = await pool.query(
+        `SELECT DISTINCT date::text as date FROM honors h
+         JOIN participants p ON h.participant_id = p.id
+         JOIN participant_organizations po ON p.id = po.participant_id
+         WHERE po.organization_id = $1
+         ORDER BY date DESC`,
+        [organizationId]
+      );
+
+      return success(res, {
+        participants: participantsResult.rows,
+        honors: honorsResult.rows,
+        availableDates: datesResult.rows.map(r => r.date)
+      }, 'Honors retrieved successfully');
+    })
+  );
+
+  /**
+   * @swagger
+   * /api/v1/honors:
+   *   post:
+   *     summary: Award honor to participant(s) (v1)
+   *     description: Award honor and add points. Accepts single object or array of honors.
+   *     tags: [Honors]
+   *     security:
+   *       - bearerAuth: []
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             oneOf:
+   *               - type: object
+   *                 required:
+   *                   - participant_id
+   *                   - date
+   *                 properties:
+   *                   participant_id:
+   *                     type: integer
+   *                   participantId:
+   *                     type: integer
+   *                   date:
+   *                     type: string
+   *                     format: date
+   *               - type: array
+   *                 items:
+   *                   type: object
+   *     responses:
+   *       200:
+   *         description: Honor(s) awarded successfully
+   */
+  router.post('/v1/honors',
+    authenticate,
+    blockDemoRoles,
+    requirePermission('honors.create'),
+    asyncHandler(async (req, res) => {
+      const organizationId = await getOrganizationId(req, pool);
+
+      // Handle both array and single object formats
+      const honorsToProcess = Array.isArray(req.body) ? req.body : [req.body];
+
+      const results = [];
+      const client = await pool.connect();
+
+      try {
+        await client.query('BEGIN');
+
+        // Get point system rules for this organization
+        const pointRules = await getPointSystemRules(client, organizationId);
+        const honorPoints = pointRules.honors?.award || 5;
+
+        for (const honor of honorsToProcess) {
+          // Accept both participantId (camelCase) and participant_id (snake_case)
+          const participantId = honor.participantId || honor.participant_id;
+          const honorDate = honor.date;
+          const reason = honor.reason || '';
+
+          if (!participantId || !honorDate) {
+            results.push({ participantId, success: false, message: 'Participant ID and date are required' });
+            continue;
+          }
+
+          // Check if honor already exists for this participant on this date
+          const existingResult = await client.query(
+            `SELECT id FROM honors WHERE participant_id = $1 AND date = $2 AND organization_id = $3`,
+            [participantId, honorDate, organizationId]
+          );
+
+          if (existingResult.rows.length > 0) {
+            // Honor already exists - skip
+            results.push({ participantId, success: true, action: 'already_awarded' });
+          } else {
+            // Add new honor with organization_id and reason
+            await client.query(
+              `INSERT INTO honors (participant_id, date, organization_id, reason) VALUES ($1, $2, $3, $4)`,
+              [participantId, honorDate, organizationId, reason]
+            );
+
+            // Get participant's group for proper point tracking
+            const groupResult = await client.query(
+              `SELECT group_id FROM participant_groups
+               WHERE participant_id = $1 AND organization_id = $2`,
+              [participantId, organizationId]
+            );
+            const groupId = groupResult.rows.length > 0 ? groupResult.rows[0].group_id : null;
+
+            // Add points for the honor based on organization rules
+            await client.query(
+              `INSERT INTO points (participant_id, group_id, value, created_at, organization_id)
+               VALUES ($1, $2, $3, $4, $5)`,
+              [participantId, groupId, honorPoints, honorDate, organizationId]
+            );
+
+            logger.info(`[honor] Participant ${participantId} awarded honor on ${honorDate}, points: +${honorPoints}`);
+            results.push({ participantId, success: true, action: 'awarded', points: honorPoints });
+          }
+        }
+
+        await client.query('COMMIT');
+        return success(res, { results }, 'Honor(s) awarded successfully', 200);
+      } catch (error) {
+        await client.query('ROLLBACK');
+        throw error;
+      } finally {
+        client.release();
+      }
+    })
+  );
+
+  /**
+   * @swagger
+   * /api/v1/honors/history:
+   *   get:
+   *     summary: Get honors history (v1)
+   *     description: Retrieve honor awards history with optional filtering
+   *     tags: [Honors]
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: query
+   *         name: start_date
+   *         schema:
+   *           type: string
+   *           format: date
+   *       - in: query
+   *         name: end_date
+   *         schema:
+   *           type: string
+   *           format: date
+   *       - in: query
+   *         name: participant_id
+   *         schema:
+   *           type: integer
+   *     responses:
+   *       200:
+   *         description: Honors history retrieved
+   */
+  router.get('/v1/honors/history',
+    authenticate,
+    requirePermission('honors.view'),
+    asyncHandler(async (req, res) => {
+      const organizationId = await getOrganizationId(req, pool);
+      const { start_date, end_date, participant_id } = req.query;
+
+      let query = `
+        SELECT h.id, h.date::text as date, h.reason,
+               p.id as participant_id, p.first_name, p.last_name,
+               g.name as group_name
+        FROM honors h
+        JOIN participants p ON h.participant_id = p.id
+        LEFT JOIN participant_groups pg ON p.id = pg.participant_id AND pg.organization_id = $1
+        LEFT JOIN groups g ON pg.group_id = g.id
+        WHERE h.organization_id = $1
+      `;
+
+      const params = [organizationId];
+      let paramIndex = 2;
+
+      if (start_date) {
+        query += ` AND h.date >= $${paramIndex}`;
+        params.push(start_date);
+        paramIndex++;
+      }
+
+      if (end_date) {
+        query += ` AND h.date <= $${paramIndex}`;
+        params.push(end_date);
+        paramIndex++;
+      }
+
+      if (participant_id) {
+        query += ` AND h.participant_id = $${paramIndex}`;
+        params.push(participant_id);
+        paramIndex++;
+      }
+
+      query += ` ORDER BY h.date DESC, p.last_name, p.first_name`;
+
+      const result = await pool.query(query, params);
+
+      // Also get summary by participant
+      const summaryQuery = `
+        SELECT p.id, p.first_name, p.last_name, COUNT(h.id) as honor_count
+        FROM honors h
+        JOIN participants p ON h.participant_id = p.id
+        WHERE h.organization_id = $1
+        GROUP BY p.id, p.first_name, p.last_name
+        ORDER BY honor_count DESC
+      `;
+
+      const summaryResult = await pool.query(summaryQuery, [organizationId]);
+
+      return success(res, {
+        honors: result.rows,
+        summary: summaryResult.rows
+      }, 'Honors history retrieved successfully');
+    })
+  );
+
+  // ==========================================
+  // LEGACY ENDPOINTS (for backward compatibility)
+  // ==========================================
+
+  /**
+   * @swagger
+   * /api/honors:
+   *   get:
+   *     summary: Get honors and participants (LEGACY)
+   *     description: Retrieve all honors and participants for management interface
+   *     tags: [Honors]
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: query
+   *         name: date
+   *         schema:
+   *           type: string
+   *           format: date
+   *     responses:
+   *       200:
+   *         description: Honors and participants retrieved
+   *     deprecated: true
    */
   router.get('/honors', async (req, res) => {
     try {

--- a/spa/api/api-endpoints.js
+++ b/spa/api/api-endpoints.js
@@ -1402,11 +1402,11 @@ export async function getBadgeSystemSettings() {
 // ============================================================================
 
 /**
- * Get honors for a date
+ * Get honors for a date (v1 - permission-based)
  */
 export async function getHonors(date = null) {
     const params = date ? { date } : {};
-    return API.get('honors', params);
+    return API.get('v1/honors', params);
 }
 
 /**
@@ -1417,7 +1417,7 @@ export async function getHonorsAndParticipants(date = null) {
 }
 
 /**
- * Get recent honors
+ * Get recent honors (legacy endpoint)
  */
 export async function getRecentHonors() {
     return API.get('recent-honors', {}, {
@@ -1427,14 +1427,14 @@ export async function getRecentHonors() {
 }
 
 /**
- * Award honor to participant
+ * Award honor to participant (v1 - permission-based)
  */
 export async function awardHonor(honorData) {
-    return API.post('award-honor', honorData);
+    return API.post('v1/honors', honorData);
 }
 
 /**
- * Get honors report
+ * Get honors report (legacy endpoint)
  */
 export async function getHonorsReport() {
     return API.get('honors-report', {}, {
@@ -1444,14 +1444,14 @@ export async function getHonorsReport() {
 }
 
 /**
- * Get honors history
+ * Get honors history (v1 - permission-based)
  */
 export async function getHonorsHistory(options = {}) {
     const params = {};
     if (options.startDate) params.start_date = options.startDate;
     if (options.endDate) params.end_date = options.endDate;
     if (options.participantId) params.participant_id = options.participantId;
-    return API.get('honors-history', params);
+    return API.get('v1/honors/history', params);
 }
 
 /**


### PR DESCRIPTION
This commit ensures honors functionality has full feature parity between mobile and web, with proper permission enforcement across the stack.

**Backend Changes:**
- Add modern /api/v1/honors endpoints with permission middleware
- Use authenticate, requirePermission('honors.view'), requirePermission('honors.create')
- Use blockDemoRoles on write operations
- Use asyncHandler and standardized response helpers
- Maintain legacy /api/honors endpoints for backward compatibility
- All queries properly filtered by organization_id

**Mobile Changes:**
- Add honors permission helpers to PermissionUtils.js:
  - canViewHonors() - requires honors.view, honors.create, or honors.manage
  - canAwardHonors() - requires honors.create or honors.manage
  - canManageHonors() - requires honors.manage
- Update HonorsScreen with permission checks:
  - Load and check user permissions on mount
  - Show permission error if user lacks honors.view
  - Disable awarding if user lacks honors.create
  - Disable participant selection if user lacks honors.create
- Add sorting functionality (by name or honors count) matching SPA
- Update config to use v1 endpoints (/v1/honors, /v1/honors/history)

**Web (SPA) Changes:**
- Update api-endpoints.js to use v1 endpoints:
  - getHonors() now calls /v1/honors
  - awardHonor() now calls /v1/honors (POST)
  - getHonorsHistory() now calls /v1/honors/history

**Feature Parity Achieved:**
✅ Date selection via Picker/dropdown (not bubbles) ✅ Participant list with honor counts
✅ Ability to select and award honors with reasons
✅ Sorting by name or honor count
✅ Custom date input
✅ Permission-based access control
✅ Organization isolation
✅ Demo role blocking on write operations

**Permissions Used:**
- honors.view - View honors and awards history
- honors.create - Award honors to participants
- honors.manage - Manage honor types and settings