### PR TITLE
Fix parent isolation - use role check instead of permission check

### DIFF
--- a/mobile/src/utils/PermissionUtils.js
+++ b/mobile/src/utils/PermissionUtils.js
@@ -184,6 +184,19 @@ export function getDashboardType(userPermissions, userRoles = [], userRole = '')
   return hasNonParentPermission ? 'leader' : 'parent';
 }
 
+/**
+ * Check if user has parent role
+ * @returns {boolean} True if user has parent or demoparent role
+ */
+export function isParent(userRoles = [], userRole = '') {
+  const normalizedRoles = []
+    .concat(userRoles || [])
+    .concat(userRole ? [userRole] : [])
+    .filter((role) => typeof role === 'string')
+    .map((role) => role.toLowerCase());
+  return normalizedRoles.some((role) => PARENT_ROLE_KEYS.has(role));
+}
+
 // ==========================================
 // Async Permission Checkers (No Arguments)
 // ==========================================

--- a/routes/reports.js
+++ b/routes/reports.js
@@ -753,8 +753,9 @@ module.exports = (pool, logger) => {
   router.get('/participant-progress', authenticate, requirePermission('reports.view'), asyncHandler(async (req, res) => {
       const organizationId = await getOrganizationId(req, pool);
 
-      // Check if user has staff permissions (participants.view means they can see all participants)
-      const isStaff = req.user.permissions && req.user.permissions.includes('participants.view');
+      // Check if user has parent role - parents are restricted even if they have other permissions
+      const isParent = req.user.roleNames && (req.user.roleNames.includes('parent') || req.user.roleNames.includes('demoparent'));
+      const isStaff = !isParent; // Staff = NOT a parent
 
       // Parents can only see their own children, staff can see all participants
       let participantsQuery, participantsParams;


### PR DESCRIPTION
CRITICAL FIX: Parents with additional permissions were bypassing restrictions. Now checking for parent ROLE instead of permissions to ensure complete isolation.

Changes:
Backend (routes/reports.js):
- Check for parent/demoparent role instead of participants.view permission
- Parents are restricted even if they have other permissions
- isStaff = NOT parent (role-based, not permission-based)

Frontend SPA (spa/reports.js):
- Import isParent() instead of canViewParticipants()
- Check parent role to determine access restrictions
- Parents redirected if accessing /reports without participantId
- Participant picker hidden for all parents regardless of permissions

Mobile (mobile/src/screens/ReportViewerScreen.js):
- Added isParent() function to PermissionUtils
- Check user role on mount to set isStaff flag
- Picker hidden for parents based on role, not API response

This ensures parents can ONLY view their own children's progress reports via direct links from ParentDashboard, regardless of what permissions have been granted to their role.