### PR TITLE
refactor: switch meeting planner from activites_rencontre to activity…

### DIFF
--- a/mobile/src/config/index.js
+++ b/mobile/src/config/index.js
@@ -119,7 +119,7 @@ const CONFIG = {
     REUNION_PREPARATION: '/reunion-preparation',
     SAVE_REUNION_PREPARATION: '/save-reunion-preparation',
     REUNION_DATES: '/reunion-dates',
-    MEETING_ACTIVITIES: '/activites-rencontre',
+    MEETING_ACTIVITIES: '/v1/meetings/activities',
     NEXT_MEETING_INFO: '/next-meeting-info',
     ANIMATEURS: '/animateurs',
   },

--- a/routes/meetings.js
+++ b/routes/meetings.js
@@ -721,7 +721,14 @@ module.exports = (pool, logger) => {
         const organizationId = await getCurrentOrganizationId(req, pool, logger);
         const meetingSections = await getMeetingSectionConfig(pool, organizationId, logger);
         const result = await pool.query(
-          `SELECT * FROM activites_rencontre ORDER BY activity`
+          `SELECT id, name AS activity, category AS type,
+                  estimated_duration_min AS estimated_time_min,
+                  estimated_duration_max AS estimated_time_max,
+                  material, description
+           FROM activity_library
+           WHERE organization_id = $1 AND is_active = TRUE
+           ORDER BY name`,
+          [organizationId]
         );
 
         res.json({ success: true, data: result.rows, meetingSections });
@@ -729,7 +736,7 @@ module.exports = (pool, logger) => {
         if (handleOrganizationResolutionError(res, error, logger)) {
           return;
         }
-        logger.error('Error fetching activites rencontre:', error);
+        logger.error('Error fetching meeting activities:', error);
         res.status(500).json({ success: false, message: error.message });
       }
     });
@@ -762,9 +769,13 @@ module.exports = (pool, logger) => {
         const organizationId = await getCurrentOrganizationId(req, pool, logger);
 
         const result = await pool.query(
-          `SELECT * FROM activites_rencontre
-         WHERE organization_id = $1 OR organization_id = 0
-         ORDER BY category, name`,
+          `SELECT id, name AS activity, category AS type,
+                  estimated_duration_min AS estimated_time_min,
+                  estimated_duration_max AS estimated_time_max,
+                  material, description
+           FROM activity_library
+           WHERE organization_id = $1 AND is_active = TRUE
+           ORDER BY category, name`,
           [organizationId]
         );
 

--- a/spa/ajax-functions.js
+++ b/spa/ajax-functions.js
@@ -266,6 +266,7 @@ export {
     getReunionPreparation,
     saveReunionPreparation,
     getReunionDates,
+    getMeetingActivities,
     getActivitesRencontre,
     saveReminder,
     getReminder,

--- a/spa/api/api-endpoints.js
+++ b/spa/api/api-endpoints.js
@@ -1801,11 +1801,9 @@ export async function getReunionDates() {
 }
 
 /**
- * Get meeting activities
+ * @deprecated Use getMeetingActivities() instead
  */
-export async function getActivitesRencontre() {
-    return API.get('v1/meetings/activities');
-}
+export const getActivitesRencontre = () => getMeetingActivities();
 
 /**
  * Get all activities for the organization

--- a/spa/preparation_reunions.js
+++ b/spa/preparation_reunions.js
@@ -5,7 +5,7 @@ import { escapeHTML } from "./utils/SecurityUtils.js";
 import { isoToDateString, formatDate, parseDate } from "./utils/DateUtils.js";
 import { formatHonorText } from "./utils/HonorUtils.js";
 import {
-        getActivitesRencontre,
+        getMeetingActivities,
         getAnimateurs,
         getHonorsHistory,
         saveReunionPreparation,
@@ -175,7 +175,7 @@ export class PreparationReunions {
 
                 // Load data with individual error handling to prevent total failure
                 const [activitiesResponse, animateursResponse, badgeSettingsResponse, participantsResponse] = await Promise.all([
-                        getActivitesRencontre().catch(error => {
+                        getMeetingActivities().catch(error => {
                                 debugError("Error loading activities:", error);
                                 return { data: [] };
                         }),


### PR DESCRIPTION
…_library

Backend:
- GET /v1/meetings/activities now queries activity_library with column aliases (name→activity, category→type, estimated_duration_*→ estimated_time_*) so the frontend response shape stays the same.
- GET /v1/meetings/activities/templates updated identically.
- Both endpoints now filter by organization_id and is_active.

Frontend:
- preparation_reunions.js uses getMeetingActivities() instead of the deprecated getActivitesRencontre().
- getActivitesRencontre() kept as a thin deprecated alias for backward compat.
- getMeetingActivities re-exported from ajax-functions.js.

Mobile:
- Config endpoint updated from legacy /activites-rencontre to /v1/meetings/activities.

https://claude.ai/code/session_016eWzNNzN5H1PaTJpKMoHuX