### PR TITLE
fix: stale-client recovery, permission slip archive, contact emails, …

### DIFF
--- a/css/dashboard-v2.css
+++ b/css/dashboard-v2.css
@@ -326,17 +326,25 @@
   overflow: hidden;
 }
 
-.dashboard-v2__tile:hover,
+/* Hover is only applied on devices that can actually hover. On touch screens
+   the :hover state is latched onto the last element tapped and never cleared,
+   which left tiles sitting permanently in their hover colour. */
+@media (hover: hover) and (pointer: fine) {
+  .dashboard-v2__tile:hover {
+    background: var(--tile-hover-bg, var(--tile-accent, var(--tile-bg-neutral)));
+    color: var(--tile-hover-fg, var(--tile-fg, var(--tile-fg-neutral)));
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-md);
+    text-decoration: none;
+    outline: none;
+  }
+}
+
 .dashboard-v2__tile:focus-visible {
   background: var(--tile-hover-bg, var(--tile-accent, var(--tile-bg-neutral)));
   color: var(--tile-hover-fg, var(--tile-fg, var(--tile-fg-neutral)));
   transform: translateY(-2px);
-  box-shadow: var(--shadow-md);
   text-decoration: none;
-  outline: none;
-}
-
-.dashboard-v2__tile:focus-visible {
   outline: 2px solid #ffffff;
   outline-offset: 2px;
   box-shadow:
@@ -344,6 +352,7 @@
     var(--shadow-md);
 }
 
+/* :active is safe on touch — it only lasts while the finger is down. */
 .dashboard-v2__tile:active {
   background: var(--tile-hover-bg, var(--tile-accent, var(--tile-bg-neutral)));
   color: var(--tile-hover-fg, var(--tile-fg, var(--tile-fg-neutral)));

--- a/css/styles.css
+++ b/css/styles.css
@@ -39,6 +39,14 @@
   --color-warning-light: #ffd773;
   --color-info: #178fce;
 
+  /* Links
+     --color-info is a UI accent at 3.6:1 on white, below the 4.5:1 WCAG 2.1 AA
+     floor for body text, so links use their own tokens instead.
+     --color-link:       5.6:1 on white, 5.2:1 on --color-background
+     --color-link-hover: 8.4:1 on white, 7.8:1 on --color-background */
+  --color-link: #0f6da3;
+  --color-link-hover: #0b5279;
+
   /* Selection & States */
   --color-selected: #0f7a5a;
   --color-selected-text: #ffffff;
@@ -243,23 +251,47 @@ a {
   transition: color var(--transition-fast);
 }
 
-a:hover,
+/* Hover is gated on hover-capable pointers: touch screens latch :hover onto
+   the last element tapped and never clear it, leaving links stuck in their
+   hover colour long after the tap. Focus styling stays unconditional. */
+@media (hover: hover) and (pointer: fine) {
+  a:hover {
+    color: var(--color-link-hover);
+    text-decoration: underline;
+  }
+}
+
 a:focus-visible {
-  color: var(--color-primary-dark);
+  color: var(--color-link-hover);
   text-decoration: underline;
 }
 
-/* Phone Link Styles */
-.phone-link {
-  color: var(--color-info);
+/* Phone & email link styles */
+.phone-link,
+.email-link {
+  color: var(--color-link);
   text-decoration: underline;
   transition: color var(--transition-fast);
   cursor: pointer;
 }
 
-.phone-link:hover,
-.phone-link:focus-visible {
-  color: var(--color-primary-dark);
+.email-link {
+  /* Comfortable tap target without breaking the inline flow. */
+  display: inline-block;
+  padding-block: var(--space-xs);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .phone-link:hover,
+  .email-link:hover {
+    color: var(--color-link-hover);
+    text-decoration: underline;
+  }
+}
+
+.phone-link:focus-visible,
+.email-link:focus-visible {
+  color: var(--color-link-hover);
   text-decoration: underline;
 }
 
@@ -6147,6 +6179,14 @@ body.online .pending-update {
   margin-inline-start: var(--space-md);
   font-family: monospace;
   color: var(--color-text);
+}
+
+.contact-email {
+  display: block;
+  margin-inline-start: var(--space-md);
+  color: var(--color-text);
+  /* Addresses can be long; keep them inside the card on narrow screens. */
+  overflow-wrap: anywhere;
 }
 
 /* ----------------------------------------------------------------------------

--- a/routes/appVersion.js
+++ b/routes/appVersion.js
@@ -1,0 +1,84 @@
+/**
+ * App version / build identity.
+ *
+ * The SPA polls this to detect that it is running against a different build
+ * than the one its cached assets came from — the situation that leaves users
+ * stranded behind a stale service worker after the app moves to a new host.
+ * It is deliberately unauthenticated and dependency-free so a client whose
+ * bundle is half-broken can still reach it.
+ */
+const express = require('express');
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const { success } = require('../middleware/response');
+const logger = require('../config/logger');
+
+const { version: packageVersion } = require('../package.json');
+
+const BUILD_HASH_LENGTH = 12;
+
+/**
+ * Fingerprint the built app shell.
+ *
+ * `dist/index.html` names every hashed JS/CSS entry the client loads, so its
+ * digest changes exactly when the client bundle changes and stays identical
+ * across restarts and replicas. That is what makes it safe to reload on: a
+ * value derived from process start time would differ between replicas and
+ * could bounce a user between them in a reload loop.
+ *
+ * @returns {string|null} Short digest of the built shell, or null in dev where
+ *   no build exists.
+ */
+function hashBuiltShell() {
+  try {
+    const indexPath = path.join(process.cwd(), 'dist', 'index.html');
+    const contents = fs.readFileSync(indexPath);
+    return crypto
+      .createHash('sha256')
+      .update(contents)
+      .digest('hex')
+      .slice(0, BUILD_HASH_LENGTH);
+  } catch (error) {
+    logger.info(`[app-version] No built shell to fingerprint: ${error.code || error.message}`);
+    return null;
+  }
+}
+
+/**
+ * Identifier for the currently running build.
+ *
+ * Resolution order:
+ *   1. `FORCE_CLIENT_REFRESH` — operator escape hatch. Setting (or changing)
+ *      this env var pushes every client through a cache purge and reload on
+ *      their next load, with no code change or redeploy of the SPA needed.
+ *   2. The commit SHA, when the platform exposes one.
+ *   3. A digest of the built app shell.
+ *   4. The package version, so the endpoint always answers with something.
+ */
+const BUILD_ID =
+  process.env.FORCE_CLIENT_REFRESH ||
+  process.env.RAILWAY_GIT_COMMIT_SHA ||
+  process.env.BUILD_ID ||
+  hashBuiltShell() ||
+  `dev-${packageVersion}`;
+
+module.exports = () => {
+  const router = express.Router();
+
+  router.get('/', (req, res) => {
+    // Must never be cached: a cached answer defeats the whole mechanism.
+    res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
+    res.setHeader('Pragma', 'no-cache');
+    res.setHeader('Expires', '0');
+
+    return success(res, {
+      version: packageVersion,
+      build_id: BUILD_ID,
+    });
+  });
+
+  return router;
+};
+
+module.exports.BUILD_ID = BUILD_ID;

--- a/routes/index.js
+++ b/routes/index.js
@@ -88,6 +88,7 @@ module.exports = (app, pool) => {
     const programProgressRoutes = require("./programProgress")(pool, logger);
     const incidentsRoutes = require("./incidents")(pool, logger);
     const yearlyPlannerRoutes = require("./yearlyPlanner")(pool, logger);
+    const appVersionRoutes = require("./appVersion")();
 
     // ============================================
     // MOUNT MODULAR ROUTES
@@ -169,6 +170,9 @@ module.exports = (app, pool) => {
 
     // WhatsApp routes already include /v1/* internally.
     app.use("/api", whatsappBaileysRoutes);
+
+    // Build identity, used by the SPA to detect stale cached clients.
+    app.use("/api/v1/app-version", appVersionRoutes);
 
     // Participants (Mount LAST due to catch-all /:id)
     app.use("/api/v1/participants", participantsRoutes);

--- a/spa/app.js
+++ b/spa/app.js
@@ -13,8 +13,13 @@ import { initOfflineSupport } from "./offline-init.js";
 import { offlineManager } from "./modules/OfflineManager.js";
 import { setContent, clearElement, createElement } from "./utils/DOMUtils.js";
 import { applyPalette as applyDashboardPalette } from "./utils/DashboardPreferences.js";
+import { checkForStaleClient, installChunkErrorRecovery } from "./modules/app-recovery/StaleClientRecovery.js";
 
 const debugMode = isDebugMode();
+
+// Recover from a stale cached app shell (e.g. after the app moves hosts) before
+// anything tries to lazy-load a chunk that no longer exists.
+installChunkErrorRecovery();
 
 // Service worker registration: vite-plugin-pwa injects registration at build time,
 // with a fallback in registerServiceWorker() if the injection is missing.
@@ -263,6 +268,12 @@ export const app = {
                         if (this.isLoggedIn) {
                                 this.handlePostLoginActions();
                         }
+
+                        // Detect a client running against a different server build than
+                        // its cached assets came from, and force a clean reload.
+                        checkForStaleClient().catch(error => {
+                                debugError("Stale client check failed:", error);
+                        });
 
                         // Ensure service worker is registered (fallback if vite-plugin-pwa injection missed)
                         this.registerServiceWorker();

--- a/spa/finance.js
+++ b/spa/finance.js
@@ -846,9 +846,12 @@ export class Finance extends BaseModule {
 
     document.querySelectorAll('[data-action="delete-definition"]').forEach((btn) => {
       btn.addEventListener('click', async (e) => {
-        const id = e.currentTarget.dataset.id;
+        // `currentTarget` is nulled once dispatch ends, so capture it before
+        // awaiting the confirmation dialog.
+        const trigger = e.currentTarget;
+        const id = trigger.dataset.id;
         if (await confirmDestructive(translate('confirm_delete'))) {
-          await withButtonLoading(e.currentTarget, async () => {
+          await withButtonLoading(trigger, async () => {
             await deleteFeeDefinition(id);
             await this.loadCoreData();
             this.render();

--- a/spa/modules/app-recovery/StaleClientRecovery.js
+++ b/spa/modules/app-recovery/StaleClientRecovery.js
@@ -1,0 +1,270 @@
+/**
+ * Stale client recovery.
+ *
+ * When the app moves to a new host, or a deploy replaces the hashed asset
+ * filenames, some browsers keep serving a previously cached app shell from the
+ * service worker. That shell then asks for JS chunks that no longer exist and
+ * the app fails to start — the user sees a blank page or an endless spinner
+ * and has no way to fix it short of clearing site data by hand.
+ *
+ * Two safety nets live here:
+ *
+ *  1. `checkForStaleClient()` compares the server's build id against the one
+ *     this client booted with. A mismatch triggers a full purge and reload.
+ *  2. `installChunkErrorRecovery()` catches dynamic-import failures, which is
+ *     what a mismatched shell actually produces at runtime, and purges too.
+ *
+ * Both funnel into `purgeAndReload()`, which is guarded so a client can never
+ * end up in a reload loop.
+ */
+
+import { CONFIG } from '../../config.js';
+import { debugLog, debugError, debugWarn } from '../../utils/DebugUtils.js';
+
+/** Build id this client booted with. */
+const BUILD_ID_KEY = 'wampums.client.buildId';
+/** Marks that a recovery reload already happened; prevents reload loops. */
+const RECOVERY_FLAG_KEY = 'wampums.client.recovering';
+/** How long a single recovery attempt stays "in progress", in milliseconds. */
+const RECOVERY_WINDOW_MS = 60 * 1000;
+/** Give up on the version probe rather than delaying boot indefinitely. */
+const VERSION_PROBE_TIMEOUT_MS = 8000;
+
+const CHUNK_ERROR_PATTERNS = [
+  'failed to fetch dynamically imported module',
+  'error loading dynamically imported module',
+  'importing a module script failed',
+  'unable to preload css',
+];
+
+/**
+ * Read the build id this client last booted with.
+ *
+ * @returns {string|null} Stored build id, or null when unknown.
+ */
+function readStoredBuildId() {
+  try {
+    return localStorage.getItem(BUILD_ID_KEY);
+  } catch (error) {
+    debugLog('Cannot read stored build id:', error);
+    return null;
+  }
+}
+
+/**
+ * Persist the build id this client is now running.
+ *
+ * @param {string} buildId - Build id reported by the server.
+ * @returns {void}
+ */
+function writeStoredBuildId(buildId) {
+  try {
+    localStorage.setItem(BUILD_ID_KEY, buildId);
+  } catch (error) {
+    debugLog('Cannot persist build id:', error);
+  }
+}
+
+/**
+ * Whether a recovery reload is already in flight.
+ *
+ * Recovery is recorded with a timestamp rather than a bare flag so that a
+ * genuinely new mismatch later in the session can still trigger a reload.
+ *
+ * @returns {boolean} True when a recovery started within the guard window.
+ */
+function isRecoveryInProgress() {
+  try {
+    const startedAt = Number(sessionStorage.getItem(RECOVERY_FLAG_KEY));
+    if (!startedAt) return false;
+    return Date.now() - startedAt < RECOVERY_WINDOW_MS;
+  } catch (error) {
+    debugLog('Cannot read recovery flag:', error);
+    return false;
+  }
+}
+
+/**
+ * Record that a recovery reload is starting.
+ *
+ * @returns {void}
+ */
+function markRecoveryStarted() {
+  try {
+    sessionStorage.setItem(RECOVERY_FLAG_KEY, String(Date.now()));
+  } catch (error) {
+    debugLog('Cannot persist recovery flag:', error);
+  }
+}
+
+/**
+ * Unregister every service worker and delete every Cache Storage bucket.
+ *
+ * IndexedDB is deliberately left alone: it holds the offline mutation outbox
+ * and cached API data, and discarding it could lose a leader's unsynced work.
+ * The problem being fixed is stale *code*, not stale data.
+ *
+ * @returns {Promise<void>} Resolves once the purge attempt finishes.
+ */
+export async function purgeClientCaches() {
+  if ('serviceWorker' in navigator) {
+    try {
+      const registrations = await navigator.serviceWorker.getRegistrations();
+      await Promise.all(
+        registrations.map((registration) => registration.unregister()),
+      );
+      debugLog(`Unregistered ${registrations.length} service worker(s)`);
+    } catch (error) {
+      debugError('Failed to unregister service workers:', error);
+    }
+  }
+
+  if (typeof caches !== 'undefined') {
+    try {
+      const keys = await caches.keys();
+      await Promise.all(keys.map((key) => caches.delete(key)));
+      debugLog(`Deleted ${keys.length} cache bucket(s)`);
+    } catch (error) {
+      debugError('Failed to delete caches:', error);
+    }
+  }
+}
+
+/**
+ * Purge stale client code and reload, at most once per guard window.
+ *
+ * @param {string} reason - Why recovery was triggered; logged for support.
+ * @returns {Promise<boolean>} True when a reload was initiated.
+ */
+export async function purgeAndReload(reason) {
+  if (isRecoveryInProgress()) {
+    debugWarn(`Stale client recovery already in progress, not retrying (${reason})`);
+    return false;
+  }
+
+  markRecoveryStarted();
+  debugWarn(`Recovering stale client: ${reason}`);
+
+  await purgeClientCaches();
+  window.location.reload();
+  return true;
+}
+
+/**
+ * Ask the server which build it is serving.
+ *
+ * The request deliberately bypasses every cache layer: a stale answer would
+ * defeat the check. The timestamp query parameter guarantees a cache miss even
+ * in an old service worker that keys entries by URL.
+ *
+ * @returns {Promise<{version: string, buildId: string}|null>} Server build, or
+ *   null when it cannot be determined (offline, timeout, unexpected shape).
+ */
+async function fetchServerBuild() {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), VERSION_PROBE_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(
+      `${CONFIG.API_BASE_URL}/api/v1/app-version?t=${Date.now()}`,
+      {
+        method: 'GET',
+        cache: 'no-store',
+        credentials: 'omit',
+        headers: { Accept: 'application/json' },
+        signal: controller.signal,
+      },
+    );
+
+    if (!response.ok) {
+      debugLog('Version probe returned', response.status);
+      return null;
+    }
+
+    const payload = await response.json();
+    const data = payload?.data || payload;
+    const buildId = data?.build_id;
+
+    if (!buildId) {
+      debugLog('Version probe returned no build id');
+      return null;
+    }
+
+    return { version: data.version || CONFIG.VERSION, buildId };
+  } catch (error) {
+    // Offline or unreachable is normal for a PWA; nothing to recover from.
+    debugLog('Version probe failed:', error);
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Compare this client's build against the server's and recover if they differ.
+ *
+ * On a first run the server build is simply recorded, so an existing user is
+ * not reloaded just for having no stored value.
+ *
+ * @returns {Promise<boolean>} True when a recovery reload was initiated.
+ */
+export async function checkForStaleClient() {
+  const serverBuild = await fetchServerBuild();
+  if (!serverBuild) return false;
+
+  const storedBuildId = readStoredBuildId();
+
+  if (!storedBuildId) {
+    writeStoredBuildId(serverBuild.buildId);
+    debugLog('Recorded initial build id:', serverBuild.buildId);
+    return false;
+  }
+
+  if (storedBuildId === serverBuild.buildId) {
+    return false;
+  }
+
+  // Record the new build before reloading so the reloaded client sees a match
+  // and does not attempt recovery again.
+  writeStoredBuildId(serverBuild.buildId);
+
+  return await purgeAndReload(
+    `build changed ${storedBuildId} -> ${serverBuild.buildId}`,
+  );
+}
+
+/**
+ * Whether an error looks like a failed dynamic import of a missing chunk.
+ *
+ * @param {unknown} error - Error or rejection reason to inspect.
+ * @returns {boolean} True when the message matches a known chunk failure.
+ */
+function isChunkLoadError(error) {
+  const message = String(error?.message || error || '').toLowerCase();
+  return CHUNK_ERROR_PATTERNS.some((pattern) => message.includes(pattern));
+}
+
+/**
+ * Recover automatically when the app shell references chunks that no longer
+ * exist, which is what a stale cached client produces at runtime.
+ *
+ * @returns {void}
+ */
+export function installChunkErrorRecovery() {
+  window.addEventListener('vite:preloadError', (event) => {
+    event.preventDefault();
+    purgeAndReload('vite preload error');
+  });
+
+  window.addEventListener('unhandledrejection', (event) => {
+    if (isChunkLoadError(event.reason)) {
+      purgeAndReload('dynamic import failure');
+    }
+  });
+
+  window.addEventListener('error', (event) => {
+    if (isChunkLoadError(event.error || event.message)) {
+      purgeAndReload('dynamic import failure');
+    }
+  });
+}

--- a/spa/parent_contact_list.js
+++ b/spa/parent_contact_list.js
@@ -5,6 +5,8 @@ import { canSendCommunications, canViewParticipants } from "./utils/PermissionUt
 import { debounce } from "./utils/PerformanceUtils.js";
 import { setContent } from "./utils/DOMUtils.js";
 import { createPhoneLink } from "./utils/PhoneUtils.js";
+import { createEmailLink } from "./utils/EmailUtils.js";
+import { escapeHTML } from "./utils/SecurityUtils.js";
 
 export class ParentContactList {
   constructor(app) {
@@ -196,7 +198,7 @@ export class ParentContactList {
     return `
             <div class="child-card" data-child-id="${childId}">
                 <details>
-                    <summary class="child-name">${child.name}</summary>
+                    <summary class="child-name">${escapeHTML(child.name)}</summary>
                 <div class="contacts">
                     ${this.renderContacts(child.contacts)}
                 </div>
@@ -210,11 +212,18 @@ export class ParentContactList {
       .map(
         (contact) => `
             <div class="contact-info">
-                <strong>${contact.name}</strong>
+                <strong>${escapeHTML(contact.name)}</strong>
                 ${
                   contact.is_emergency
                     ? `<span class="emergency-contact">${translate(
                         "is_emergency_contact",
+                      )}</span>`
+                    : ""
+                }
+                ${
+                  contact.email
+                    ? `<span class="contact-email">${translate("email")}: ${createEmailLink(
+                        contact.email
                       )}</span>`
                     : ""
                 }

--- a/spa/permission_slip_dashboard.js
+++ b/spa/permission_slip_dashboard.js
@@ -592,14 +592,17 @@ export class PermissionSlipDashboard {
     document.querySelectorAll(".sign-slip").forEach((button) => {
       button.addEventListener("click", async (event) => {
         event.preventDefault();
-        const slipId = event.currentTarget.getAttribute("data-id");
+        // `event.currentTarget` is nulled once dispatch ends, so capture the
+        // button before awaiting the dialog below.
+        const trigger = event.currentTarget;
+        const slipId = trigger.getAttribute("data-id");
         const signerName = (await promptDialog({
           title: translate("permission_slip_signer"),
           message: translate("permission_slip_signer"),
         }))?.trim();
         if (!signerName) return;
 
-        withButtonLoading(event.currentTarget, async () => {
+        withButtonLoading(trigger, async () => {
           try {
             await signPermissionSlip(slipId, { signed_by: signerName, signature_hash: `signed-${Date.now()}` });
             this.app.showMessage(translate("permission_slip_signed"), "success");
@@ -616,12 +619,15 @@ export class PermissionSlipDashboard {
     document.querySelectorAll('.archive-slip').forEach((button) => {
       button.addEventListener('click', async (event) => {
         event.preventDefault();
-        const slipId = event.currentTarget.getAttribute('data-id');
+        // `event.currentTarget` is nulled once dispatch ends, so capture the
+        // button before awaiting the confirmation dialog below.
+        const trigger = event.currentTarget;
+        const slipId = trigger.getAttribute('data-id');
         if (!(await confirmDestructive(translate("permission_slip_archive_confirm")))) {
           return;
         }
 
-        withButtonLoading(event.currentTarget, async () => {
+        withButtonLoading(trigger, async () => {
           try {
             const result = await archivePermissionSlip(slipId);
             if (result?.queued) {
@@ -656,12 +662,15 @@ export class PermissionSlipDashboard {
     document.querySelectorAll('.delete-slip').forEach((button) => {
       button.addEventListener('click', async (event) => {
         event.preventDefault();
-        const slipId = event.currentTarget.getAttribute('data-id');
+        // `event.currentTarget` is nulled once dispatch ends, so capture the
+        // button before awaiting the confirmation dialog below.
+        const trigger = event.currentTarget;
+        const slipId = trigger.getAttribute('data-id');
         if (!(await confirmDestructive(translate("permission_slip_delete_confirm")))) {
           return;
         }
 
-        withButtonLoading(event.currentTarget, async () => {
+        withButtonLoading(trigger, async () => {
           try {
             const { deletePermissionSlip } = await import('./api/api-endpoints.js');
             await deletePermissionSlip(slipId);

--- a/spa/utils/DashboardPreferences.js
+++ b/spa/utils/DashboardPreferences.js
@@ -13,6 +13,20 @@ const STORAGE_KEY = "wampums.dashboard.prefs.v1";
 const LIGHT_TEXT = "#ffffff";
 const DARK_TEXT = "#000000";
 
+/** WCAG 2.1 AA minimum contrast for normal-size text. */
+const MIN_CONTRAST_AA = 4.5;
+/** How far the hover tone moves away from the resting tile colour. */
+const HOVER_SHIFT = 0.16;
+/** Extra nudge applied per iteration when the first shift is not AA yet. */
+const HOVER_SHIFT_STEP = 0.1;
+/** Guard against an unbounded loop on pathological colours. */
+const MAX_HOVER_SHIFT_STEPS = 12;
+/**
+ * Below this relative luminance a tile is already near-black, so the hover
+ * tone has to get lighter rather than darker to stay visible.
+ */
+const NEAR_BLACK_LUMINANCE = 0.06;
+
 const DEFAULT_PREFS = Object.freeze({
   paletteId: DEFAULT_PALETTE_ID,
   hiddenTiles: [],
@@ -64,6 +78,65 @@ export function setCollapsedToolGroups(groups) {
 }
 
 /**
+ * Parse a six-digit hexadecimal colour into 0-255 channels.
+ *
+ * @param {string} color - A six-digit hexadecimal colour.
+ * @returns {number[]|null} `[r, g, b]`, or null when the input is not parseable.
+ */
+function parseHexColor(color) {
+  const match = /^#([0-9a-f]{6})$/i.exec(color);
+  if (!match) return null;
+
+  return match[1].match(/.{2}/g).map((channel) => Number.parseInt(channel, 16));
+}
+
+/**
+ * Serialise 0-255 channels back to a six-digit hexadecimal colour.
+ *
+ * @param {number[]} channels - `[r, g, b]` in the 0-255 range.
+ * @returns {string} A six-digit hexadecimal colour.
+ */
+function toHexColor(channels) {
+  return `#${channels
+    .map((channel) => {
+      const clamped = Math.max(0, Math.min(255, Math.round(channel)));
+      return clamped.toString(16).padStart(2, "0");
+    })
+    .join("")}`;
+}
+
+/**
+ * WCAG relative luminance of 0-255 channels.
+ *
+ * @param {number[]} channels - `[r, g, b]` in the 0-255 range.
+ * @returns {number} Relative luminance between 0 and 1.
+ */
+function relativeLuminance(channels) {
+  const linear = channels
+    .map((channel) => channel / 255)
+    .map((channel) =>
+      channel <= 0.04045
+        ? channel / 12.92
+        : ((channel + 0.055) / 1.055) ** 2.4,
+    );
+
+  return (0.2126 * linear[0]) + (0.7152 * linear[1]) + (0.0722 * linear[2]);
+}
+
+/**
+ * WCAG contrast ratio between two luminance values.
+ *
+ * @param {number} a - First relative luminance.
+ * @param {number} b - Second relative luminance.
+ * @returns {number} Contrast ratio between 1 and 21.
+ */
+function contrastRatio(a, b) {
+  const lighter = Math.max(a, b);
+  const darker = Math.min(a, b);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/**
  * Pick black or white text for a background color using WCAG relative
  * luminance. Choosing the higher-contrast option guarantees at least 4.5:1
  * for valid six-digit hex palette colors.
@@ -72,25 +145,63 @@ export function setCollapsedToolGroups(groups) {
  * @returns {string} Accessible foreground color.
  */
 function getAccessibleForeground(backgroundColor) {
-  const match = /^#([0-9a-f]{6})$/i.exec(backgroundColor);
-  if (!match) return LIGHT_TEXT;
+  const channels = parseHexColor(backgroundColor);
+  if (!channels) return LIGHT_TEXT;
 
-  const channels = match[1]
-    .match(/.{2}/g)
-    .map((channel) => Number.parseInt(channel, 16) / 255)
-    .map((channel) =>
-      channel <= 0.04045
-        ? channel / 12.92
-        : ((channel + 0.055) / 1.055) ** 2.4,
-    );
-  const luminance =
-    (0.2126 * channels[0]) +
-    (0.7152 * channels[1]) +
-    (0.0722 * channels[2]);
+  const luminance = relativeLuminance(channels);
   const lightContrast = 1.05 / (luminance + 0.05);
   const darkContrast = (luminance + 0.05) / 0.05;
 
   return lightContrast >= darkContrast ? LIGHT_TEXT : DARK_TEXT;
+}
+
+/**
+ * Derive the hover/active tone for a tile.
+ *
+ * The previous behaviour reused the palette's `accent` — the same colour as the
+ * tile border — which read as "this tile is selected" rather than "hovered",
+ * and left tiles looking permanently stuck in the darkest shade of their
+ * domain colour. Instead we shift the resting colour a controlled step away
+ * from itself (darker normally, lighter for near-black tiles so the change
+ * stays visible) and keep stepping until the paired text colour clears WCAG
+ * 2.1 AA at 4.5:1.
+ *
+ * @param {string} backgroundColor - The resting tile colour.
+ * @returns {{bg: string, fg: string}} An AA-compliant hover pair.
+ */
+function deriveHoverTone(backgroundColor) {
+  const channels = parseHexColor(backgroundColor);
+  if (!channels) {
+    return { bg: backgroundColor, fg: getAccessibleForeground(backgroundColor) };
+  }
+
+  const lighten = relativeLuminance(channels) < NEAR_BLACK_LUMINANCE;
+  let shift = HOVER_SHIFT;
+  let candidate = channels;
+
+  for (let step = 0; step <= MAX_HOVER_SHIFT_STEPS; step += 1) {
+    candidate = channels.map((channel) =>
+      lighten
+        ? channel + ((255 - channel) * shift)
+        : channel * (1 - shift),
+    );
+
+    const hex = toHexColor(candidate);
+    const fg = getAccessibleForeground(hex);
+    const pairContrast = contrastRatio(
+      relativeLuminance(parseHexColor(hex)),
+      relativeLuminance(parseHexColor(fg)),
+    );
+
+    if (pairContrast >= MIN_CONTRAST_AA) {
+      return { bg: hex, fg };
+    }
+
+    shift += HOVER_SHIFT_STEP;
+  }
+
+  const fallback = toHexColor(candidate);
+  return { bg: fallback, fg: getAccessibleForeground(fallback) };
 }
 
 /**
@@ -107,11 +218,10 @@ export function applyPalette(paletteId = null) {
     root.style.setProperty(`--tile-bg-${domain}`, tones.bg);
     root.style.setProperty(`--tile-fg-${domain}`, tones.fg);
     root.style.setProperty(`--tile-accent-${domain}`, tones.accent);
-    root.style.setProperty(`--tile-hover-bg-${domain}`, tones.accent);
-    root.style.setProperty(
-      `--tile-hover-fg-${domain}`,
-      getAccessibleForeground(tones.accent),
-    );
+
+    const hover = deriveHoverTone(tones.bg);
+    root.style.setProperty(`--tile-hover-bg-${domain}`, hover.bg);
+    root.style.setProperty(`--tile-hover-fg-${domain}`, hover.fg);
   });
 
   root.dataset.dashboardPalette = palette.id;

--- a/spa/utils/EmailUtils.js
+++ b/spa/utils/EmailUtils.js
@@ -1,0 +1,36 @@
+/**
+ * Email Utilities
+ *
+ * Helpers for rendering email addresses as safe, clickable links.
+ */
+
+import { escapeHTML, sanitizeEmail } from './SecurityUtils.js';
+
+/**
+ * Create a clickable email link with the mailto: protocol.
+ *
+ * Addresses that fail validation are still displayed (a malformed address on
+ * file is useful information for a leader trying to reach a parent) but are
+ * rendered as plain text rather than a link.
+ *
+ * @param {string} email - Email address to link
+ * @param {string} [label] - Optional link text (defaults to the address)
+ * @returns {string} HTML string with a clickable mailto: link, or escaped text
+ */
+export function createEmailLink(email, label = null) {
+  if (!email) {
+    return '';
+  }
+
+  const raw = email.toString().trim();
+  const safeAddress = sanitizeEmail(raw);
+  const displayText = escapeHTML(label || raw);
+
+  if (!safeAddress) {
+    return displayText;
+  }
+
+  // sanitizeEmail already rejects whitespace, control characters and the
+  // quoting characters, so escaping is all the href attribute context needs.
+  return `<a href="mailto:${escapeHTML(safeAddress)}" class="email-link">${displayText}</a>`;
+}

--- a/spa/utils/PerformanceUtils.js
+++ b/spa/utils/PerformanceUtils.js
@@ -29,12 +29,22 @@ export function debounce(func, wait = 300) {
 }
 
 /**
- * Wraps an async operation with button loading state management
- * @param {HTMLButtonElement} button - Button to disable/show loading state
+ * Wraps an async operation with button loading state management.
+ *
+ * The button is optional: when it is missing (for example a caller that read
+ * `event.currentTarget` after an `await`, which nulls it) the operation still
+ * runs, only without the loading affordance. Silently dropping the action would
+ * make the feature look broken.
+ *
+ * @param {HTMLButtonElement|null} button - Button to disable/show loading state
  * @param {Function} asyncFn - Async function to execute
  * @returns {Promise} Result of the async function
  */
 export async function withButtonLoading(button, asyncFn) {
+  if (!button) {
+    return await asyncFn();
+  }
+
   if (button.disabled) return;
 
   setButtonLoading(button, true);

--- a/src-sw.js
+++ b/src-sw.js
@@ -159,6 +159,14 @@ registerRoute(
   })
 );
 
+// 4c-bis. Build identity probe - NetworkOnly, and registered before the generic
+// API route below so it can never be answered from a cache. A stale answer here
+// would hide exactly the mismatch the probe exists to detect.
+registerRoute(
+  ({ url }) => url.pathname === '/api/v1/app-version',
+  new NetworkOnly()
+);
+
 // 4d. API routes (GET only) - custom handler using IndexedDB caching
 registerRoute(
   ({ url, request }) => {


### PR DESCRIPTION
…sticky hover

Four unrelated user-reported issues.

1. Users stuck on a stale client after the server move Adds GET /api/v1/app-version, whose build_id is a digest of the built app shell (dist/index.html), so it changes exactly when the client bundle changes and stays stable across restarts and replicas. The SPA compares it at boot and, on a mismatch, unregisters service workers, clears Cache Storage and reloads once. A second net catches dynamic-import failures, which is how a stale shell actually fails at runtime. IndexedDB is left intact so the offline mutation outbox is never discarded. FORCE_CLIENT_REFRESH env var is an operator escape hatch to push every client through a purge without a redeploy.

2. Archive button did nothing on permission slips The handler read event.currentTarget after awaiting the confirm dialog, by which point dispatch has ended and currentTarget is null, so withButtonLoading threw before the request was ever sent. The button is now captured up front (same fix for sign, delete and the finance fee-definition delete, which had the identical bug), and withButtonLoading no longer swallows the action when handed a null button.

3. Guardian emails on the Emergency Contacts page Renders the address, already present in the API response, as a mailto link via a new EmailUtils.createEmailLink. Names are escaped on the way out.

4. Sticky green hover on the dashboard Touch screens latch :hover onto the last element tapped and never clear it, which left tiles and links sitting permanently in their hover colour. :hover is now gated behind (hover: hover) and (pointer: fine); focus and active styling are unchanged. Tile hover tones are derived from the resting colour rather than reusing the border accent, and verified at >= 4.5:1 against their text colour across all 45 palette/domain combinations. Links get their own tokens because --color-info sits at 3.6:1 on white, below the WCAG 2.1 AA floor for body text.