### PR TITLE
Add comprehensive error handling to progress report timeline

### DIFF
--- a/mobile/assets/lang/fr.json
+++ b/mobile/assets/lang/fr.json
@@ -478,6 +478,7 @@
   "error_loading_participant_documents": "Erreur lors du chargement des documents du participant",
   "error_loading_preparation_reunions": "Erreur lors du chargement de la préparation des réunions",
   "error_loading_report": "erreur de chargement du rapport",
+  "error_loading_timeline": "Erreur lors du chargement de la chronologie",
   "error_loading_upcoming_meeting": "Erreur lors du chargement de la réunion à venir",
   "error_logging_in": "Erreur de connexion",
   "error_no_fundraiser_id": "Aucun identifiant de campagne fourni",


### PR DESCRIPTION
Added safety measures to prevent silent crashes:
1. Wrap timeline rendering in try-catch block
2. Filter out events with no date before processing
3. Safe date parsing with error handling
4. Catch errors in date sorting
5. Better key generation for timeline items
6. Add fallback error message if timeline fails to render

This should prevent crashes from:
- Invalid/null dates
- Date parsing errors
- Malformed timeline data
- Unexpected data structures

Added translation: 'error_loading_timeline'