### PR TITLE
fix: Ensure today's date always appears in honors date picker

### DIFF
--- a/mobile/src/screens/HonorsScreen.js
+++ b/mobile/src/screens/HonorsScreen.js
@@ -138,13 +138,21 @@ const HonorsScreen = () => {
         setParticipants(data.participants || []);
         setHonors(data.honors || []);
 
+        // Get available dates from API (in ISO format YYYY-MM-DD)
         const dates = data.availableDates || [];
-        const today = DateUtils.formatDate(new Date());
+        const today = DateUtils.getTodayISO(); // Use ISO format to match backend dates
+
+        // Ensure today is always in the list
         const uniqueDates = Array.from(new Set([today, ...dates]));
+
+        // Sort dates in descending order (newest first)
+        uniqueDates.sort((a, b) => new Date(b) - new Date(a));
+
         setAvailableDates(uniqueDates);
 
+        // Default to today if no date selected
         if (!targetDate) {
-          setSelectedDate(uniqueDates[0]);
+          setSelectedDate(today);
         }
       } else {
         throw new Error(response.message || t('error_loading_honors'));


### PR DESCRIPTION
**Issue:** Date picker dropdown not showing today as an option, only showing past dates with honors (e.g., yesterday). Users couldn't award new honors for today.

**Root Cause:**
Date format mismatch between frontend and backend:
- Backend returns dates in ISO format: "2026-01-03" (YYYY-MM-DD)
- Frontend was adding today using formatDate(): "01/03/2026" (locale format)
- These formats didn't match, so today wasn't recognized as being in the list

**Fix:**
1. Use DateUtils.getTodayISO() instead of formatDate(new Date())
2. This ensures consistent ISO format (YYYY-MM-DD) matching backend
3. Add explicit sorting by date (newest first)
4. Default to today when no date is selected
5. Display uses formatDate() for user-friendly labels while keeping ISO values

**Result:**
✅ Today always appears as the first option in the dropdown ✅ Users can select today to award new honors
✅ Past dates with honors also appear (sorted newest first) ✅ Date picker shows localized display (e.g., "Jan 3, 2026") but uses ISO values