### PR TITLE
fix: Initialize date picker to today immediately on mount

### DIFF
--- a/mobile/src/screens/HonorsScreen.js
+++ b/mobile/src/screens/HonorsScreen.js
@@ -73,7 +73,7 @@ const HonorsScreen = () => {
   const [participants, setParticipants] = useState([]);
   const [honors, setHonors] = useState([]);
   const [availableDates, setAvailableDates] = useState([]);
-  const [selectedDate, setSelectedDate] = useState('');
+  const [selectedDate, setSelectedDate] = useState(DateUtils.getTodayISO()); // Initialize to today
   const [selectedHonors, setSelectedHonors] = useState({});
   const [saving, setSaving] = useState(false);
   const [userPermissions, setUserPermissions] = useState([]);
@@ -151,11 +151,6 @@ const HonorsScreen = () => {
         uniqueDates.sort((a, b) => new Date(b) - new Date(a));
 
         setAvailableDates(uniqueDates);
-
-        // Default to today if no date selected
-        if (!targetDate) {
-          setSelectedDate(today);
-        }
       } else {
         throw new Error(response.message || t('error_loading_honors'));
       }


### PR DESCRIPTION
**Issue:** Date picker was showing yesterday's date instead of today when the honors screen first loads.

**Root Cause:**
selectedDate was initialized to empty string '', causing a race condition:
1. Component renders with selectedDate = ''
2. Picker has no matching value, defaults to first item (could be yesterday)
3. loadHonorsData() async sets selectedDate to today
4. Brief flash shows wrong date, or state update doesn't propagate correctly

**The Fix:**
Initialize selectedDate to today's ISO date immediately:
```javascript
const [selectedDate, setSelectedDate] = useState(DateUtils.getTodayISO());
```

This ensures:
✅ Picker always has a valid value from first render ✅ No race conditions or async delays
✅ Today's date shows immediately
✅ Removed conditional logic to set date later (no longer needed)

**Result:**
- Picker shows today's date from the moment the screen loads
- All participants visible and selectable (not grayed out)
- Consistent behavior across all timezones