### PR TITLE
Material Management: thumbnails + zoomable photo modal; checkbox labels accept React nodes

### DIFF
--- a/mobile/src/components/FormField.js
+++ b/mobile/src/components/FormField.js
@@ -70,8 +70,12 @@ const FormField = ({
  * Checkbox Component
  *
  * Reusable checkbox input with label.
+ *
+ * @param {string|React.ReactNode} label - Checkbox label
  */
 export const Checkbox = ({ label, checked, onPress, style }) => {
+  const isTextLabel = typeof label === 'string' || typeof label === 'number';
+
   return (
     <TouchableOpacity
       style={[styles.checkboxContainer, style]}
@@ -81,7 +85,11 @@ export const Checkbox = ({ label, checked, onPress, style }) => {
       <View style={[commonStyles.checkbox, checked && commonStyles.checkboxChecked]}>
         {checked && <Text style={styles.checkmark}>✓</Text>}
       </View>
-      {label && <Text style={styles.checkboxLabel}>{label}</Text>}
+      {label
+        ? isTextLabel
+          ? <Text style={styles.checkboxLabel}>{label}</Text>
+          : <View style={styles.checkboxLabelContainer}>{label}</View>
+        : null}
     </TouchableOpacity>
   );
 };
@@ -203,6 +211,10 @@ const styles = StyleSheet.create({
     marginLeft: theme.spacing.sm,
     fontSize: theme.fontSize.base,
     color: theme.colors.text,
+    flex: 1,
+  },
+  checkboxLabelContainer: {
+    marginLeft: theme.spacing.sm,
     flex: 1,
   },
   radioContainer: {


### PR DESCRIPTION
### Motivation
- Make Material Management display small equipment photos that users can tap to view larger/zoomable images using an in-app modal.
- Improve inventory selection UX by surfacing thumbnails next to each equipment row and keeping the existing selection/quantity flow.
- Allow richer checkbox labels so we can render complex content (name, category, stats) inline with the checkbox.
- Reuse existing app `Modal`/`Image` UI patterns and respect mobile-safe touch targets and accessibility.

### Description
- Updated `mobile/src/components/FormField.js` so the `Checkbox` accepts a `string|React.ReactNode` label and will render custom React nodes when provided, adding `checkboxLabelContainer` styles.
- Enhanced `mobile/src/screens/MaterialManagementScreen.js` to render an equipment thumbnail beside each checkbox, add an image tap handler, and show a zoomable photo modal using the shared `Modal` component and `useWindowDimensions` for sizing.
- Added styles and accessibility attributes for the thumbnail and modal (`equipmentImage`, `equipmentImageWrapper`, `photoModal*`, etc.) while preserving existing reservation and selection logic.
- Changes touched the UI only; backend APIs and existing selection/reservation behavior were left intact.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69594c9e3cdc8324851a8271e331fb23)