### PR TITLE
Fix crash when caching fails for specific participant data

### DIFF
--- a/mobile/src/api/api-core.js
+++ b/mobile/src/api/api-core.js
@@ -218,7 +218,13 @@ const makeRequest = async (method, endpoint, data = null, options = {}) => {
 
     // Cache successful GET responses
     if (method === 'GET' && useCache && normalizedResponse.success !== false) {
-      await CacheManager.cacheData(finalCacheKey, normalizedResponse, cacheDuration);
+      try {
+        await CacheManager.cacheData(finalCacheKey, normalizedResponse, cacheDuration);
+      } catch (cacheErr) {
+        // Don't let caching errors break the request
+        debugError('[API] Error caching response:', finalCacheKey, cacheErr.message);
+        // Continue anyway - we have the data even if we couldn't cache it
+      }
     }
 
     return normalizedResponse;


### PR DESCRIPTION
CRITICAL FIX: The app was crashing when trying to cache participant 20's progress data. The crash occurred after deleting expired cache but before caching new data.

Root cause: CacheManager.cacheData() was throwing an unhandled error, likely due to:
- Data too large to serialize
- Circular references in data
- Data structure that can't be JSON stringified

Solution: Wrap cacheData in try-catch
- Log the error for debugging
- Continue with the request anyway (we have the data)
- Don't let cache failures break the user experience

This ensures the progress report loads even if caching fails.

Crash sequence observed:
1. Cache Expired for participant 20
2. Cache Deleted
3. [CRASH] - when trying to cache new data
4. Now: [ERROR LOG] - continues to return data