### PR TITLE
fix(dashboard): reconnaître les rôles canoniques et fiabiliser les on…

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -11158,9 +11158,15 @@ body.modal-open {
   min-height: 6rem;
 }
 
+/* Each mount owns one container inside the panel, so a tab switch made while a
+   module is still initializing cannot let that module repaint the live tab. */
+.tabbed-page__mount[hidden] {
+  display: none;
+}
+
 /* Hosted pages draw their own container; strip the outer padding they would
    otherwise stack on top of the shell's. */
-.tabbed-page__panel > .container {
+.tabbed-page__mount > .container {
   padding-left: 0;
   padding-right: 0;
 }

--- a/spa/config/dashboard-customization.js
+++ b/spa/config/dashboard-customization.js
@@ -8,6 +8,8 @@
  * `dashboard-tiles.js`, the single source of truth.
  */
 
+import { CONFIG } from "../config.js";
+
 export const DOMAINS = [
   "people",       // participants, parents, contacts, groups, messages to families
   "attendance",   // points, honors, meeting, attendance
@@ -140,6 +142,30 @@ export const ROLE_WEIGHTS = {
   admin: { admin: 0, money: 1, attendance: 2 },
   default: {},
 };
+
+/**
+ * Canonical role name (`CONFIG.ROLES`) → weight profile above.
+ *
+ * The profile names are historical and describe the *layout*, not the role:
+ * "treasurer" is the money-first layout, so the canonical `finance` role maps
+ * to it. Roles with no entry here fall back to the `default` profile.
+ */
+export const ROLE_WEIGHT_PROFILES = {
+  [CONFIG.ROLES.DISTRICT]: "admin",
+  [CONFIG.ROLES.UNIT_ADMIN]: "admin",
+  [CONFIG.ROLES.ADMINISTRATION]: "admin",
+  [CONFIG.ROLES.DEMO_ADMIN]: "admin",
+  [CONFIG.ROLES.FINANCE]: "treasurer",
+  [CONFIG.ROLES.LEADER]: "animator",
+  [CONFIG.ROLES.PARENT]: "parent",
+  [CONFIG.ROLES.DEMO_PARENT]: "parent",
+};
+
+/**
+ * Order in which profiles win when a user holds several roles — an animator who
+ * also keeps the books gets the money-first layout.
+ */
+export const ROLE_WEIGHT_PROFILE_PRECEDENCE = ["admin", "treasurer", "parent", "animator"];
 
 export function getPalette(id) {
   return PALETTES[id] || PALETTES[DEFAULT_PALETTE_ID];

--- a/spa/config/tabbed-pages.js
+++ b/spa/config/tabbed-pages.js
@@ -36,6 +36,10 @@ export const TABBED_PAGES = {
       {
         key: "badges",
         labelKey: "tab_progression_badges",
+        // The route itself admits anyone who can see participants, so this tab
+        // needs its own gate: without it a participants-only user lands on the
+        // tracker's "not authorized" panel instead of the Programme tab.
+        gate: () => hasAnyPermission("badges.view", "badges.approve", "badges.manage"),
         load: () => import("../badge_tracker.js").then((m) => m.BadgeTracker),
       },
       {

--- a/spa/dashboard.js
+++ b/spa/dashboard.js
@@ -32,7 +32,11 @@ import {
 import { DashboardCacheManager } from "./utils/DashboardCacheManager.js";
 import { NewsFeed } from "./modules/NewsFeed.js";
 import { CarpoolQuickAccessModal } from "./modules/modals/CarpoolQuickAccessModal.js";
-import { ROLE_WEIGHTS } from "./config/dashboard-customization.js";
+import {
+  ROLE_WEIGHTS,
+  ROLE_WEIGHT_PROFILES,
+  ROLE_WEIGHT_PROFILE_PRECEDENCE,
+} from "./config/dashboard-customization.js";
 import {
   DASHBOARD_TILES,
   TOOL_GROUP_ORDER,
@@ -418,13 +422,36 @@ export class Dashboard extends BaseModule {
   //   Moment-layout helpers
   // -----------------------------
 
+  /**
+   * Pick the ROLE_WEIGHTS profile that matches the user's roles.
+   *
+   * Canonical role names come from `CONFIG.ROLES`; the free-form names below are
+   * only kept for legacy token payloads that predate that list.
+   *
+   * @returns {string} Key into ROLE_WEIGHTS, or "default" when no role matches.
+   */
   _dominantRoleKey() {
     const roles = (this.app?.userRoles || []).map((r) => (r || "").toString().toLowerCase());
-    if (roles.includes("admin") || roles.includes("super_admin")) return "admin";
-    if (roles.some((r) => r.includes("treasur") || r.includes("tresor"))) return "treasurer";
-    if (roles.includes("parent") || roles.includes("guardian")) return "parent";
-    if (roles.includes("animator") || roles.includes("animateur") || roles.includes("leader")) return "animator";
-    return "default";
+    const profiles = new Set();
+
+    roles.forEach((role) => {
+      const canonical = ROLE_WEIGHT_PROFILES[role];
+      if (canonical) {
+        profiles.add(canonical);
+        return;
+      }
+      if (role === "admin" || role === "super_admin") {
+        profiles.add("admin");
+      } else if (role.includes("treasur") || role.includes("tresor")) {
+        profiles.add("treasurer");
+      } else if (role === "guardian") {
+        profiles.add("parent");
+      } else if (role === "animator" || role === "animateur") {
+        profiles.add("animator");
+      }
+    });
+
+    return ROLE_WEIGHT_PROFILE_PRECEDENCE.find((key) => profiles.has(key)) || "default";
   }
 
   /**

--- a/spa/modules/TabbedPage.js
+++ b/spa/modules/TabbedPage.js
@@ -24,6 +24,12 @@ import { BaseModule } from "../utils/BaseModule.js";
 
 const PANEL_ID = "tabbed-page-panel";
 
+/**
+ * @param {number} token - Mount activation token.
+ * @returns {string} DOM id of that mount's container.
+ */
+const mountId = (token) => `${PANEL_ID}-mount-${token}`;
+
 export class TabbedPage extends BaseModule {
   /**
    * @param {Object} app - Application instance.
@@ -35,6 +41,9 @@ export class TabbedPage extends BaseModule {
     this.tabs = (config.tabs || []).filter((tab) => !tab.gate || tab.gate());
     this.activeKey = null;
     this.activeModule = null;
+    // Every mount gets a token; only the newest one may own the panel.
+    this.mountToken = 0;
+    this.pendingMounts = new Set();
   }
 
   async init() {
@@ -159,9 +168,23 @@ export class TabbedPage extends BaseModule {
 
     this.activeKey = key;
     this.syncUrl(key);
-    this.render();
-    this.attachEventListeners();
+    // Update the tab bar in place rather than re-rendering the shell: the panel
+    // element must survive a switch, otherwise a module still initializing in it
+    // would lose its mount point and fall back to rendering over #app.
+    this.updateTabStates();
     await this.mountActiveTab();
+  }
+
+  /**
+   * Reflect `activeKey` on the existing tab buttons.
+   */
+  updateTabStates() {
+    document.querySelectorAll(".tabbed-page__tab").forEach((button) => {
+      const isActive = button.dataset.tab === this.activeKey;
+      button.classList.toggle("is-active", isActive);
+      button.setAttribute("aria-selected", String(isActive));
+      button.tabIndex = isActive ? 0 : -1;
+    });
   }
 
   /**
@@ -182,41 +205,102 @@ export class TabbedPage extends BaseModule {
   /**
    * Tear down the previous tab's module and mount the active one.
    *
+   * A module's `init()` renders while it awaits its data, so a tab switch made
+   * mid-init cannot simply be ignored afterwards — the obsolete module would go
+   * on painting. Each mount therefore gets its own token and its own container
+   * inside the panel: an obsolete module keeps writing into its own container,
+   * which is hidden the moment it stops being current and removed once its
+   * `init()` settles. It can never repaint the live tab.
+   *
    * A tab that fails to load must not take the whole page down: the shell and
    * the other tabs stay usable and the failure is shown inside the panel.
    */
   async mountActiveTab() {
-    this.destroyActiveModule();
-
     const tab = this.tabs.find((t) => t.key === this.activeKey);
     if (!tab) return;
 
     const panel = document.getElementById(PANEL_ID);
     if (!panel) return;
 
-    setContent(panel, `<p class="loading-state">${escapeHTML(translate("loading"))}</p>`);
+    const token = ++this.mountToken;
+    const containerId = mountId(token);
+
+    this.destroyActiveModule();
+    this.retireMounts(panel);
+    this.pendingMounts.add(token);
+    panel.appendChild(this.createMount(token, containerId));
 
     try {
       const PageClass = await tab.load();
       // The tab may have changed while the import was in flight.
-      if (this.isDestroyed || this.activeKey !== tab.key) return;
+      if (!this.isCurrentMount(token)) return;
 
       const instance = new PageClass(this.app, {
         ...(tab.options || {}),
-        containerId: PANEL_ID,
+        containerId,
         embedded: true,
       });
       this.activeModule = instance;
       await instance.init();
+      if (!this.isCurrentMount(token)) return;
       debugLog(`TabbedPage mounted tab "${tab.key}"`);
     } catch (error) {
       debugError(`Failed to mount tab "${tab.key}":`, error);
-      if (this.activeKey !== tab.key) return;
-      const target = document.getElementById(PANEL_ID);
+      if (!this.isCurrentMount(token)) return;
+      const target = document.getElementById(containerId);
       if (target) {
         setContent(target, `<p class="error-message">${escapeHTML(translate("error_loading_data"))}</p>`);
       }
+    } finally {
+      this.pendingMounts.delete(token);
+      if (!this.isCurrentMount(token)) {
+        document.getElementById(containerId)?.remove();
+      }
     }
+  }
+
+  /**
+   * @param {number} token
+   * @returns {boolean} True while this mount still owns the panel.
+   */
+  isCurrentMount(token) {
+    return !this.isDestroyed && this.mountToken === token;
+  }
+
+  /**
+   * Build the container a single mount renders into.
+   *
+   * @param {number} token
+   * @param {string} containerId
+   * @returns {HTMLElement}
+   */
+  createMount(token, containerId) {
+    const mount = document.createElement("div");
+    mount.id = containerId;
+    mount.className = "tabbed-page__mount";
+    mount.dataset.mountToken = String(token);
+    setContent(mount, `<p class="loading-state">${escapeHTML(translate("loading"))}</p>`);
+    return mount;
+  }
+
+  /**
+   * Clear the panel for a new mount.
+   *
+   * A container whose module has finished initializing is removed outright. One
+   * that is still being initialized is only hidden: removing it would leave that
+   * module without a mount point, and `getMountPoint()` would then fall back to
+   * `#app` and wipe the whole shell.
+   *
+   * @param {HTMLElement} panel
+   */
+  retireMounts(panel) {
+    Array.from(panel.children).forEach((child) => {
+      if (this.pendingMounts.has(Number(child.dataset.mountToken))) {
+        child.hidden = true;
+      } else {
+        child.remove();
+      }
+    });
   }
 
   destroyActiveModule() {


### PR DESCRIPTION
…glets

Trois correctifs relevés en revue :

- `_dominantRoleKey()` ne reconnaissait que « treasurer » et admin/super_admin, donc un utilisateur finance, unitadmin, district ou demoadmin retombait sur le profil `default` et voyait son groupe Argent ou Administration replié. Le mappage rôle → profil de pondération s'appuie maintenant sur `CONFIG.ROLES`; les anciens noms libres restent tolérés pour les jetons hérités.

- L'onglet Badges de /progression n'avait aucune garde alors que la route admet quiconque possède `participants.view`. Il ouvrait donc son état « non autorisé » par défaut. Il est désormais filtré sur les permissions badges, ce qui fait tomber l'onglet initial sur Programme.

- Changer d'onglet pendant un `init()` asynchrone laissait l'ancien module repeindre le panneau réutilisé. Chaque montage reçoit un jeton d'activation et son propre conteneur : le module obsolète écrit dans son conteneur masqué, qui est retiré une fois son `init()` terminé. `switchTo()` met à jour la barre d'onglets en place au lieu de re-rendre la coquille, pour que le panneau survive au changement.