### PR TITLE
fix: harden DB pool for networked Postgres and repair /organizations/…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ logs/
 .env.local
 .env.development
 .env.production
+# Any *.env file (cloudflare.env, etc.) — these hold live API tokens
+*.env
+# Railway bucket S3 credentials
+.railway-bucket*.json
 
 # Vite build output
 /dist/

--- a/config/database.js
+++ b/config/database.js
@@ -9,7 +9,15 @@ const poolConfig = {
     max: parseInt(process.env.DB_POOL_MAX || '20', 10),  // Maximum pool size (default: 20)
     min: parseInt(process.env.DB_POOL_MIN || '5', 10),   // Minimum idle connections (default: 5)
     idleTimeoutMillis: parseInt(process.env.DB_IDLE_TIMEOUT || '30000', 10),  // Close idle connections after 30s
-    connectionTimeoutMillis: parseInt(process.env.DB_CONNECTION_TIMEOUT || '2000', 10),  // Timeout waiting for connection (2s)
+    // 10s, not 2s: the database is reached over the network (Railway private
+    // networking), so a new connection includes a TLS handshake. 2s was tuned
+    // for a local pooler and caused spurious timeouts under load.
+    connectionTimeoutMillis: parseInt(process.env.DB_CONNECTION_TIMEOUT || '10000', 10),
+    // Detect connections dropped by the network. Postgres' own tcp_keepalives_idle
+    // is 7200s, so without client-side keepalive a dead socket can sit in the pool
+    // for two hours before anyone notices, and gets handed to a request as if live.
+    keepAlive: true,
+    keepAliveInitialDelayMillis: parseInt(process.env.DB_KEEPALIVE_DELAY || '10000', 10),
     // Allow connections to be reused to reduce overhead
     allowExitOnIdle: false,
 };
@@ -25,8 +33,14 @@ if (process.env.DATABASE_URL || process.env.SB_URL) {
 const pool = new Pool(poolConfig);
 
 // Handle pool errors
-pool.on("error", (err, client) => {
-    console.error("Unexpected error on idle PostgreSQL client:", err);
+pool.on("error", (err) => {
+    // Log the message only. Passing the Error object serialises the whole pg
+    // Client with it (connection params, TLS socket, timers), turning a single
+    // failure into ~80 lines of noise and burying the actual cause.
+    console.error(
+        `Unexpected error on idle PostgreSQL client: ${err.message}` +
+        (err.code ? ` (code ${err.code})` : "")
+    );
     // Pool errors are typically non-fatal (e.g., network issues)
     // The pool will handle reconnection automatically
 });

--- a/routes/organizations.js
+++ b/routes/organizations.js
@@ -138,8 +138,15 @@ module.exports = (pool, logger) => {
   router.get('/status', asyncHandler(async (req, res) => {
     try {
       const organizationId = await getCurrentOrganizationId(req, pool, logger);
+      // `domain` lives on organization_domains, not organizations — selecting it
+      // directly threw "column domain does not exist" and returned 500 on every call.
       const result = await pool.query(
-        'SELECT id, name, domain, created_at FROM organizations WHERE id = $1',
+        `SELECT id, name,
+                (SELECT od.domain FROM organization_domains od
+                  WHERE od.organization_id = organizations.id
+                  ORDER BY od.id LIMIT 1) AS domain,
+                created_at
+           FROM organizations WHERE id = $1`,
         [organizationId]
       );
 


### PR DESCRIPTION
…status

The database now lives across a network boundary (Railway private networking) rather than behind a local pooler, which exposed three problems:

- connectionTimeoutMillis was 2s, tuned for a local pooler. A new connection now includes a TLS handshake, so raise the default to 10s.
- TCP keepalive was off. Postgres' tcp_keepalives_idle is 7200s, so a socket dropped by the network could sit in the pool for two hours and be handed to a request as though live. Enable client-side keepalive.
- The pool error handler logged the Error object, which serialises the whole pg Client with it (connection params, TLS socket, timers). One failure produced ~80 lines and buried the cause. Log message and code only.

Separately, GET /api/v1/organizations/status selected `domain` from `organizations`, where no such column exists — it lives on `organization_domains`. Every call returned 500. Read it via a correlated subquery so the response shape is unchanged.

Also gitignore *.env and .railway-bucket*.json: cloudflare.env and the bucket credential files were untracked but not ignored, one `git add -A` away from being committed.