### PR TITLE
fix: send permission slip emails to all guardians, not just one

### DIFF
--- a/migrations/add_guardians_emailed_to_permission_slips.sql
+++ b/migrations/add_guardians_emailed_to_permission_slips.sql
@@ -1,0 +1,12 @@
+-- Add guardians_emailed column to permission_slips to track all guardians who received emails
+-- This enables sending emails to ALL guardians linked to a participant, not just one
+
+ALTER TABLE permission_slips
+ADD COLUMN IF NOT EXISTS guardians_emailed JSONB DEFAULT '[]'::jsonb;
+
+-- Add index for querying which guardians have been emailed
+CREATE INDEX IF NOT EXISTS idx_permission_slips_guardians_emailed
+ON permission_slips USING gin(guardians_emailed);
+
+COMMENT ON COLUMN permission_slips.guardians_emailed IS
+'Array of guardian IDs that have been sent email notifications for this permission slip';


### PR DESCRIPTION
Previously, permission slip emails were only sent to a single guardian per participant. This change ensures all guardians linked to a participant via the participant_guardians table receive the email notification.

Changes:
- Modified send-emails endpoint to query all guardians for each participant
- Modified send-reminders endpoint to send reminders to all guardians
- Added guardians_emailed JSONB column to track which guardians were emailed
- Includes parent user emails as fallback if no guardian emails exist

https://claude.ai/code/session_012FScVScfxsT8j8Lydp22BB