### PR TITLE
Fix form submission endpoint to use /save-form-submission

### DIFF
--- a/mobile/src/api/api-endpoints.js
+++ b/mobile/src/api/api-endpoints.js
@@ -1540,7 +1540,7 @@ export const getFormSubmission = async (participantId, formType) => {
  * @param {Object} formData - Form data to save
  */
 export const submitDynamicForm = async (formType, participantId, formData) => {
-  return API.post(`${CONFIG.ENDPOINTS.FORMS}/form-submission`, {
+  return API.post(`${CONFIG.ENDPOINTS.FORMS}/save-form-submission`, {
     form_type: formType,
     participant_id: participantId,
     submission_data: formData,


### PR DESCRIPTION
The mobile app was posting to /form-submission but the backend route is /save-form-submission. This caused a 404 error when trying to save forms.

Changed: /form-submission -> /save-form-submission

This fixes the 'Cannot POST /api/form-submission' error when saving the health form (and other dynamic forms).