### PR TITLE
Fix HealthFormScreen form structure parsing

### DIFF
--- a/mobile/src/screens/HealthFormScreen.js
+++ b/mobile/src/screens/HealthFormScreen.js
@@ -68,9 +68,11 @@ const HealthFormScreen = ({ route, navigation }) => {
       setParents(parentsData);
 
       // Get health form structure from response
-      const formFormats = formFormatsResponse.success ? formFormatsResponse.data : {};
+      // getOrganizationFormFormats returns the transformed object directly, not wrapped in {success, data}
+      const formFormats = formFormatsResponse || {};
       if (formFormats?.fiche_sante) {
-        const formStructureData = formFormats.fiche_sante.form_structure || formFormats.fiche_sante;
+        // formFormats.fiche_sante is already the form_structure from getOrganizationFormFormats
+        const formStructureData = formFormats.fiche_sante;
         setFormStructure(formStructureData);
         
         // Initialize with existing data or defaults


### PR DESCRIPTION
The code was incorrectly treating the response from getOrganizationFormFormats as if it had a {success, data} wrapper, when it actually returns the transformed object directly.

Before (broken):
  const formFormats = formFormatsResponse.success ? formFormatsResponse.data : {};
  const formStructureData = formFormats.fiche_sante.form_structure || formFormats.fiche_sante;

After (correct):
  const formFormats = formFormatsResponse || {};
  const formStructureData = formFormats.fiche_sante;

The getOrganizationFormFormats function already extracts and transforms the form_structure from the API response, so we just need to use it directly.

This fixes the issue where the health form fields weren't rendering - only the emergency contacts section was showing.