### PR TITLE
Fix mobile progress report cache key issue

### DIFF
--- a/mobile/src/api/api-endpoints.js
+++ b/mobile/src/api/api-endpoints.js
@@ -1392,7 +1392,10 @@ export const getMissingDocumentsReport = async () => {
  */
 export const getParticipantProgressReport = async (participantId = null) => {
   const params = participantId ? { participant_id: participantId } : {};
-  return API.get('/participant-progress', params);
+  const cacheKey = participantId
+    ? `/participant-progress?participant_id=${participantId}`
+    : '/participant-progress';
+  return API.get('/participant-progress', params, { cacheKey });
 };
 
 /**


### PR DESCRIPTION
CRITICAL FIX: The progress report was showing empty data because the cache key didn't include the participant_id parameter. All requests to /participant-progress were using the same cache entry, causing:
- Request for participant list only: cached as '/participant-progress'
- Request for specific participant: returned cached list (no progress data)

Changes:
1. api-core.js: Add support for custom cacheKey option in makeRequest
2. api-endpoints.js: Use unique cache keys for participant progress:
   - '/participant-progress' for list only
   - '/participant-progress?participant_id=X' for specific participant

This ensures each participant's progress data is cached separately, fixing the empty state and crashes when switching participants.

Fixes the issue reported where:
- Initial load worked for Jules
- Changing to Mathieu showed no data and caused silent crash