### PR TITLE
Fix parent finance visibility issue in mobile app

### DIFF
--- a/mobile/src/screens/ParentDashboardScreen.js
+++ b/mobile/src/screens/ParentDashboardScreen.js
@@ -623,7 +623,7 @@ const ParentDashboardScreen = () => {
         <Text style={styles.sectionTitle}>{t('quick_actions')}</Text>
         <TouchableOpacity
           style={styles.actionButton}
-          onPress={() => navigation.navigate('Finance')}
+          onPress={() => navigation.navigate('ParentFinance')}
         >
           <Text style={styles.actionButtonText}>💰 {t('view_fees')}</Text>
         </TouchableOpacity>


### PR DESCRIPTION
Parents were able to see financial data for ALL participants instead of only their own children. This was caused by the "View Fees" button in the Quick Actions section navigating to the staff Finance screen instead of the parent-specific ParentFinance screen.

Changes:
- Updated ParentDashboardScreen.js line 626 to navigate to 'ParentFinance' instead of 'Finance'
- ParentFinance screen properly filters financial data to only show the authenticated parent's children via the /user-children and /v1/finance/participants/:participantId/statement endpoints

The backend authorization was already correct - this was purely a frontend navigation bug.

Fixes: Parent finance data visibility issue