### PR TITLE
Fix mobile progress report loading when navigating from ParentDashboard

### DIFF
--- a/mobile/src/screens/ReportViewerScreen.js
+++ b/mobile/src/screens/ReportViewerScreen.js
@@ -114,10 +114,20 @@ const ReportViewerScreen = ({ route, navigation }) => {
           data = await getFinanceReport();
           break;
         case 'participant-progress':
+          // Load participant list first
           data = await getParticipantProgressReport();
           if (data?.data?.participants) {
             setParticipantList(data.data.participants);
-            if (!selectedParticipantId && data.data.participants.length > 0) {
+
+            // If we already have a selectedParticipantId (from navigation params),
+            // load that participant's progress immediately
+            if (selectedParticipantId) {
+              const progressData = await getParticipantProgressReport(selectedParticipantId);
+              setReportData(progressData);
+              setLoading(false);
+              return;
+            } else if (data.data.participants.length > 0) {
+              // Otherwise, auto-select the first participant
               setSelectedParticipantId(data.data.participants[0].id);
             }
           }


### PR DESCRIPTION
The issue was that when navigating with a participantId parameter, the selectedParticipantId was set in initial state, but the useEffect that loads progress data only triggers on changes, not initial values.

Fixed by checking if selectedParticipantId exists when loading the participant-progress report, and immediately loading that participant's data if it does.

This prevents the empty/crash state when parents click the progress report button from their dashboard.