### PR TITLE
fix: Resolve timezone bug causing all participants to be grayed out

### DIFF
--- a/mobile/src/screens/HonorsScreen.js
+++ b/mobile/src/screens/HonorsScreen.js
@@ -102,12 +102,14 @@ const HonorsScreen = () => {
   const canAward = hasPermission('honors.create', userPermissions) ||
                    hasPermission('honors.manage', userPermissions);
 
+  /**
+   * Check if selected date is in the past
+   * Compares ISO date strings to avoid timezone issues
+   */
   const isPastDate = () => {
     if (!selectedDate) return false;
-    const target = new Date(selectedDate);
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    return target < today;
+    const today = DateUtils.getTodayISO();
+    return selectedDate < today; // ISO format strings are lexicographically sortable
   };
 
   /**


### PR DESCRIPTION
**Critical Bug:** All participants appeared grayed out even when viewing today's date, preventing users from awarding honors.

**Root Cause:**
The isPastDate() function had a timezone handling bug:

```javascript
// BEFORE (broken):
const target = new Date(selectedDate); // "2026-01-03" → UTC midnight
const today = new Date();               // Local time
return target < today;
```

When selectedDate = "2026-01-03":
- new Date("2026-01-03") = Jan 3, 2026 00:00:00 UTC
- In EST (UTC-5): This equals Jan 2, 2026 19:00:00 EST
- But today = Jan 3, 2026 00:00:00 EST
- So target < today = TRUE (incorrectly treats today as past!)

**The Fix:**
Compare ISO date strings directly instead of Date objects:

```javascript
// AFTER (fixed):
const today = DateUtils.getTodayISO(); // "2026-01-03"
return selectedDate < today;
```

ISO format (YYYY-MM-DD) is lexicographically sortable, so string comparison works correctly and avoids all timezone issues.

**Result:**
✅ Today's date shows all participants as active (not grayed out) ✅ Can select and award honors for today
✅ Past dates correctly show as disabled
✅ Works in all timezones