### PR TITLE
feat(annee-scoute): rendre la fin d'année non destructive (phases 1-3)

### DIFF
--- a/attached_assets/Full_Database_schema.sql
+++ b/attached_assets/Full_Database_schema.sql
@@ -87,11 +87,17 @@ CREATE TABLE public.points (
   created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
   organization_id integer,
   honor_id integer,
+  scout_year_id integer,
   CONSTRAINT points_pkey PRIMARY KEY (id),
   CONSTRAINT points_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id),
   CONSTRAINT points_participant_id_fkey FOREIGN KEY (participant_id) REFERENCES public.participants(id),
-  CONSTRAINT points_honor_id_fkey FOREIGN KEY (honor_id) REFERENCES public.honors(id)
+  CONSTRAINT points_honor_id_fkey FOREIGN KEY (honor_id) REFERENCES public.honors(id),
+  CONSTRAINT points_scout_year_id_fkey FOREIGN KEY (scout_year_id) REFERENCES public.scout_years(id)
 );
+-- Read-only view over points restricted to each organization active scout year.
+-- CREATE VIEW public.active_year_points AS
+--   SELECT p.* FROM points p JOIN scout_years sy ON sy.id = p.scout_year_id
+--    WHERE sy.status = 'active';
 CREATE TABLE public.processed_transactions (
   id integer NOT NULL DEFAULT nextval('processed_transactions_id_seq'::regclass),
   transaction_id character varying NOT NULL,
@@ -210,6 +216,10 @@ CREATE TABLE public.user_organizations (
   created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
   user_id uuid,
   role_ids jsonb DEFAULT '[]'::jsonb,
+  status text NOT NULL DEFAULT 'active'::text CHECK (status = ANY (ARRAY['active'::text, 'inactive'::text, 'alumni'::text])),
+  deactivated_at timestamp with time zone,
+  deactivated_reason text,
+  last_active_scout_year_id integer,
   CONSTRAINT user_organizations_pkey PRIMARY KEY (id),
   CONSTRAINT user_organizations_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id),
   CONSTRAINT user_organizations_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id)
@@ -313,14 +323,30 @@ CREATE TABLE public.reunion_preparations (
   CONSTRAINT reunion_preparations_animateur_responsable_fkey FOREIGN KEY (animateur_responsable) REFERENCES public.users(id),
   CONSTRAINT reunion_preparations_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id)
 );
-CREATE TABLE public.participant_organizations (
+CREATE TABLE public.participant_enrollments (
   participant_id integer NOT NULL,
   organization_id integer NOT NULL,
   inscription_date date,
-  CONSTRAINT participant_organizations_pkey PRIMARY KEY (participant_id, organization_id),
-  CONSTRAINT participant_organizations_participant_id_fkey FOREIGN KEY (participant_id) REFERENCES public.participants(id),
-  CONSTRAINT participant_organizations_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id)
+  scout_year_id integer NOT NULL,
+  status text NOT NULL DEFAULT 'active'::text CHECK (status = ANY (ARRAY['active'::text, 'graduated'::text, 'left'::text, 'transferred'::text])),
+  ended_on date,
+  exit_reason text,
+  exception_note text,
+  transferred_to_organization_id integer,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT participant_enrollments_pkey PRIMARY KEY (participant_id, organization_id, scout_year_id),
+  CONSTRAINT participant_enrollments_participant_id_fkey FOREIGN KEY (participant_id) REFERENCES public.participants(id),
+  CONSTRAINT participant_enrollments_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id),
+  CONSTRAINT participant_enrollments_scout_year_id_fkey FOREIGN KEY (scout_year_id) REFERENCES public.scout_years(id),
+  CONSTRAINT participant_enrollments_transferred_to_organization_id_fkey FOREIGN KEY (transferred_to_organization_id) REFERENCES public.organizations(id)
 );
+-- Read-only compatibility view: the roster of the ACTIVE scout year.
+-- Every legacy read site joins this; writes must target participant_enrollments.
+-- CREATE VIEW public.participant_organizations AS
+--   SELECT pe.participant_id, pe.organization_id, pe.inscription_date
+--     FROM participant_enrollments pe
+--     JOIN scout_years sy ON sy.id = pe.scout_year_id
+--    WHERE sy.status = 'active' AND pe.status = 'active';
 CREATE TABLE public.activites_rencontre (
   id bigint NOT NULL,
   activity text NOT NULL,
@@ -1487,4 +1513,38 @@ CREATE TABLE public.medication_admin_authorizations (
   CONSTRAINT maa_admin_user_id_1_fkey FOREIGN KEY (admin_user_id_1) REFERENCES public.users(id),
   CONSTRAINT maa_admin_user_id_2_fkey FOREIGN KEY (admin_user_id_2) REFERENCES public.users(id),
   CONSTRAINT maa_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id)
+);
+CREATE TABLE public.scout_years (
+  id integer NOT NULL DEFAULT nextval('scout_years_id_seq'::regclass),
+  organization_id integer NOT NULL,
+  label text NOT NULL,
+  start_date date NOT NULL,
+  end_date date NOT NULL,
+  status text NOT NULL DEFAULT 'planning'::text CHECK (status = ANY (ARRAY['planning'::text, 'active'::text, 'closed'::text])),
+  closed_at timestamp with time zone,
+  closed_by uuid,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT scout_years_pkey PRIMARY KEY (id),
+  CONSTRAINT scout_years_label_unique UNIQUE (organization_id, label),
+  CONSTRAINT scout_years_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id),
+  CONSTRAINT scout_years_closed_by_fkey FOREIGN KEY (closed_by) REFERENCES public.users(id)
+);
+CREATE TABLE public.scout_year_transitions (
+  id integer NOT NULL DEFAULT nextval('scout_year_transitions_id_seq'::regclass),
+  organization_id integer NOT NULL,
+  from_scout_year_id integer,
+  to_scout_year_id integer NOT NULL,
+  executed_at timestamp with time zone NOT NULL DEFAULT now(),
+  executed_by uuid,
+  summary jsonb NOT NULL DEFAULT '{}'::jsonb,
+  changeset jsonb NOT NULL DEFAULT '{}'::jsonb,
+  rolled_back_at timestamp with time zone,
+  rolled_back_by uuid,
+  CONSTRAINT scout_year_transitions_pkey PRIMARY KEY (id),
+  CONSTRAINT scout_year_transitions_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id),
+  CONSTRAINT scout_year_transitions_from_scout_year_id_fkey FOREIGN KEY (from_scout_year_id) REFERENCES public.scout_years(id),
+  CONSTRAINT scout_year_transitions_to_scout_year_id_fkey FOREIGN KEY (to_scout_year_id) REFERENCES public.scout_years(id),
+  CONSTRAINT scout_year_transitions_executed_by_fkey FOREIGN KEY (executed_by) REFERENCES public.users(id),
+  CONSTRAINT scout_year_transitions_rolled_back_by_fkey FOREIGN KEY (rolled_back_by) REFERENCES public.users(id)
 );

--- a/devdocs/GESTION_ANNEE_SCOUTE.md
+++ b/devdocs/GESTION_ANNEE_SCOUTE.md
@@ -1,0 +1,317 @@
+# Gestion de l'année scoute — proposition d'architecture
+
+**Statut :** phases 1 à 3 implémentées — phases 4 à 6 à faire
+**Date :** 2026-07-31
+
+> **Décisions prises :** vue de compatibilité (§4.2) ; parents sans enfant passés à
+> `inactive` par défaut (§4.5) ; livraison des phases 1 à 3 d'un bloc.
+>
+> **Livré :** `migrations/create_scout_years_and_enrollments.sql`,
+> `services/scoutYear.js`, `routes/scoutYears.js`, helpers `getScoutYear` /
+> `getScoutYearId` dans `middleware/auth.js`. Voir §9 pour l'état exact.
+
+---
+
+## 1. Le problème
+
+À chaque rentrée, une unité doit :
+
+- faire monter les jeunes qui ont atteint l'âge limite (12 ans avant décembre) vers la section suivante ;
+- repartir à zéro pour les points, les présences, les honneurs ;
+- désactiver les parents qui n'ont plus d'enfant inscrit ;
+- **sans jamais rien supprimer** — on veut pouvoir retrouver un ancien jeune ou un ancien parent en consultant une année antérieure ;
+- avec une étape de vérification, pour ne pas sortir un jeune qui reste exceptionnellement ;
+- le tout avec le moins de friction possible.
+
+## 2. Ce que la structure actuelle permet (et ne permet pas)
+
+| Élément | État actuel | Problème pour la transition d'année |
+|---|---|---|
+| `participant_organizations` | (participant_id, organization_id, inscription_date), PK sur les deux premiers | Pas d'année, pas de statut, pas de date de fin. Un jeune est inscrit ou n'existe plus dans l'unité. |
+| `participants` | Pas de `organization_id`, pas de `is_active` | ✅ La personne survit déjà à la sortie de l'unité. |
+| `points` | Journal d'événements (`created_at`), pas d'année | « Réinitialiser » = supprimer des lignes. Perte d'historique. |
+| `attendance`, `honors` | Datés | ✅ Filtrables par plage de dates. |
+| `participant_groups` | PK (participant_id, organization_id) | Une seule sixaine, aucun historique. |
+| `user_organizations` | (user_id, organization_id, role_ids) | Aucun statut : impossible de « désactiver » un parent sans le retirer, donc sans le perdre. |
+| `organization_settings` | Réglage `fiscal_year` `{start_month:9, start_day:1}` | ✅ Base existante pour calculer les bornes d'année. |
+
+**Volumétrie du changement :** `participant_organizations` est jointe à 85 endroits dans `routes/`, mais écrite à 5 seulement (`import.js:272`, `participants.js:286`, `participants.js:619`, `participants.js:803`, `participants.js:1329`).
+
+## 3. Principe directeur
+
+> **Rien n'est supprimé. Ce qui change, c'est l'année à laquelle on regarde.**
+
+L'année scoute devient une dimension de première classe. « Réinitialiser les points » ne veut plus dire *effacer* : ça veut dire *changer d'année*, et les totaux de la nouvelle année partent naturellement à zéro pendant que ceux de l'an dernier restent consultables.
+
+Corollaire : la transition d'année est **réversible**. C'est ce qui autorise le « sans friction » — on peut se permettre un assistant à un clic parce qu'une erreur s'annule.
+
+## 4. Modèle de données proposé
+
+### 4.1 Table `scout_years`
+
+```sql
+CREATE TABLE scout_years (
+  id              serial PRIMARY KEY,
+  organization_id integer NOT NULL REFERENCES organizations(id),
+  label           text NOT NULL,           -- '2026-2027'
+  start_date      date NOT NULL,
+  end_date        date NOT NULL,
+  status          text NOT NULL DEFAULT 'planning'
+                  CHECK (status IN ('planning','active','closed')),
+  closed_at       timestamptz,
+  closed_by       uuid REFERENCES users(id),
+  created_at      timestamptz DEFAULT now(),
+  UNIQUE (organization_id, label)
+);
+
+-- Une seule année active par organisation
+CREATE UNIQUE INDEX scout_years_one_active
+  ON scout_years (organization_id) WHERE status = 'active';
+```
+
+Les bornes sont calculées depuis le réglage `fiscal_year` existant, modifiables à la main.
+
+### 4.2 Inscriptions annuelles + vue de compatibilité
+
+C'est la pièce maîtresse. On transforme la table d'appartenance en table d'inscriptions annuelles, et on recrée une **vue** portant l'ancien nom, filtrée sur l'année active :
+
+```sql
+ALTER TABLE participant_organizations RENAME TO participant_enrollments;
+
+ALTER TABLE participant_enrollments
+  ADD COLUMN scout_year_id integer REFERENCES scout_years(id),
+  ADD COLUMN status text NOT NULL DEFAULT 'active'
+      CHECK (status IN ('active','graduated','left','transferred')),
+  ADD COLUMN ended_on date,
+  ADD COLUMN exit_reason text,
+  ADD COLUMN exception_note text,          -- « reste malgré l'âge : ... »
+  ADD COLUMN transferred_to_organization_id integer REFERENCES organizations(id);
+
+-- Nouvelle PK
+ALTER TABLE participant_enrollments DROP CONSTRAINT participant_organizations_pkey;
+ALTER TABLE participant_enrollments
+  ADD PRIMARY KEY (participant_id, organization_id, scout_year_id);
+
+CREATE VIEW participant_organizations AS
+  SELECT pe.participant_id, pe.organization_id, pe.inscription_date
+  FROM participant_enrollments pe
+  JOIN scout_years sy ON sy.id = pe.scout_year_id
+  WHERE sy.status = 'active' AND pe.status = 'active';
+```
+
+**Effet :** les 85 jointures existantes continuent de fonctionner sans modification, et signifient désormais « l'effectif de l'année courante ». Seuls les 5 sites d'écriture doivent être réécrits vers `participant_enrollments` (une vue sur jointure n'est pas modifiable dans PostgreSQL — c'est voulu, ça force l'explicite en écriture).
+
+Ensuite, on rend *progressivement* explicites les endpoints où l'année a du sens (effectif, points, présences, honneurs, rapports, tableaux de bord), via un paramètre `?scout_year_id=`. Le reste continue de tourner sur l'année active.
+
+### 4.3 Points
+
+```sql
+ALTER TABLE points ADD COLUMN scout_year_id integer REFERENCES scout_years(id);
+CREATE INDEX points_year_idx ON points (organization_id, scout_year_id, participant_id);
+```
+
+Backfill par plage de dates, puis colonne obligatoire à l'insertion. Les totaux sont toujours calculés `WHERE scout_year_id = <année consultée>`. **Aucune ligne n'est jamais supprimée** ; le « reset » est un effet de bord du changement d'année.
+
+Pour `attendance` et `honors`, pas de nouvelle colonne : ils sont intrinsèquement datés, on joint sur `scout_years.start_date/end_date`. (Décision à valider — voir §8.)
+
+### 4.4 Sixaines annuelles
+
+Même traitement que les inscriptions :
+
+```sql
+ALTER TABLE participant_groups ADD COLUMN scout_year_id integer REFERENCES scout_years(id);
+-- PK → (participant_id, organization_id, scout_year_id)
+```
+
+Les sixaines (`groups`) survivent d'une année à l'autre ; les affectations et les rôles de sizainier/second sont remis à plat chaque année, avec l'option « reconduire les affectations de l'an dernier » dans l'assistant.
+
+### 4.5 Statut des comptes parents
+
+```sql
+ALTER TABLE user_organizations
+  ADD COLUMN status text NOT NULL DEFAULT 'active'
+      CHECK (status IN ('active','inactive','alumni')),
+  ADD COLUMN deactivated_at timestamptz,
+  ADD COLUMN deactivated_reason text,
+  ADD COLUMN last_active_scout_year_id integer REFERENCES scout_years(id);
+```
+
+Trois états, et la distinction compte :
+
+- **active** — accès normal ;
+- **inactive** — plus d'accès à l'unité, mais le compte, les liens `guardian_users` / `participant_guardians` et tout l'historique restent intacts ; retrouvable en consultant une année antérieure ; réactivable en un clic si l'enfant revient ;
+- **alumni** — variante optionnelle : pas d'accès aux données de l'unité, mais reste joignable pour les communications de type « nouvelles du groupe » (utile pour le lien que tu veux garder).
+
+**Points de vigilance dans le code :**
+
+1. `middleware/auth.js:240` vérifie l'appartenance à l'organisation → doit rejeter `status <> 'active'` avec un message clair (« votre compte n'est plus rattaché à cette unité »), et non un 403 générique.
+2. Le chargement des permissions (`auth.js:322`) et des rôles (`auth.js:338`) doit filtrer sur `status = 'active'`.
+3. `routes/announcements.js:86,148` — ne pas envoyer aux comptes inactifs (sauf ciblage « alumni » explicite).
+4. **Ne jamais désactiver un utilisateur qui détient un rôle non-parent** (animateur, admin, trésorier) dans l'unité. Règle absolue de l'assistant.
+
+### 4.6 Journal des transitions (le filet de sécurité)
+
+```sql
+CREATE TABLE scout_year_transitions (
+  id                serial PRIMARY KEY,
+  organization_id   integer NOT NULL REFERENCES organizations(id),
+  from_scout_year_id integer REFERENCES scout_years(id),
+  to_scout_year_id   integer NOT NULL REFERENCES scout_years(id),
+  executed_at       timestamptz NOT NULL DEFAULT now(),
+  executed_by       uuid NOT NULL REFERENCES users(id),
+  summary           jsonb NOT NULL,   -- compteurs affichés dans le rapport
+  changeset         jsonb NOT NULL,   -- tout ce qui a changé, pour l'annulation
+  rolled_back_at    timestamptz,
+  rolled_back_by    uuid REFERENCES users(id)
+);
+```
+
+`changeset` contient la liste exacte des inscriptions créées/clôturées, des comptes désactivés, des affectations de sixaines — assez pour rejouer l'inverse. Annulation possible tant que la nouvelle année n'a pas de données saisies (ou dans une fenêtre de N jours, au choix).
+
+## 5. L'assistant de transition
+
+Route SPA : `spa/modules/scout-year/`. Permission : `scout_year.manage` (nouvelle), sinon `organization.manage`.
+
+### Étape 1 — Prévisualisation de l'effectif
+
+`GET /api/v1/scout-years/transition/preview`
+
+Le serveur propose une disposition pour **chaque** jeune :
+
+| Disposition | Règle |
+|---|---|
+| `graduating` | atteint l'âge limite avant la date pivot |
+| `returning` | tout le reste |
+
+Affichage : les sortants en premier, cases déjà cochées, un bouton **« Tout accepter »**. Pour chaque sortant, une bascule « reste exceptionnellement » qui demande une note courte (facultative) et le reclasse en `returning` avec `exception_note`. Pour chaque montant, option « transféré vers → <unité> » si l'organisation a des unités sœurs (`organization_local_groups` existe déjà).
+
+Le cas nominal, c'est : ouvrir, survoler la liste, cliquer une fois. La vérification que tu demandes est là, mais elle ne coûte rien quand il n'y a pas d'exception.
+
+### Étape 2 — Conséquences
+
+Calculées à partir des choix de l'étape 1, chacune débrayable :
+
+- **N comptes parents à désactiver** — liste nominative, avec la raison (« plus d'enfant inscrit »), décochable individuellement. Les parents qui sont aussi animateurs sont exclus automatiquement et signalés.
+- **Points** — « les totaux de 2025-2026 sont archivés (aperçu du classement final), la nouvelle année démarre à zéro ».
+- **Sixaines** — remettre à plat / reconduire les affectations.
+- **Fiches santé et inscriptions** — marquer à renouveler (voir §6).
+- **Animateurs** — liste de l'équipe pour revue manuelle : qui part, qui reste. Pas d'automatisme ici, c'est trop sensible.
+
+### Étape 3 — Confirmation
+
+Un seul écran récapitulatif, une transaction unique côté serveur. `POST /api/v1/scout-years/transition`.
+
+### Étape 4 — Rapport
+
+Compteurs, lien d'export, et un bouton **« Annuler cette transition »** bien visible. `POST /api/v1/scout-years/transitions/:id/rollback`.
+
+### Configuration de la règle d'âge
+
+Réglage `year_transition` dans `organization_settings` :
+
+```json
+{
+  "max_age": 12,
+  "age_reference_date": "12-31",
+  "auto_graduate": true,
+  "min_age": 7
+}
+```
+
+`age_reference_date` = 31 décembre de l'année civile où démarre l'année scoute — c'est ta règle « 12 ans ou l'auront avant décembre ». Les bornes doivent pouvoir varier par section (louveteaux 7-11, éclaireurs 12-14), donc le réglage est per-organisation, chaque organisation ayant déjà son `program_section`.
+
+## 6. Ce à quoi il faut penser aussi
+
+Ta liste couvre l'essentiel ; voici ce qui viendrait mordre plus tard.
+
+**À traiter dans la transition :**
+
+- **Fiches santé / formulaires d'inscription** (`form_submissions`) — allergies, contacts d'urgence, autorisations : ces données **périment** et doivent être re-collectées chaque année. C'est le plus important des oubliés, à la fois pour la sécurité et pour la conformité. Ajouter `scout_year_id` à `form_submissions` et un état « à renouveler » sur le tableau de bord parent.
+- **Autorisations médicales** (`medication_treatment_authorizations`, `participant_medications`) — expirent avec l'année, doivent être re-signées.
+- **Frais et paiements** (`participant_fees`, `payment_plans`) — nouveau cycle de cotisation ; les soldes impayés de l'an dernier ne doivent pas disparaître de la vue du trésorier.
+- **Rôles de sixaine** (`first_leader`, `second_leader`) — remis à zéro.
+- **Abonnements push** (`subscribers`) des familles parties — à purger, sinon elles reçoivent les notifications de l'unité.
+- **`year_plans`** (planificateur annuel, déjà doté d'un `is_active`) — à rattacher au `scout_year_id` plutôt que de vivre en parallèle.
+
+**À ne PAS réinitialiser (acquis cumulatifs) :**
+
+- **Badges** (`badge_progress`) et **progression OAS** (`participant_oas_competency`, `participant_oas_stage_award`, `participant_top_award_progress`) — un badge obtenu reste obtenu. Question ouverte : les progressions *en cours* se reportent-elles à l'année suivante ? (Oui, à mon avis, mais à confirmer.)
+
+**Transverses :**
+
+- **Sélecteur d'année dans l'interface** — un menu dans l'en-tête. Consulter une année close bascule l'app en **lecture seule** avec un bandeau explicite (« Vous consultez 2024-2025 — archives »). C'est le mécanisme par lequel tu « retrouves » un ancien jeune ou un ancien parent.
+- **Rapports et exports** — doivent tous porter l'année consultée, et exclure les archives par défaut.
+- **Loi 25 / conservation** — garder indéfiniment les coordonnées de familles parties demande une politique de conservation explicite (durée, purge, mention dans la politique de confidentialité). Un réglage `data_retention_years` et une purge assistée seraient à prévoir, même si ce n'est pas dans la première livraison. C'est le pendant juridique du « on ne supprime rien ».
+
+## 7. Découpage en phases
+
+| Phase | Contenu | Utilisable seule ? |
+|---|---|---|
+| **1. Socle** | `scout_years`, `participant_enrollments` + vue de compatibilité, réécriture des 5 sites d'écriture, backfill de l'année en cours, helper `getScoutYearId(req, pool)` | Oui — aucun changement visible, mais tout le reste en dépend |
+| **2. Points annuels** | `points.scout_year_id`, backfill, filtrage des totaux | Oui — le « reset » devient possible manuellement |
+| **3. Statut des comptes** | `user_organizations.status`, application dans `auth.js` et `announcements.js`, écran d'activation/désactivation manuelle | Oui |
+| **4. Assistant** | Preview / execute / rollback + module SPA + `scout_year_transitions` | C'est la livraison qui rend le tout « sans friction » |
+| **5. Consultation historique** | Sélecteur d'année, mode lecture seule, endpoints year-aware (rapports, tableaux de bord) | C'est ce qui sert le « garder contact » |
+| **6. Renouvellements** | `form_submissions.scout_year_id`, fiches santé et autorisations à renouveler, cycle de frais | Peut suivre |
+
+Les phases 1 à 3 sont surtout de la migration SQL et des ajustements ciblés. La phase 4 est la plus grosse en volume d'interface. La phase 5 est celle qui touche le plus de fichiers (les endpoints de lecture, un par un), mais elle est incrémentale et sans risque grâce à la vue de compatibilité.
+
+## 8. Décisions restantes
+
+1. ~~Parents sans enfant : `inactive` ou `alumni` ?~~ → **`inactive`** par défaut. Les trois statuts existent en base ; `alumni` est disponible mais aucun automatisme ne l'attribue.
+2. **Présences et honneurs : colonne `scout_year_id` ou filtrage par plage de dates ?** Non tranché, non implémenté. Ces deux tables sont toujours interrogées sans borne d'année (§9).
+3. **Portée du rollback :** annulation possible indéfiniment tant que la nouvelle année est vide, ou fenêtre fixe de N jours ? La table `scout_year_transitions` enregistre déjà le nécessaire ; l'endpoint reste à écrire.
+4. **Progressions de badges/OAS en cours :** se reportent à la nouvelle année, ou repartent à zéro avec l'historique conservé ? Aucun changement fait : elles se reportent (comportement actuel).
+5. **Transfert vers une unité sœur :** la colonne `transferred_to_organization_id` existe, aucune interface ne l'alimente.
+
+---
+
+## 9. État d'implémentation
+
+### Fait
+
+**Base de données** — `migrations/create_scout_years_and_enrollments.sql`, transactionnel et ré-exécutable :
+
+- `scout_years` (une seule année active par organisation, contrainte d'exclusion `btree_gist` contre le chevauchement) ;
+- fonction `scout_year_for_date()` dérivant les bornes du réglage `fiscal_year` existant ;
+- **historique amorcé** : les années sont créées depuis la plus ancienne trace d'activité de l'unité jusqu'à aujourd'hui, toutes `closed` sauf l'année courante ;
+- `participant_organizations` renommée `participant_enrollments` (+ `scout_year_id`, `status`, `ended_on`, `exit_reason`, `exception_note`, `transferred_to_organization_id`), PK à trois colonnes ;
+- **vue `participant_organizations`** filtrée sur l'année active : les 85 jointures existantes fonctionnent sans modification ;
+- `points.scout_year_id` + rétro-remplissage par date + trigger `points_set_scout_year_trigger` qui estampille tout insert (les 8 sites d'écriture restent inchangés, les imports et le SQL manuel sont couverts aussi) ;
+- **vue `active_year_points`** pour les agrégats « score de la saison » ;
+- `user_organizations.status` (`active` / `inactive` / `alumni`) + `deactivated_at`, `deactivated_reason`, `last_active_scout_year_id` ;
+- `scout_year_transitions` (journal + `changeset` JSONB pour une annulation future) ;
+- permissions `scout_year.view` et `scout_year.manage`.
+
+La migration **ne supprime jamais de ligne** : si une inscription ne peut être rattachée à une année, elle lève une exception et annule tout plutôt que d'effacer.
+
+**Invariant clé** — l'année active contient toujours aujourd'hui. `openNextScoutYear` ramène la date de début à aujourd'hui quand la transition est lancée en avance (les points du 26 au 31 août tombent alors dans la nouvelle année, pas dans celle qu'on vient de fermer) et ré-estampille les points déjà attribués quand elle est lancée en retard.
+
+**Backend**
+
+- `services/scoutYear.js` : bornes d'année, année active, ouverture de l'année suivante, détection des comptes sans enfant inscrit ;
+- `middleware/auth.js` : `getScoutYear(req, pool)` / `getScoutYearId(req, pool)` (paramètre `?scout_year_id=` ou en-tête `x-scout-year-id`), et **statut de membership appliqué** dans `requirePermission`, `requireOrganizationRole` et `getUserDataScope` ;
+- `routes/auth.js` : connexion et validation 2FA refusent un membership non actif avec `membership_inactive` ;
+- `routes/announcements.js` : les comptes désactivés ne reçoivent plus courriels ni notifications push ;
+- `routes/scoutYears.js` monté sur `/api/v1/scout-years` :
+  - `GET /` — historique des années,
+  - `GET /active` — année active,
+  - `GET /transition/preview` — **l'étape de vérification** : disposition proposée pour chaque jeune, comptes parents concernés, aucun effet de bord,
+  - `POST /transition` — exécution en une transaction, avec exceptions nominatives,
+  - `GET /memberships/without-child`, `PATCH /memberships/:id/status` — contrôle manuel, réactivation incluse ;
+- les 5 sites d'écriture pointent sur `participant_enrollments` ; `DELETE /api/v1/participants/:id` **ferme** l'inscription (`status = 'left'`) au lieu de supprimer ;
+- les agrégats de points lisent `active_year_points`, et les requêtes qui énumèrent une sixaine sont jointes à l'effectif pour ne plus compter ni récompenser un jeune parti.
+
+**Garde-fous de la transition** — un compte portant un rôle non-parent (animateur, admin) n'est jamais désactivé, quoi qu'envoie le client : la règle est dans le `UPDATE` lui-même, pas seulement dans l'interface. Un jeune sans date de naissance n'est jamais sorti automatiquement, il est marqué `needs_review`.
+
+**Vérification** — migration exécutée et ré-exécutée sur un PostgreSQL 16 jetable, transition complète jouée bout en bout contre les vraies routes (28 assertions), suite du projet à 815 tests verts, 8 scripts de lint au vert.
+
+### Pas fait
+
+- **Interface** : aucun module SPA. L'assistant décrit au §5 n'existe que côté API ; il faut encore `spa/modules/scout-year/` et les clés i18n.
+- **Annulation** : `POST /transitions/:id/rollback` n'existe pas. Le journal contient déjà de quoi la rejouer.
+- **Sélecteur d'année et lecture seule** (§4.3, phase 5) : seul `GET /api/v1/points` accepte `?scout_year_id=`. Les rapports, tableaux de bord et présences répondent toujours pour l'année active uniquement.
+- **Présences et honneurs** non bornés par l'année (décision 2 ci-dessus). Concrètement, un décompte d'honneurs cumulé traverse encore les années.
+- **Sixaines annuelles** (§4.4) : `participant_groups` n'a pas de `scout_year_id`. Les affectations survivent à la transition et il n'y a pas d'historique par année. Les lignes des jeunes partis restent mais sont désormais filtrées à la lecture.
+- **Renouvellements** (§6, phase 6) : fiches santé, autorisations médicales, frais — rien n'a changé, une fiche de l'an dernier reste considérée valide.
+- **Purge / conservation** : aucune politique de rétention implémentée.

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -2,6 +2,7 @@
 const winston = require('winston');
 const { OrganizationNotFoundError, respondWithOrganizationFallback } = require('../utils/api-helpers');
 const { requireJWTSecret, verifyJWTToken } = require('../utils/jwt-config');
+const scoutYearService = require('../services/scoutYear');
 
 // Configure logger for auth middleware
 const logger = winston.createLogger({
@@ -200,6 +201,42 @@ exports.getOrganizationId = async (req, pool) => {
 };
 
 /**
+ * Get the scout year a request is about
+ *
+ * Defaults to the organization's active year. A past year can be consulted with
+ * `?scout_year_id=` or the `x-scout-year-id` header; requests for a year that
+ * belongs to another organization are rejected.
+ *
+ * @param {Object} req - Express request object
+ * @param {Object} pool - Database connection pool
+ * @returns {Promise<Object>} Scout year row ({ id, label, start_date, end_date, status })
+ *
+ * @example
+ * const scoutYear = await getScoutYear(req, pool);
+ * const rows = await pool.query(
+ *   'SELECT * FROM points WHERE organization_id = $1 AND scout_year_id = $2',
+ *   [organizationId, scoutYear.id]
+ * );
+ */
+exports.getScoutYear = async (req, pool) => {
+  const organizationId = await exports.getOrganizationId(req, pool);
+  const requested = req.query?.scout_year_id ?? req.headers['x-scout-year-id'] ?? null;
+  return scoutYearService.resolveScoutYear(pool, organizationId, requested);
+};
+
+/**
+ * Get the ID of the scout year a request is about
+ *
+ * @param {Object} req - Express request object
+ * @param {Object} pool - Database connection pool
+ * @returns {Promise<number>} Scout year ID
+ */
+exports.getScoutYearId = async (req, pool) => {
+  const scoutYear = await exports.getScoutYear(req, pool);
+  return scoutYear.id;
+};
+
+/**
  * Verify user belongs to organization with specific role
  * Use as middleware in routes that require organization membership
  *
@@ -237,7 +274,7 @@ exports.requireOrganizationRole = (allowedRoles = null) => {
 
       // Verify user belongs to organization
       const result = await pool.query(
-        'SELECT role FROM user_organizations WHERE user_id = $1 AND organization_id = $2',
+        'SELECT role, status FROM user_organizations WHERE user_id = $1 AND organization_id = $2',
         [req.user.id, organizationId]
       );
 
@@ -245,6 +282,16 @@ exports.requireOrganizationRole = (allowedRoles = null) => {
         return res.status(403).json({
           success: false,
           message: 'User not a member of this organization'
+        });
+      }
+
+      // Deactivated memberships (e.g. a parent with no enrolled child) keep their
+      // account and history but lose access to the organization.
+      if (result.rows[0].status !== 'active') {
+        return res.status(403).json({
+          success: false,
+          message: 'This account is no longer active in this organization',
+          membershipStatus: result.rows[0].status
         });
       }
 
@@ -324,6 +371,7 @@ exports.requirePermission = (...permissions) => {
         JOIN role_permissions rp ON rp.role_id = role_id_text::integer
         JOIN permissions p ON p.id = rp.permission_id
         WHERE uo.user_id = $1 AND uo.organization_id = $2
+          AND uo.status = 'active'
       `;
 
       const result = await pool.query(permissionsQuery, [req.user.id, organizationId]);
@@ -339,6 +387,7 @@ exports.requirePermission = (...permissions) => {
         CROSS JOIN LATERAL jsonb_array_elements_text(uo.role_ids) AS role_id_text
         JOIN roles r ON r.id = role_id_text::integer
         WHERE uo.user_id = $1 AND uo.organization_id = $2
+          AND uo.status = 'active'
       `;
 
       const rolesResult = await pool.query(rolesQuery, [req.user.id, organizationId]);
@@ -351,6 +400,26 @@ exports.requirePermission = (...permissions) => {
 
       if (!hasAllPermissions) {
         const missingPermissions = requiredPermissions.filter(perm => !userPermissions.includes(perm));
+
+        // A deactivated membership resolves to zero permissions. Say so, instead
+        // of reporting every permission as missing.
+        const membership = await pool.query(
+          'SELECT status FROM user_organizations WHERE user_id = $1 AND organization_id = $2',
+          [req.user.id, organizationId]
+        );
+        const membershipStatus = membership.rows[0]?.status;
+
+        if (membershipStatus && membershipStatus !== 'active') {
+          logger.info(`Inactive membership blocked for user ${req.user.id} (status ${membershipStatus})`);
+          return res.status(403).json({
+            success: false,
+            message: 'This account is no longer active in this organization',
+            membershipStatus,
+            required: requiredPermissions,
+            missing: missingPermissions
+          });
+        }
+
         logger.info(`Permission denied for user ${req.user.id}: missing ${missingPermissions.join(', ')}`);
 
         return res.status(403).json({
@@ -535,6 +604,7 @@ exports.getUserDataScope = async (req, pool) => {
       CROSS JOIN LATERAL jsonb_array_elements_text(uo.role_ids) AS role_id_text
       JOIN roles r ON r.id = role_id_text::integer
       WHERE uo.user_id = $1 AND uo.organization_id = $2
+        AND uo.status = 'active'
       ORDER BY r.data_scope DESC
     `, [req.user.id, organizationId]);
 

--- a/migrations/create_scout_years_and_enrollments.sql
+++ b/migrations/create_scout_years_and_enrollments.sql
@@ -1,0 +1,485 @@
+-- Migration: Scout year management (phases 1-3)
+--
+-- Introduces the scout year as a first-class dimension so that a year transition
+-- never deletes data:
+--   * participant_organizations becomes participant_enrollments, scoped per year,
+--     and is replaced by a read-only view of the same name filtered on the active
+--     year so the ~85 existing read sites keep working unchanged.
+--   * points gain a scout_year_id, so "resetting the points" is a side effect of
+--     opening a new year rather than a DELETE.
+--   * user_organizations gain a status, so a parent with no enrolled child can be
+--     deactivated without losing the account, its guardian links or its history.
+--
+-- Safe to run more than once.
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1. Scout years
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS scout_years (
+  id              serial PRIMARY KEY,
+  organization_id integer NOT NULL REFERENCES organizations(id),
+  label           text NOT NULL,
+  start_date      date NOT NULL,
+  end_date        date NOT NULL,
+  status          text NOT NULL DEFAULT 'planning'
+                    CHECK (status IN ('planning', 'active', 'closed')),
+  closed_at       timestamptz,
+  closed_by       uuid REFERENCES users(id),
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT scout_years_label_unique UNIQUE (organization_id, label),
+  CONSTRAINT scout_years_dates_ordered CHECK (end_date > start_date)
+);
+
+-- At most one active year per organization.
+CREATE UNIQUE INDEX IF NOT EXISTS scout_years_one_active_per_org
+  ON scout_years (organization_id)
+  WHERE status = 'active';
+
+CREATE INDEX IF NOT EXISTS scout_years_org_range_idx
+  ON scout_years (organization_id, start_date, end_date);
+
+-- Years of a same organization must never overlap: the "which year does this
+-- date belong to" lookup has to be unambiguous. Requires btree_gist; skipped
+-- with a warning if the extension cannot be installed.
+DO $$
+BEGIN
+  BEGIN
+    CREATE EXTENSION IF NOT EXISTS btree_gist;
+  EXCEPTION WHEN OTHERS THEN
+    RAISE WARNING 'btree_gist unavailable (%), skipping the scout_years overlap constraint', SQLERRM;
+    RETURN;
+  END;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'scout_years_no_overlap'
+  ) THEN
+    ALTER TABLE scout_years
+      ADD CONSTRAINT scout_years_no_overlap
+      EXCLUDE USING gist (
+        organization_id WITH =,
+        daterange(start_date, end_date, '[]') WITH &&
+      );
+  END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Year boundary helper
+--
+-- Derives the scout year containing a given date from the organization's
+-- existing `fiscal_year` setting (defaults to September 1st).
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION scout_year_for_date(
+  p_organization_id integer,
+  p_on_date date
+)
+RETURNS TABLE (year_label text, year_start date, year_end date)
+LANGUAGE plpgsql
+STABLE
+AS $$
+DECLARE
+  v_setting    jsonb;
+  v_month      integer := 9;
+  v_day        integer := 1;
+  v_start_year integer;
+  v_start      date;
+BEGIN
+  SELECT setting_value
+    INTO v_setting
+    FROM organization_settings
+   WHERE organization_id = p_organization_id
+     AND setting_key = 'fiscal_year'
+   LIMIT 1;
+
+  IF v_setting IS NOT NULL THEN
+    v_month := COALESCE(NULLIF(v_setting->>'start_month', '')::integer, 9);
+    v_day   := COALESCE(NULLIF(v_setting->>'start_day', '')::integer, 1);
+  END IF;
+
+  -- Guard against an out-of-range configuration rather than raising.
+  IF v_month < 1 OR v_month > 12 THEN
+    v_month := 9;
+  END IF;
+  IF v_day < 1 OR v_day > 28 THEN
+    v_day := LEAST(GREATEST(v_day, 1), 28);
+  END IF;
+
+  v_start_year := EXTRACT(YEAR FROM p_on_date)::integer;
+  v_start := make_date(v_start_year, v_month, v_day);
+
+  IF p_on_date < v_start THEN
+    v_start_year := v_start_year - 1;
+    v_start := make_date(v_start_year, v_month, v_day);
+  END IF;
+
+  year_label := v_start_year::text || '-' || (v_start_year + 1)::text;
+  year_start := v_start;
+  year_end   := (v_start + INTERVAL '1 year' - INTERVAL '1 day')::date;
+  RETURN NEXT;
+END;
+$$;
+
+COMMENT ON FUNCTION scout_year_for_date(integer, date) IS
+  'Scout year label and boundaries containing p_on_date, based on the organization fiscal_year setting.';
+
+-- ---------------------------------------------------------------------------
+-- 3. Seed the year history
+--
+-- Creates every year from the organization's earliest known activity up to the
+-- current one, so past data is browsable from day one. Only the current year is
+-- marked active; earlier ones are closed.
+-- ---------------------------------------------------------------------------
+
+DO $$
+DECLARE
+  v_org           RECORD;
+  v_bounds        RECORD;
+  v_first_date    date;
+  v_cursor_date   date;
+  v_current_label text;
+BEGIN
+  FOR v_org IN SELECT id FROM organizations LOOP
+    SELECT * INTO v_bounds FROM scout_year_for_date(v_org.id, CURRENT_DATE);
+    v_current_label := v_bounds.year_label;
+
+    SELECT LEAST(
+             COALESCE((SELECT MIN(inscription_date) FROM participant_organizations
+                        WHERE organization_id = v_org.id), CURRENT_DATE),
+             COALESCE((SELECT MIN(created_at)::date FROM points
+                        WHERE organization_id = v_org.id), CURRENT_DATE),
+             COALESCE((SELECT MIN(date) FROM attendance
+                        WHERE organization_id = v_org.id), CURRENT_DATE),
+             COALESCE((SELECT MIN(date) FROM honors
+                        WHERE organization_id = v_org.id), CURRENT_DATE)
+           )
+      INTO v_first_date;
+
+    v_first_date := LEAST(COALESCE(v_first_date, CURRENT_DATE), CURRENT_DATE);
+    v_cursor_date := v_first_date;
+
+    LOOP
+      SELECT * INTO v_bounds FROM scout_year_for_date(v_org.id, v_cursor_date);
+
+      INSERT INTO scout_years (organization_id, label, start_date, end_date, status)
+      VALUES (
+        v_org.id,
+        v_bounds.year_label,
+        v_bounds.year_start,
+        v_bounds.year_end,
+        CASE WHEN v_bounds.year_label = v_current_label THEN 'active' ELSE 'closed' END
+      )
+      ON CONFLICT (organization_id, label) DO NOTHING;
+
+      EXIT WHEN v_bounds.year_label = v_current_label;
+      v_cursor_date := v_bounds.year_end + 1;
+    END LOOP;
+  END LOOP;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 4. Year-scoped participant enrollments
+-- ---------------------------------------------------------------------------
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+     WHERE table_schema = 'public' AND table_name = 'participant_organizations'
+       AND table_type = 'BASE TABLE'
+  ) THEN
+    ALTER TABLE participant_organizations RENAME TO participant_enrollments;
+  END IF;
+END;
+$$;
+
+ALTER TABLE participant_enrollments
+  ADD COLUMN IF NOT EXISTS scout_year_id integer REFERENCES scout_years(id),
+  ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'active',
+  ADD COLUMN IF NOT EXISTS ended_on date,
+  ADD COLUMN IF NOT EXISTS exit_reason text,
+  ADD COLUMN IF NOT EXISTS exception_note text,
+  ADD COLUMN IF NOT EXISTS transferred_to_organization_id integer REFERENCES organizations(id),
+  ADD COLUMN IF NOT EXISTS created_at timestamptz NOT NULL DEFAULT now();
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'participant_enrollments_status_check'
+  ) THEN
+    ALTER TABLE participant_enrollments
+      ADD CONSTRAINT participant_enrollments_status_check
+      CHECK (status IN ('active', 'graduated', 'left', 'transferred'));
+  END IF;
+END;
+$$;
+
+-- Existing rows are the current roster: attach them to the active year.
+UPDATE participant_enrollments pe
+   SET scout_year_id = sy.id
+  FROM scout_years sy
+ WHERE sy.organization_id = pe.organization_id
+   AND sy.status = 'active'
+   AND pe.scout_year_id IS NULL;
+
+-- Any leftover (organization without an active year) falls back to the most
+-- recent known year so the NOT NULL constraint below can be applied safely.
+UPDATE participant_enrollments pe
+   SET scout_year_id = sy.id
+  FROM (
+    SELECT DISTINCT ON (organization_id) organization_id, id
+      FROM scout_years
+     ORDER BY organization_id, start_date DESC
+  ) sy
+ WHERE sy.organization_id = pe.organization_id
+   AND pe.scout_year_id IS NULL;
+
+-- Nothing is ever deleted by this migration: if a row still cannot be attached
+-- to a year (an enrollment pointing at a missing organization), abort and let an
+-- operator look at it rather than dropping the record.
+DO $$
+DECLARE
+  v_orphans integer;
+BEGIN
+  SELECT COUNT(*) INTO v_orphans
+    FROM participant_enrollments
+   WHERE scout_year_id IS NULL;
+
+  IF v_orphans > 0 THEN
+    RAISE EXCEPTION
+      'Cannot assign a scout year to % participant_enrollments row(s). Check for enrollments referencing a missing organization before re-running.',
+      v_orphans;
+  END IF;
+END;
+$$;
+
+ALTER TABLE participant_enrollments ALTER COLUMN scout_year_id SET NOT NULL;
+
+-- Repoint the primary key so a participant can hold one enrollment per year.
+DO $$
+DECLARE
+  v_pkey text;
+BEGIN
+  SELECT conname INTO v_pkey
+    FROM pg_constraint
+   WHERE conrelid = 'participant_enrollments'::regclass AND contype = 'p';
+
+  IF v_pkey IS NOT NULL AND v_pkey <> 'participant_enrollments_pkey' THEN
+    EXECUTE format('ALTER TABLE participant_enrollments RENAME CONSTRAINT %I TO participant_enrollments_pkey', v_pkey);
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'participant_enrollments'::regclass
+       AND contype = 'p'
+       AND array_length(conkey, 1) = 2
+  ) THEN
+    ALTER TABLE participant_enrollments DROP CONSTRAINT participant_enrollments_pkey;
+    ALTER TABLE participant_enrollments
+      ADD CONSTRAINT participant_enrollments_pkey
+      PRIMARY KEY (participant_id, organization_id, scout_year_id);
+  END IF;
+END;
+$$;
+
+CREATE INDEX IF NOT EXISTS participant_enrollments_year_idx
+  ON participant_enrollments (organization_id, scout_year_id, status);
+
+CREATE INDEX IF NOT EXISTS participant_enrollments_participant_idx
+  ON participant_enrollments (participant_id);
+
+-- Compatibility view: every existing read site keeps working and now means
+-- "roster of the active scout year". Writes must target participant_enrollments
+-- directly (a view over a join is not auto-updatable, which is intentional).
+CREATE OR REPLACE VIEW participant_organizations AS
+  SELECT pe.participant_id,
+         pe.organization_id,
+         pe.inscription_date
+    FROM participant_enrollments pe
+    JOIN scout_years sy ON sy.id = pe.scout_year_id
+   WHERE sy.status = 'active'
+     AND pe.status = 'active';
+
+COMMENT ON VIEW participant_organizations IS
+  'Read-only compatibility view over participant_enrollments, restricted to the active scout year. Write to participant_enrollments instead.';
+
+-- ---------------------------------------------------------------------------
+-- 5. Year-scoped points
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE points
+  ADD COLUMN IF NOT EXISTS scout_year_id integer REFERENCES scout_years(id);
+
+-- Back-fill from the award date.
+UPDATE points p
+   SET scout_year_id = sy.id
+  FROM scout_years sy
+ WHERE sy.organization_id = p.organization_id
+   AND COALESCE(p.created_at, now())::date BETWEEN sy.start_date AND sy.end_date
+   AND p.scout_year_id IS NULL;
+
+-- Anything outside a known range (or predating the seeded history) lands on the
+-- organization's earliest year rather than staying invisible.
+UPDATE points p
+   SET scout_year_id = sy.id
+  FROM (
+    SELECT DISTINCT ON (organization_id) organization_id, id
+      FROM scout_years
+     ORDER BY organization_id, start_date ASC
+  ) sy
+ WHERE sy.organization_id = p.organization_id
+   AND p.scout_year_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS points_scout_year_idx
+  ON points (organization_id, scout_year_id, participant_id);
+
+CREATE INDEX IF NOT EXISTS points_scout_year_group_idx
+  ON points (organization_id, scout_year_id, group_id);
+
+-- Stamp every future insert. Points are written from eight call sites across
+-- five route files (attendance, honors, badges, points); a trigger keeps the
+-- rule in one place and also covers imports and manual SQL. Back-dated rows
+-- (an honor recorded for a past date) land in the year containing that date.
+--
+-- This relies on the invariant that the active year always contains today:
+-- services/scoutYear.js clamps the boundaries when a year is activated ahead of
+-- its nominal start, so points awarded between an early transition and
+-- September 1st land in the newly opened year, not the closed one.
+CREATE OR REPLACE FUNCTION points_set_scout_year()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.scout_year_id IS NOT NULL OR NEW.organization_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT id INTO NEW.scout_year_id
+    FROM scout_years
+   WHERE organization_id = NEW.organization_id
+     AND COALESCE(NEW.created_at, now())::date BETWEEN start_date AND end_date
+   LIMIT 1;
+
+  IF NEW.scout_year_id IS NULL THEN
+    SELECT id INTO NEW.scout_year_id
+      FROM scout_years
+     WHERE organization_id = NEW.organization_id
+       AND status = 'active'
+     LIMIT 1;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS points_set_scout_year_trigger ON points;
+CREATE TRIGGER points_set_scout_year_trigger
+  BEFORE INSERT ON points
+  FOR EACH ROW
+  EXECUTE FUNCTION points_set_scout_year();
+
+-- Companion view for the many aggregate queries that mean "this season's
+-- score". Endpoints that let the user consult an archived year query `points`
+-- directly with an explicit scout_year_id instead.
+CREATE OR REPLACE VIEW active_year_points AS
+  SELECT p.id,
+         p.participant_id,
+         p.group_id,
+         p.value,
+         p.created_at,
+         p.organization_id,
+         p.honor_id,
+         p.scout_year_id
+    FROM points p
+    JOIN scout_years sy ON sy.id = p.scout_year_id
+   WHERE sy.status = 'active';
+
+COMMENT ON VIEW active_year_points IS
+  'Read-only view over points, restricted to each organization active scout year.';
+
+-- ---------------------------------------------------------------------------
+-- 6. Membership status (parents kept, not deleted)
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE user_organizations
+  ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'active',
+  ADD COLUMN IF NOT EXISTS deactivated_at timestamptz,
+  ADD COLUMN IF NOT EXISTS deactivated_reason text,
+  ADD COLUMN IF NOT EXISTS last_active_scout_year_id integer REFERENCES scout_years(id);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'user_organizations_status_check'
+  ) THEN
+    ALTER TABLE user_organizations
+      ADD CONSTRAINT user_organizations_status_check
+      CHECK (status IN ('active', 'inactive', 'alumni'));
+  END IF;
+END;
+$$;
+
+CREATE INDEX IF NOT EXISTS user_organizations_status_idx
+  ON user_organizations (organization_id, status);
+
+-- ---------------------------------------------------------------------------
+-- 7. Transition log
+--
+-- Records what each transition changed. Used for traceability today, and it is
+-- what a future rollback will replay in reverse.
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS scout_year_transitions (
+  id                 serial PRIMARY KEY,
+  organization_id    integer NOT NULL REFERENCES organizations(id),
+  from_scout_year_id integer REFERENCES scout_years(id),
+  to_scout_year_id   integer NOT NULL REFERENCES scout_years(id),
+  executed_at        timestamptz NOT NULL DEFAULT now(),
+  executed_by        uuid REFERENCES users(id),
+  summary            jsonb NOT NULL DEFAULT '{}'::jsonb,
+  changeset          jsonb NOT NULL DEFAULT '{}'::jsonb,
+  rolled_back_at     timestamptz,
+  rolled_back_by     uuid REFERENCES users(id)
+);
+
+CREATE INDEX IF NOT EXISTS scout_year_transitions_org_idx
+  ON scout_year_transitions (organization_id, executed_at DESC);
+
+-- ---------------------------------------------------------------------------
+-- 8. Permissions
+-- ---------------------------------------------------------------------------
+
+INSERT INTO permissions (permission_key, permission_name, category, description)
+VALUES
+  ('scout_year.view',   'View Scout Years',   'organization',
+   'View the scout year history and consult archived years'),
+  ('scout_year.manage', 'Manage Scout Years', 'organization',
+   'Open, close and configure scout years, and activate or deactivate memberships')
+ON CONFLICT (permission_key) DO NOTHING;
+
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+  FROM roles r
+ CROSS JOIN permissions p
+ WHERE p.permission_key = 'scout_year.manage'
+   AND r.role_name IN ('unitadmin', 'district')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+  FROM roles r
+ CROSS JOIN permissions p
+ WHERE p.permission_key = 'scout_year.view'
+   AND r.role_name IN ('unitadmin', 'district', 'animation', 'demoadmin')
+ON CONFLICT DO NOTHING;
+
+COMMIT;

--- a/routes/announcements.js
+++ b/routes/announcements.js
@@ -87,6 +87,7 @@ async function buildRecipients(pool, organizationId, roles, groupIds) {
     JOIN users u ON u.id = uo.user_id
     JOIN roles r ON r.id = ANY(SELECT jsonb_array_elements_text(uo.role_ids)::int)
     WHERE uo.organization_id = $1
+      AND uo.status = 'active'
       AND r.role_name = ANY($${groupParams.length + 1}::text[])
       AND u.email IS NOT NULL AND u.email <> ''
   `;
@@ -149,6 +150,7 @@ async function buildRecipients(pool, organizationId, roles, groupIds) {
     JOIN roles r ON r.id = ANY(SELECT jsonb_array_elements_text(uo.role_ids)::int)
     WHERE s.organization_id = $1
       AND uo.organization_id = $1
+      AND uo.status = 'active'
       AND r.role_name = ANY($2::text[])
   `;
   const subscribersResult = await pool.query(subscriberQuery, [organizationId, roleFilter]);

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -157,7 +157,8 @@ module.exports = (pool, logger) => {
         const trimmedPassword = password.trim();
 
         const userResult = await pool.query(
-          `SELECT u.id, u.email, u.password, u.is_verified, u.full_name
+          `SELECT u.id, u.email, u.password, u.is_verified, u.full_name,
+                  uo.status AS membership_status
            FROM users u
            JOIN user_organizations uo ON u.id = uo.user_id
            WHERE u.email = $1 AND uo.organization_id = $2`,
@@ -193,6 +194,21 @@ module.exports = (pool, logger) => {
           return res.status(403).json({
             success: false,
             message: 'account_not_verified_login'
+          });
+        }
+
+        // A membership deactivated at the year transition keeps its account and
+        // history, but can no longer sign in to the organization.
+        if (user.membership_status && user.membership_status !== 'active') {
+          logger.info('Login refused for inactive membership', {
+            userId: user.id,
+            organizationId,
+            membershipStatus: user.membership_status
+          });
+          return res.status(403).json({
+            success: false,
+            message: 'membership_inactive',
+            membershipStatus: user.membership_status
           });
         }
 
@@ -275,7 +291,8 @@ module.exports = (pool, logger) => {
            FROM user_organizations uo
            CROSS JOIN LATERAL jsonb_array_elements_text(uo.role_ids) AS role_id_text
            JOIN roles r ON r.id = role_id_text::integer
-           WHERE uo.user_id = $1 AND uo.organization_id = $2`,
+           WHERE uo.user_id = $1 AND uo.organization_id = $2
+             AND uo.status = 'active'`,
           [user.id, organizationId]
         );
 
@@ -285,7 +302,8 @@ module.exports = (pool, logger) => {
            CROSS JOIN LATERAL jsonb_array_elements_text(uo.role_ids) AS role_id_text
            JOIN role_permissions rp ON rp.role_id = role_id_text::integer
            JOIN permissions p ON p.id = rp.permission_id
-           WHERE uo.user_id = $1 AND uo.organization_id = $2`,
+           WHERE uo.user_id = $1 AND uo.organization_id = $2
+             AND uo.status = 'active'`,
           [user.id, organizationId]
         );
 
@@ -399,7 +417,7 @@ module.exports = (pool, logger) => {
 
         // Fetch user
         const userResult = await pool.query(
-          `SELECT u.id, u.email, u.full_name
+          `SELECT u.id, u.email, u.full_name, uo.status AS membership_status
            FROM users u
            JOIN user_organizations uo ON u.id = uo.user_id
            WHERE u.email = $1 AND uo.organization_id = $2`,
@@ -412,6 +430,19 @@ module.exports = (pool, logger) => {
           return res.status(401).json({
             success: false,
             message: 'invalid_email'
+          });
+        }
+
+        if (user.membership_status && user.membership_status !== 'active') {
+          logger.info('2FA login refused for inactive membership', {
+            userId: user.id,
+            organizationId,
+            membershipStatus: user.membership_status
+          });
+          return res.status(403).json({
+            success: false,
+            message: 'membership_inactive',
+            membershipStatus: user.membership_status
           });
         }
 
@@ -435,7 +466,8 @@ module.exports = (pool, logger) => {
            FROM user_organizations uo
            CROSS JOIN LATERAL jsonb_array_elements_text(uo.role_ids) AS role_id_text
            JOIN roles r ON r.id = role_id_text::integer
-           WHERE uo.user_id = $1 AND uo.organization_id = $2`,
+           WHERE uo.user_id = $1 AND uo.organization_id = $2
+             AND uo.status = 'active'`,
           [user.id, organizationId]
         );
 
@@ -445,7 +477,8 @@ module.exports = (pool, logger) => {
            CROSS JOIN LATERAL jsonb_array_elements_text(uo.role_ids) AS role_id_text
            JOIN role_permissions rp ON rp.role_id = role_id_text::integer
            JOIN permissions p ON p.id = rp.permission_id
-           WHERE uo.user_id = $1 AND uo.organization_id = $2`,
+           WHERE uo.user_id = $1 AND uo.organization_id = $2
+             AND uo.status = 'active'`,
           [user.id, organizationId]
         );
 

--- a/routes/dashboards.js
+++ b/routes/dashboards.js
@@ -274,7 +274,7 @@ document.addEventListener("DOMContentLoaded", function() {
         // Get total points for all children
         pool.query(
           `SELECT participant_id, COALESCE(SUM(value), 0) as total_points
-           FROM points
+           FROM active_year_points
            WHERE participant_id = ANY($1) AND organization_id = $2
            GROUP BY participant_id`,
           [childIds, organizationId]

--- a/routes/groups.js
+++ b/routes/groups.js
@@ -54,14 +54,16 @@ module.exports = (pool) => {
               COALESCE(group_points.total_points, 0) as total_points
        FROM groups g
        LEFT JOIN (
-         SELECT group_id, COUNT(DISTINCT participant_id) AS member_count
-         FROM participant_groups
-         WHERE organization_id = $1
-         GROUP BY group_id
+         SELECT pg.group_id, COUNT(DISTINCT pg.participant_id) AS member_count
+         FROM participant_groups pg
+         JOIN participant_organizations po ON po.participant_id = pg.participant_id
+          AND po.organization_id = $1
+         WHERE pg.organization_id = $1
+         GROUP BY pg.group_id
        ) member_counts ON member_counts.group_id = g.id
        LEFT JOIN (
          SELECT group_id, SUM(value) AS total_points
-         FROM points
+         FROM active_year_points
          WHERE organization_id = $1 AND participant_id IS NULL
          GROUP BY group_id
        ) group_points ON group_points.group_id = g.id

--- a/routes/import.js
+++ b/routes/import.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const { verifyJWT, getCurrentOrganizationId, verifyOrganizationMembership, handleOrganizationResolutionError } = require('../utils/api-helpers');
 const { asyncHandler } = require('../middleware/response');
+const { ensureActiveScoutYear } = require('../services/scoutYear');
 
 module.exports = function (pool, logger) {
   const router = express.Router();
@@ -268,10 +269,13 @@ module.exports = function (pool, logger) {
             );
             participantId = newParticipant.rows[0].id;
 
+            // participant_organizations is a read-only view over
+            // participant_enrollments: enroll in the active scout year.
+            const scoutYear = await ensureActiveScoutYear(client, organizationId);
             await client.query(
-              `INSERT INTO participant_organizations (participant_id, organization_id)
-               VALUES ($1, $2) ON CONFLICT DO NOTHING`,
-              [participantId, organizationId]
+              `INSERT INTO participant_enrollments (participant_id, organization_id, scout_year_id)
+               VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`,
+              [participantId, organizationId, scoutYear.id]
             );
             stats.participantsCreated++;
           }

--- a/routes/index.js
+++ b/routes/index.js
@@ -88,6 +88,7 @@ module.exports = (app, pool) => {
     const programProgressRoutes = require("./programProgress")(pool, logger);
     const incidentsRoutes = require("./incidents")(pool, logger);
     const yearlyPlannerRoutes = require("./yearlyPlanner")(pool, logger);
+    const scoutYearsRoutes = require("./scoutYears")(pool, logger);
     const appVersionRoutes = require("./appVersion")();
 
     // ============================================
@@ -167,6 +168,7 @@ module.exports = (app, pool) => {
     app.use("/api/v1/program-progress", programProgressRoutes);
     app.use("/api/v1/incidents", incidentsRoutes);
     app.use("/api/v1/yearly-planner", yearlyPlannerRoutes);
+    app.use("/api/v1/scout-years", scoutYearsRoutes);
 
     // WhatsApp routes already include /v1/* internally.
     app.use("/api", whatsappBaileysRoutes);

--- a/routes/participants.js
+++ b/routes/participants.js
@@ -4,6 +4,7 @@ const router = express.Router();
 const { authenticate, getOrganizationId, requirePermission, blockDemoRoles, getUserDataScope } = require('../middleware/auth');
 const { success, error, paginated, asyncHandler } = require('../middleware/response');
 const { verifyOrganizationMembership } = require('../utils/api-helpers');
+const { ensureActiveScoutYear } = require('../services/scoutYear');
 
 /**
  * Fetch a group's context for a specific organization.
@@ -97,7 +98,7 @@ module.exports = (pool) => {
         LEFT JOIN form_submissions fs ON fs.participant_id = p.id AND fs.organization_id = $1
         LEFT JOIN (
           SELECT participant_id, SUM(value) AS total_points
-          FROM points
+          FROM active_year_points
           WHERE organization_id = $1 AND participant_id IS NOT NULL
           GROUP BY participant_id
         ) point_totals ON point_totals.participant_id = p.id
@@ -146,7 +147,7 @@ module.exports = (pool) => {
         LEFT JOIN form_submissions fs ON fs.participant_id = p.id AND fs.organization_id = $1
         LEFT JOIN (
           SELECT participant_id, SUM(value) AS total_points
-          FROM points
+          FROM active_year_points
           WHERE organization_id = $1 AND participant_id IS NOT NULL
           GROUP BY participant_id
         ) point_totals ON point_totals.participant_id = p.id
@@ -281,11 +282,13 @@ module.exports = (pool) => {
 
       const participantId = participantResult.rows[0].id;
 
-      // Link to organization
+      // Enroll in the active scout year. participant_organizations is a
+      // read-only view over participant_enrollments.
+      const scoutYear = await ensureActiveScoutYear(client, organizationId);
       await client.query(
-        `INSERT INTO participant_organizations (participant_id, organization_id)
-         VALUES ($1, $2)`,
-        [participantId, organizationId]
+        `INSERT INTO participant_enrollments (participant_id, organization_id, scout_year_id)
+         VALUES ($1, $2, $3)`,
+        [participantId, organizationId, scoutYear.id]
       );
 
       // Link to group if provided
@@ -614,12 +617,14 @@ module.exports = (pool) => {
 
         participantId = insertResult.rows[0].id;
 
-        // Link to organization
+        // Enroll in the active scout year. participant_organizations is a
+        // read-only view over participant_enrollments.
+        const scoutYear = await ensureActiveScoutYear(client, organizationId);
         await client.query(
-          `INSERT INTO participant_organizations (participant_id, organization_id)
-           VALUES ($1, $2)
-           ON CONFLICT (participant_id, organization_id) DO NOTHING`,
-          [participantId, organizationId]
+          `INSERT INTO participant_enrollments (participant_id, organization_id, scout_year_id)
+           VALUES ($1, $2, $3)
+           ON CONFLICT (participant_id, organization_id, scout_year_id) DO NOTHING`,
+          [participantId, organizationId, scoutYear.id]
         );
       }
 
@@ -797,13 +802,16 @@ module.exports = (pool) => {
       return error(res, 'Participant ID is required', 400);
     }
 
-    // Insert with inscription_date (defaults to today if not provided)
-    // On conflict, keep the existing inscription_date (don't update it)
+    // Enroll in the active scout year with inscription_date (defaults to today).
+    // On conflict, keep the existing inscription_date but revive an enrollment
+    // that was closed at a previous transition.
+    const scoutYear = await ensureActiveScoutYear(pool, organizationId);
     await pool.query(
-      `INSERT INTO participant_organizations (participant_id, organization_id, inscription_date)
-       VALUES ($1, $2, COALESCE($3::date, CURRENT_DATE))
-       ON CONFLICT (participant_id, organization_id) DO NOTHING`,
-      [participant_id, organizationId, inscription_date]
+      `INSERT INTO participant_enrollments (participant_id, organization_id, scout_year_id, inscription_date)
+       VALUES ($1, $2, $3, COALESCE($4::date, CURRENT_DATE))
+       ON CONFLICT (participant_id, organization_id, scout_year_id)
+       DO UPDATE SET status = 'active', ended_on = NULL, exit_reason = NULL`,
+      [participant_id, organizationId, scoutYear.id, inscription_date]
     );
 
     return success(res, null, 'Participant linked to organization');
@@ -1169,7 +1177,7 @@ module.exports = (pool) => {
                 WHERE participant_id = p.id AND organization_id = $2), '[]'::json
              ) as form_submissions,
              COALESCE(
-               (SELECT SUM(value) FROM points WHERE participant_id = p.id AND organization_id = $2),
+               (SELECT SUM(value) FROM active_year_points WHERE participant_id = p.id AND organization_id = $2),
                0
              ) as total_points
       FROM participants p
@@ -1307,7 +1315,11 @@ module.exports = (pool) => {
    * @swagger
    * /api/v1/participants/{id}:
    *   delete:
-   *     summary: Delete a participant
+   *     summary: Remove a participant from the current scout year
+   *     description: >
+   *       Closes the participant's enrollment for the active scout year. Nothing
+   *       is deleted: the participant and every past year stay consultable in the
+   *       archives.
    *     tags: [Participants]
    *     security:
    *       - bearerAuth: []
@@ -1319,24 +1331,32 @@ module.exports = (pool) => {
    *           type: integer
    *     responses:
    *       200:
-   *         description: Participant deleted
+   *         description: Enrollment closed for the active scout year
    */
   router.delete('/:id', authenticate, blockDemoRoles, requirePermission('participants.delete'), asyncHandler(async (req, res) => {
     const { id } = req.params;
+    const { exit_reason: exitReason } = req.body || {};
     const organizationId = await getOrganizationId(req, pool);
+    const scoutYear = await ensureActiveScoutYear(pool, organizationId);
 
     const result = await pool.query(
-      `DELETE FROM participant_organizations
-       WHERE participant_id = $1 AND organization_id = $2
-       RETURNING *`,
-      [id, organizationId]
+      `UPDATE participant_enrollments
+          SET status = 'left',
+              ended_on = CURRENT_DATE,
+              exit_reason = COALESCE($4, exit_reason)
+        WHERE participant_id = $1
+          AND organization_id = $2
+          AND scout_year_id = $3
+          AND status = 'active'
+        RETURNING participant_id, organization_id, scout_year_id, status, ended_on`,
+      [id, organizationId, scoutYear.id, exitReason || null]
     );
 
     if (result.rows.length === 0) {
       return error(res, 'Participant not found', 404);
     }
 
-    return success(res, null, 'Participant removed from organization');
+    return success(res, result.rows[0], 'Participant removed from the current scout year');
   }));
 
   return router;

--- a/routes/points.js
+++ b/routes/points.js
@@ -11,8 +11,9 @@ const express = require('express');
 const router = express.Router();
 
 // Import auth middleware
-const { authenticate, requirePermission, blockDemoRoles, getOrganizationId } = require('../middleware/auth');
+const { authenticate, requirePermission, blockDemoRoles, getOrganizationId, getScoutYear } = require('../middleware/auth');
 const { asyncHandler } = require('../middleware/response');
+const { ensureActiveScoutYear } = require('../services/scoutYear');
 
 // Import utilities and middleware
 const { getCurrentOrganizationId, verifyJWT, verifyOrganizationMembership, handleOrganizationResolutionError } = require('../utils/api-helpers');
@@ -41,6 +42,15 @@ module.exports = (pool, logger) => {
   router.get('/', authenticate, requirePermission('points.view'), asyncHandler(async (req, res) => {
     const organizationId = await getOrganizationId(req, pool);
 
+    // Totals are scoped to a scout year. Defaults to the active one; pass
+    // ?scout_year_id= to consult an archived season.
+    let scoutYear;
+    try {
+      scoutYear = await getScoutYear(req, pool);
+    } catch (err) {
+      return errorResponse(res, 'Unknown scout year for this organization', 400);
+    }
+
     // Fetch all groups with group-only points plus the sum of current member points.
     const groupsResult = await pool.query(
       `SELECT g.id,
@@ -51,16 +61,18 @@ module.exports = (pool, logger) => {
        LEFT JOIN (
          SELECT group_id, SUM(value) AS total_points
          FROM points
-         WHERE organization_id = $1 AND participant_id IS NULL
+         WHERE organization_id = $1 AND participant_id IS NULL AND scout_year_id = $2
          GROUP BY group_id
        ) group_points ON group_points.group_id = g.id
        LEFT JOIN (
          SELECT pg.group_id, SUM(COALESCE(participant_points.total_points, 0)) AS total_points
          FROM participant_groups pg
+         JOIN participant_enrollments pe ON pe.participant_id = pg.participant_id
+          AND pe.organization_id = $1 AND pe.scout_year_id = $2 AND pe.status = 'active'
          LEFT JOIN (
            SELECT participant_id, SUM(value) AS total_points
            FROM points
-           WHERE organization_id = $1 AND participant_id IS NOT NULL
+           WHERE organization_id = $1 AND participant_id IS NOT NULL AND scout_year_id = $2
            GROUP BY participant_id
          ) participant_points ON participant_points.participant_id = pg.participant_id
          WHERE pg.organization_id = $1
@@ -68,26 +80,34 @@ module.exports = (pool, logger) => {
        ) member_points ON member_points.group_id = g.id
        WHERE g.organization_id = $1
        ORDER BY g.name`,
-      [organizationId]
+      [organizationId, scoutYear.id]
     );
 
-    // Fetch all participants with their associated group and total points
+    // Fetch the participants enrolled that year with their group and total points
     const participantsResult = await pool.query(
       `SELECT part.id, part.first_name, part.last_name, pg.group_id, COALESCE(SUM(p.value), 0) AS total_points
        FROM participants part
-       JOIN participant_organizations po ON part.id = po.participant_id
+       JOIN participant_enrollments pe ON part.id = pe.participant_id
+        AND pe.organization_id = $1 AND pe.scout_year_id = $2 AND pe.status = 'active'
        LEFT JOIN participant_groups pg ON part.id = pg.participant_id AND pg.organization_id = $1
        LEFT JOIN points p ON part.id = p.participant_id AND p.organization_id = $1
-       WHERE po.organization_id = $1
+        AND p.scout_year_id = $2
        GROUP BY part.id, part.first_name, part.last_name, pg.group_id
        ORDER BY part.first_name`,
-      [organizationId]
+      [organizationId, scoutYear.id]
     );
 
     res.json({
       success: true,
       groups: groupsResult.rows,
-      participants: participantsResult.rows
+      participants: participantsResult.rows,
+      scout_year: {
+        id: scoutYear.id,
+        label: scoutYear.label,
+        status: scoutYear.status,
+        start_date: scoutYear.start_date,
+        end_date: scoutYear.end_date
+      }
     });
   }));
 
@@ -137,6 +157,10 @@ module.exports = (pool, logger) => {
       return res.status(400).json({ success: false, message: 'Updates must be an array' });
     }
 
+    // Totals returned to the client are the running totals of the active scout
+    // year, not lifetime totals: opening a new year is what resets the score.
+    const activeScoutYear = await ensureActiveScoutYear(pool, organizationId);
+
     const client = await pool.connect();
     const responseUpdates = [];
 
@@ -155,10 +179,14 @@ module.exports = (pool, logger) => {
           // If date is provided, only award points to present/late participants
           const groupId = parseInt(id);
 
-          // Get all participants in this group (using participant_groups table)
+          // Group members still enrolled this year. Joining the roster keeps
+          // participants who left at the last transition from being awarded
+          // points on a stale participant_groups row.
           const membersResult = await client.query(
             `SELECT p.id FROM participants p
                JOIN participant_groups pg ON p.id = pg.participant_id
+               JOIN participant_organizations po ON po.participant_id = p.id
+                AND po.organization_id = $1
                WHERE pg.organization_id = $1 AND pg.group_id = $2`,
             [organizationId, groupId]
           );
@@ -233,8 +261,9 @@ module.exports = (pool, logger) => {
               `SELECT participant_id as id, COALESCE(SUM(value), 0) as total
                  FROM points
                  WHERE organization_id = $1 AND participant_id = ANY($2)
+                   AND scout_year_id = $3
                  GROUP BY participant_id`,
-              [organizationId, memberIds]
+              [organizationId, memberIds, activeScoutYear.id]
             );
 
             // Map results to expected format
@@ -253,8 +282,9 @@ module.exports = (pool, logger) => {
               `SELECT participant_id as id, COALESCE(SUM(value), 0) as total
                  FROM points
                  WHERE organization_id = $1 AND participant_id = ANY($2)
+                   AND scout_year_id = $3
                  GROUP BY participant_id`,
-              [organizationId, skippedParticipants]
+              [organizationId, skippedParticipants, activeScoutYear.id]
             );
 
             const skippedWithTotals = new Set();
@@ -277,8 +307,9 @@ module.exports = (pool, logger) => {
           // Calculate new total for the group (group-level points only)
           const totalResult = await client.query(
             `SELECT COALESCE(SUM(value), 0) as total FROM points
-               WHERE organization_id = $1 AND group_id = $2 AND participant_id IS NULL`,
-            [organizationId, groupId]
+               WHERE organization_id = $1 AND group_id = $2 AND participant_id IS NULL
+                 AND scout_year_id = $3`,
+            [organizationId, groupId, activeScoutYear.id]
           );
 
           responseUpdates.push({
@@ -320,8 +351,9 @@ module.exports = (pool, logger) => {
           // Calculate new total for this participant
           const totalResult = await client.query(
             `SELECT COALESCE(SUM(value), 0) as total FROM points
-               WHERE organization_id = $1 AND participant_id = $2`,
-            [organizationId, participantId]
+               WHERE organization_id = $1 AND participant_id = $2
+                 AND scout_year_id = $3`,
+            [organizationId, participantId, activeScoutYear.id]
           );
 
           responseUpdates.push({
@@ -385,15 +417,17 @@ module.exports = (pool, logger) => {
          FROM groups g
          LEFT JOIN (
            SELECT group_id, SUM(value) AS total_points
-           FROM points
+           FROM active_year_points
            WHERE organization_id = $1 AND participant_id IS NULL
            GROUP BY group_id
          ) group_points ON group_points.group_id = g.id
          LEFT JOIN (
-           SELECT group_id, COUNT(DISTINCT participant_id) AS member_count
-           FROM participant_groups
-           WHERE organization_id = $1
-           GROUP BY group_id
+           SELECT pg.group_id, COUNT(DISTINCT pg.participant_id) AS member_count
+           FROM participant_groups pg
+           JOIN participant_organizations po ON po.participant_id = pg.participant_id
+            AND po.organization_id = $1
+           WHERE pg.organization_id = $1
+           GROUP BY pg.group_id
          ) member_counts ON member_counts.group_id = g.id
          WHERE g.organization_id = $1
          ORDER BY total_points DESC
@@ -412,7 +446,7 @@ module.exports = (pool, logger) => {
          JOIN participant_organizations po ON p.id = po.participant_id
          LEFT JOIN participant_groups pg ON p.id = pg.participant_id AND pg.organization_id = $1
          LEFT JOIN groups g ON pg.group_id = g.id
-         LEFT JOIN points pts ON pts.participant_id = p.id AND pts.organization_id = $1
+         LEFT JOIN active_year_points pts ON pts.participant_id = p.id AND pts.organization_id = $1
          WHERE po.organization_id = $1
          GROUP BY p.id, p.first_name, p.last_name, g.name
          ORDER BY total_points DESC
@@ -452,7 +486,7 @@ module.exports = (pool, logger) => {
        LEFT JOIN groups g ON pg.group_id = g.id
        LEFT JOIN (
          SELECT participant_id, SUM(value) AS total_points
-         FROM points
+         FROM active_year_points
          WHERE organization_id = $1 AND participant_id IS NOT NULL
          GROUP BY participant_id
        ) point_totals ON point_totals.participant_id = p.id

--- a/routes/reports.js
+++ b/routes/reports.js
@@ -689,7 +689,7 @@ module.exports = (pool, logger) => {
          LEFT JOIN groups g ON pg.group_id = g.id
          LEFT JOIN (
            SELECT participant_id, SUM(value) AS total_points
-           FROM points
+           FROM active_year_points
            WHERE organization_id = $1 AND participant_id IS NOT NULL
            GROUP BY participant_id
          ) point_totals ON point_totals.participant_id = p.id
@@ -845,7 +845,7 @@ module.exports = (pool, logger) => {
 
     const pointsResult = await pool.query(
       `SELECT created_at::date as date, value
-         FROM points
+         FROM active_year_points
          WHERE participant_id = $1 AND organization_id = $2
          ORDER BY created_at ASC`,
       [participantId, organizationId]

--- a/routes/scoutYears.js
+++ b/routes/scoutYears.js
@@ -1,0 +1,473 @@
+/**
+ * Scout Year Routes
+ *
+ * Year lifecycle for a unit: consult the year history, preview what a transition
+ * would do, run it, and manage membership status.
+ *
+ * The guiding rule is that nothing is deleted. Closing a year leaves every
+ * enrollment, point and account in place; they simply stop belonging to the
+ * active year.
+ *
+ * @module routes/scoutYears
+ */
+
+const express = require('express');
+const {
+  authenticate,
+  requirePermission,
+  blockDemoRoles,
+  getOrganizationId
+} = require('../middleware/auth');
+const { success, error, asyncHandler } = require('../middleware/response');
+const {
+  computeYearBounds,
+  ensureActiveScoutYear,
+  listScoutYears,
+  openNextScoutYear,
+  listMembershipsWithoutEnrolledChild
+} = require('../services/scoutYear');
+
+/** Age at which a participant leaves the section, unless configured otherwise. */
+const DEFAULT_MAX_AGE = 12;
+/** Reference day used to evaluate that age: December 31st of the starting year. */
+const DEFAULT_AGE_REFERENCE = '12-31';
+
+module.exports = (pool, logger) => {
+  const router = express.Router();
+
+  /**
+   * Read the organization's year transition rules.
+   *
+   * @param {number} organizationId - Organization ID
+   * @returns {Promise<{maxAge: number, ageReference: string}>} Transition rules
+   */
+  async function getTransitionSettings(organizationId) {
+    const result = await pool.query(
+      `SELECT setting_value FROM organization_settings
+        WHERE organization_id = $1 AND setting_key = 'year_transition'
+        LIMIT 1`,
+      [organizationId]
+    );
+
+    const setting = result.rows[0]?.setting_value || {};
+    const maxAge = parseInt(setting.max_age, 10);
+
+    return {
+      maxAge: Number.isNaN(maxAge) ? DEFAULT_MAX_AGE : maxAge,
+      ageReference: typeof setting.age_reference_date === 'string'
+        ? setting.age_reference_date
+        : DEFAULT_AGE_REFERENCE
+    };
+  }
+
+  /**
+   * @swagger
+   * /api/v1/scout-years:
+   *   get:
+   *     summary: List the organization's scout years
+   *     tags: [Scout Years]
+   *     security:
+   *       - bearerAuth: []
+   *     responses:
+   *       200:
+   *         description: Scout years, most recent first
+   */
+  router.get('/', authenticate, requirePermission('scout_year.view'), asyncHandler(async (req, res) => {
+    const organizationId = await getOrganizationId(req, pool);
+    await ensureActiveScoutYear(pool, organizationId);
+    const years = await listScoutYears(pool, organizationId);
+    return success(res, years);
+  }));
+
+  /**
+   * @swagger
+   * /api/v1/scout-years/active:
+   *   get:
+   *     summary: Get the active scout year
+   *     tags: [Scout Years]
+   *     security:
+   *       - bearerAuth: []
+   *     responses:
+   *       200:
+   *         description: Active scout year
+   */
+  router.get('/active', authenticate, requirePermission('scout_year.view'), asyncHandler(async (req, res) => {
+    const organizationId = await getOrganizationId(req, pool);
+    const scoutYear = await ensureActiveScoutYear(pool, organizationId);
+    return success(res, scoutYear);
+  }));
+
+  /**
+   * @swagger
+   * /api/v1/scout-years/transition/preview:
+   *   get:
+   *     summary: Preview the next year transition
+   *     description: >
+   *       Proposes a disposition for every enrolled participant and lists the
+   *       parent accounts that would end up without an enrolled child. Changes
+   *       nothing.
+   *     tags: [Scout Years]
+   *     security:
+   *       - bearerAuth: []
+   *     responses:
+   *       200:
+   *         description: Proposed transition
+   */
+  router.get('/transition/preview', authenticate, requirePermission('scout_year.manage'), asyncHandler(async (req, res) => {
+    const organizationId = await getOrganizationId(req, pool);
+    const currentYear = await ensureActiveScoutYear(pool, organizationId);
+    const { maxAge, ageReference } = await getTransitionSettings(organizationId);
+
+    // Boundaries the next year would get, and the date its age rule refers to.
+    const nextBounds = await computeYearBounds(
+      pool,
+      organizationId,
+      new Date(new Date(currentYear.end_date).getTime() + 86400000)
+    );
+    const referenceDate = `${nextBounds.label.split('-')[0]}-${ageReference}`;
+
+    const participantsResult = await pool.query(
+      `SELECT p.id,
+              p.first_name,
+              p.last_name,
+              p.date_naissance,
+              g.name AS group_name,
+              CASE
+                WHEN p.date_naissance IS NULL THEN NULL
+                ELSE date_part('year', age($3::date, p.date_naissance))::int
+              END AS age_at_reference,
+              COALESCE((
+                SELECT SUM(value) FROM points
+                 WHERE participant_id = p.id AND scout_year_id = $2
+              ), 0) AS points_this_year
+         FROM participant_enrollments pe
+         JOIN participants p ON p.id = pe.participant_id
+         LEFT JOIN participant_groups pg ON pg.participant_id = p.id AND pg.organization_id = $1
+         LEFT JOIN groups g ON g.id = pg.group_id
+        WHERE pe.organization_id = $1
+          AND pe.scout_year_id = $2
+          AND pe.status = 'active'
+        ORDER BY p.first_name, p.last_name`,
+      [organizationId, currentYear.id, referenceDate]
+    );
+
+    // A participant with no birth date is never graduated automatically: the
+    // leader has to decide.
+    const participants = participantsResult.rows.map(row => ({
+      ...row,
+      points_this_year: parseInt(row.points_this_year, 10),
+      disposition: row.age_at_reference !== null && row.age_at_reference >= maxAge
+        ? 'graduating'
+        : 'returning',
+      needs_review: row.age_at_reference === null
+    }));
+
+    const graduatingIds = participants
+      .filter(p => p.disposition === 'graduating')
+      .map(p => p.id);
+
+    // Which parents would be left without an enrolled child, assuming the
+    // proposed dispositions are applied.
+    const membershipCandidates = await listMembershipsWithoutEnrolledChild(
+      pool,
+      organizationId,
+      currentYear.id
+    );
+    const membershipsAfterTransition = graduatingIds.length === 0
+      ? membershipCandidates
+      : await pool.query(
+        `WITH linked_participants AS (
+           SELECT up.user_id, up.participant_id FROM user_participants up
+           UNION
+           SELECT gu.user_id, pg.participant_id
+             FROM guardian_users gu
+             JOIN participant_guardians pg ON pg.guardian_id = gu.guardian_id
+         ),
+         staying AS (
+           SELECT pe.participant_id
+             FROM participant_enrollments pe
+            WHERE pe.organization_id = $1
+              AND pe.scout_year_id = $2
+              AND pe.status = 'active'
+              AND NOT (pe.participant_id = ANY($3::int[]))
+         )
+         SELECT uo.id AS membership_id, uo.user_id, u.email, u.full_name,
+                ARRAY_AGG(DISTINCT r.role_name::text) FILTER (WHERE r.role_name IS NOT NULL) AS role_names
+           FROM user_organizations uo
+           JOIN users u ON u.id = uo.user_id
+           LEFT JOIN LATERAL jsonb_array_elements_text(uo.role_ids) AS role_id_text ON TRUE
+           LEFT JOIN roles r ON r.id = role_id_text::integer
+          WHERE uo.organization_id = $1
+            AND uo.status = 'active'
+          GROUP BY uo.id, uo.user_id, u.email, u.full_name
+         HAVING ARRAY_AGG(DISTINCT r.role_name::text) FILTER (WHERE r.role_name IS NOT NULL)
+                  <@ ARRAY['parent','guardian','demoparent']::text[]
+            AND NOT EXISTS (
+              SELECT 1 FROM linked_participants lp
+               JOIN staying s ON s.participant_id = lp.participant_id
+              WHERE lp.user_id = uo.user_id
+            )
+          ORDER BY u.full_name NULLS LAST, u.email`,
+        [organizationId, currentYear.id, graduatingIds]
+      ).then(result => result.rows);
+
+    return success(res, {
+      current_year: currentYear,
+      next_year: nextBounds,
+      age_rule: { max_age: maxAge, reference_date: referenceDate },
+      participants,
+      memberships_to_deactivate: membershipsAfterTransition,
+      counts: {
+        returning: participants.filter(p => p.disposition === 'returning').length,
+        graduating: graduatingIds.length,
+        needs_review: participants.filter(p => p.needs_review).length,
+        memberships_to_deactivate: membershipsAfterTransition.length
+      }
+    });
+  }));
+
+  /**
+   * @swagger
+   * /api/v1/scout-years/transition:
+   *   post:
+   *     summary: Close the active year and open the next one
+   *     description: >
+   *       Applies the dispositions confirmed by the leader. Participants who
+   *       leave keep their enrollment record, flagged as graduated; returning
+   *       participants get a fresh enrollment in the new year. Deactivated
+   *       parent accounts keep every link and can be reactivated.
+   *     tags: [Scout Years]
+   *     security:
+   *       - bearerAuth: []
+   *     responses:
+   *       201:
+   *         description: Transition executed
+   *       400:
+   *         description: Invalid payload
+   */
+  router.post('/transition', authenticate, blockDemoRoles, requirePermission('scout_year.manage'), asyncHandler(async (req, res) => {
+    const organizationId = await getOrganizationId(req, pool);
+    const {
+      graduating_participant_ids: graduatingInput = [],
+      deactivate_membership_ids: deactivateInput = [],
+      exceptions = []
+    } = req.body || {};
+
+    if (!Array.isArray(graduatingInput) || !Array.isArray(deactivateInput)) {
+      return error(res, 'graduating_participant_ids and deactivate_membership_ids must be arrays', 400);
+    }
+
+    const graduatingIds = graduatingInput.map(id => parseInt(id, 10)).filter(id => !Number.isNaN(id));
+    const membershipIds = deactivateInput.map(id => parseInt(id, 10)).filter(id => !Number.isNaN(id));
+    // Notes recorded for participants the leader kept despite the age rule.
+    const exceptionNotes = new Map(
+      (Array.isArray(exceptions) ? exceptions : [])
+        .filter(item => item && item.participant_id)
+        .map(item => [parseInt(item.participant_id, 10), String(item.note || '').slice(0, 500)])
+    );
+
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      const { previousYear, newYear, restampedPoints } = await openNextScoutYear(client, {
+        organizationId,
+        userId: req.user.id
+      });
+
+      if (!previousYear) {
+        await client.query('ROLLBACK');
+        return error(res, 'No active scout year to close', 409);
+      }
+
+      // Close the enrollments of participants who are leaving. The rows stay.
+      const graduated = await client.query(
+        `UPDATE participant_enrollments
+            SET status = 'graduated',
+                ended_on = $4::date,
+                exit_reason = COALESCE(exit_reason, 'age_limit')
+          WHERE organization_id = $1
+            AND scout_year_id = $2
+            AND status = 'active'
+            AND participant_id = ANY($3::int[])
+          RETURNING participant_id`,
+        [organizationId, previousYear.id, graduatingIds, previousYear.end_date]
+      );
+
+      // Carry everyone else over, preserving their original inscription date.
+      const carriedOver = await client.query(
+        `INSERT INTO participant_enrollments
+                (participant_id, organization_id, scout_year_id, inscription_date, status, exception_note)
+         SELECT pe.participant_id, pe.organization_id, $3, pe.inscription_date, 'active',
+                CASE WHEN pe.participant_id = ANY($5::int[]) THEN $6::jsonb ->> pe.participant_id::text END
+           FROM participant_enrollments pe
+          WHERE pe.organization_id = $1
+            AND pe.scout_year_id = $2
+            AND pe.status = 'active'
+            AND NOT (pe.participant_id = ANY($4::int[]))
+         ON CONFLICT (participant_id, organization_id, scout_year_id) DO NOTHING
+         RETURNING participant_id`,
+        [
+          organizationId,
+          previousYear.id,
+          newYear.id,
+          graduatingIds,
+          [...exceptionNotes.keys()],
+          JSON.stringify(Object.fromEntries(exceptionNotes))
+        ]
+      );
+
+      // Deactivate the confirmed memberships. Never touch a membership that
+      // holds a non-parent role, whatever the client sent.
+      let deactivated = { rows: [] };
+      if (membershipIds.length > 0) {
+        deactivated = await client.query(
+          `UPDATE user_organizations uo
+              SET status = 'inactive',
+                  deactivated_at = now(),
+                  deactivated_reason = 'no_enrolled_child',
+                  last_active_scout_year_id = $3
+            WHERE uo.id = ANY($2::int[])
+              AND uo.organization_id = $1
+              AND uo.status = 'active'
+              AND NOT EXISTS (
+                SELECT 1
+                  FROM jsonb_array_elements_text(uo.role_ids) AS role_id_text
+                  JOIN roles r ON r.id = role_id_text::integer
+                 WHERE r.role_name <> ALL (ARRAY['parent','guardian','demoparent'])
+              )
+            RETURNING uo.id, uo.user_id`,
+          [organizationId, membershipIds, previousYear.id]
+        );
+      }
+
+      const summary = {
+        graduated: graduated.rows.length,
+        carried_over: carriedOver.rows.length,
+        memberships_deactivated: deactivated.rows.length,
+        memberships_skipped: membershipIds.length - deactivated.rows.length,
+        points_restamped: restampedPoints
+      };
+
+      const transition = await client.query(
+        `INSERT INTO scout_year_transitions
+                (organization_id, from_scout_year_id, to_scout_year_id, executed_by, summary, changeset)
+         VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb)
+         RETURNING id, executed_at`,
+        [
+          organizationId,
+          previousYear.id,
+          newYear.id,
+          req.user.id,
+          JSON.stringify(summary),
+          JSON.stringify({
+            graduated_participant_ids: graduated.rows.map(r => r.participant_id),
+            carried_over_participant_ids: carriedOver.rows.map(r => r.participant_id),
+            deactivated_membership_ids: deactivated.rows.map(r => r.id),
+            exceptions: Object.fromEntries(exceptionNotes)
+          })
+        ]
+      );
+
+      await client.query('COMMIT');
+
+      logger.info('Scout year transition executed', {
+        organizationId,
+        from: previousYear.label,
+        to: newYear.label,
+        ...summary
+      });
+
+      return success(res, {
+        transition_id: transition.rows[0].id,
+        executed_at: transition.rows[0].executed_at,
+        previous_year: previousYear,
+        new_year: newYear,
+        summary
+      }, 'Scout year transition completed', 201);
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }));
+
+  /**
+   * @swagger
+   * /api/v1/scout-years/memberships/without-child:
+   *   get:
+   *     summary: List active memberships with no enrolled child
+   *     tags: [Scout Years]
+   *     security:
+   *       - bearerAuth: []
+   *     responses:
+   *       200:
+   *         description: Candidate memberships
+   */
+  router.get('/memberships/without-child', authenticate, requirePermission('scout_year.manage'), asyncHandler(async (req, res) => {
+    const organizationId = await getOrganizationId(req, pool);
+    const scoutYear = await ensureActiveScoutYear(pool, organizationId);
+    const memberships = await listMembershipsWithoutEnrolledChild(pool, organizationId, scoutYear.id);
+    return success(res, memberships);
+  }));
+
+  /**
+   * @swagger
+   * /api/v1/scout-years/memberships/{membershipId}/status:
+   *   patch:
+   *     summary: Activate or deactivate a membership
+   *     description: >
+   *       Deactivating keeps the account, its guardian links and its history; the
+   *       user simply loses access to the unit and stops receiving its
+   *       communications. Reactivating restores access.
+   *     tags: [Scout Years]
+   *     security:
+   *       - bearerAuth: []
+   *     responses:
+   *       200:
+   *         description: Membership updated
+   *       400:
+   *         description: Invalid status
+   *       404:
+   *         description: Membership not found
+   */
+  router.patch('/memberships/:membershipId/status', authenticate, blockDemoRoles, requirePermission('scout_year.manage'), asyncHandler(async (req, res) => {
+    const organizationId = await getOrganizationId(req, pool);
+    const membershipId = parseInt(req.params.membershipId, 10);
+    const { status, reason } = req.body || {};
+
+    if (Number.isNaN(membershipId)) {
+      return error(res, 'Invalid membership identifier', 400);
+    }
+
+    const allowedStatuses = ['active', 'inactive', 'alumni'];
+    if (!allowedStatuses.includes(status)) {
+      return error(res, `status must be one of: ${allowedStatuses.join(', ')}`, 400);
+    }
+
+    const isDeactivation = status !== 'active';
+    const scoutYear = await ensureActiveScoutYear(pool, organizationId);
+
+    const result = await pool.query(
+      `UPDATE user_organizations
+          SET status = $3,
+              deactivated_at = CASE WHEN $4 THEN now() ELSE NULL END,
+              deactivated_reason = CASE WHEN $4 THEN $5 ELSE NULL END,
+              last_active_scout_year_id = CASE WHEN $4 THEN $6 ELSE last_active_scout_year_id END
+        WHERE id = $1 AND organization_id = $2
+        RETURNING id, user_id, status, deactivated_at, deactivated_reason`,
+      [membershipId, organizationId, status, isDeactivation, reason || null, scoutYear.id]
+    );
+
+    if (result.rows.length === 0) {
+      return error(res, 'Membership not found', 404);
+    }
+
+    logger.info('Membership status changed', { organizationId, membershipId, status });
+
+    return success(res, result.rows[0], 'Membership status updated');
+  }));
+
+  return router;
+};

--- a/services/scoutYear.js
+++ b/services/scoutYear.js
@@ -1,0 +1,405 @@
+/**
+ * Scout Year Service
+ *
+ * The scout year is the dimension that makes a year transition non-destructive:
+ * participants, points and memberships are scoped to a year rather than wiped.
+ *
+ * Year boundaries derive from the organization's existing `fiscal_year` setting
+ * (defaults to September 1st).
+ *
+ * Key invariant: **the active year always contains today.** `openNextScoutYear`
+ * clamps boundaries when a transition is run ahead of the nominal start date, so
+ * points awarded between an early transition and September 1st land in the newly
+ * opened year rather than the one that was just closed. The `points` insert
+ * trigger relies on this.
+ *
+ * @module services/scoutYear
+ */
+
+const DEFAULT_FISCAL_START_MONTH = 9;
+const DEFAULT_FISCAL_START_DAY = 1;
+const MIN_MONTH = 1;
+const MAX_MONTH = 12;
+const MIN_DAY = 1;
+/** Highest day-of-month accepted as a fiscal year start, so every month is valid. */
+const MAX_DAY = 28;
+
+/**
+ * Format a Date as an ISO calendar date (YYYY-MM-DD) in UTC.
+ *
+ * @param {Date} date - Date to format
+ * @returns {string} ISO calendar date
+ */
+function toIsoDate(date) {
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * Parse a value into a UTC-midnight Date.
+ *
+ * @param {string|Date} value - ISO date string or Date
+ * @returns {Date} UTC-midnight date
+ */
+function toUtcDate(value) {
+  if (value instanceof Date) {
+    return new Date(Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate()));
+  }
+  const [year, month, day] = String(value).slice(0, 10).split('-').map(Number);
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+/**
+ * Today as a UTC-midnight Date.
+ *
+ * @returns {Date} Today
+ */
+function today() {
+  return toUtcDate(new Date());
+}
+
+/**
+ * Add a number of days to a date.
+ *
+ * @param {Date} date - Base date
+ * @param {number} days - Days to add (may be negative)
+ * @returns {Date} Shifted date
+ */
+function addDays(date, days) {
+  const result = new Date(date.getTime());
+  result.setUTCDate(result.getUTCDate() + days);
+  return result;
+}
+
+/**
+ * Read the organization's fiscal year start, falling back to September 1st.
+ *
+ * @param {Object} pool - Database pool or client
+ * @param {number} organizationId - Organization ID
+ * @returns {Promise<{startMonth: number, startDay: number}>} Fiscal year start
+ */
+async function getFiscalYearStart(pool, organizationId) {
+  const result = await pool.query(
+    `SELECT setting_value
+       FROM organization_settings
+      WHERE organization_id = $1 AND setting_key = 'fiscal_year'
+      LIMIT 1`,
+    [organizationId]
+  );
+
+  const setting = result.rows[0]?.setting_value || {};
+  const rawMonth = parseInt(setting.start_month, 10);
+  const rawDay = parseInt(setting.start_day, 10);
+
+  const startMonth = Number.isNaN(rawMonth) || rawMonth < MIN_MONTH || rawMonth > MAX_MONTH
+    ? DEFAULT_FISCAL_START_MONTH
+    : rawMonth;
+  const startDay = Number.isNaN(rawDay) || rawDay < MIN_DAY || rawDay > MAX_DAY
+    ? DEFAULT_FISCAL_START_DAY
+    : rawDay;
+
+  return { startMonth, startDay };
+}
+
+/**
+ * Compute the nominal boundaries of the scout year containing a given date.
+ *
+ * Mirrors the `scout_year_for_date()` SQL function used by the migration.
+ *
+ * @param {Object} pool - Database pool or client
+ * @param {number} organizationId - Organization ID
+ * @param {string|Date} [onDate] - Date to locate (defaults to today)
+ * @returns {Promise<{label: string, startDate: string, endDate: string}>} Year boundaries
+ */
+async function computeYearBounds(pool, organizationId, onDate = today()) {
+  const { startMonth, startDay } = await getFiscalYearStart(pool, organizationId);
+  const reference = toUtcDate(onDate);
+
+  let startYear = reference.getUTCFullYear();
+  let start = new Date(Date.UTC(startYear, startMonth - 1, startDay));
+
+  if (reference < start) {
+    startYear -= 1;
+    start = new Date(Date.UTC(startYear, startMonth - 1, startDay));
+  }
+
+  const end = addDays(new Date(Date.UTC(startYear + 1, startMonth - 1, startDay)), -1);
+
+  return {
+    label: `${startYear}-${startYear + 1}`,
+    startDate: toIsoDate(start),
+    endDate: toIsoDate(end)
+  };
+}
+
+/**
+ * Get the organization's active scout year.
+ *
+ * @param {Object} pool - Database pool or client
+ * @param {number} organizationId - Organization ID
+ * @returns {Promise<Object|null>} Active scout year row, or null
+ */
+async function getActiveScoutYear(pool, organizationId) {
+  const result = await pool.query(
+    `SELECT id, organization_id, label, start_date, end_date, status
+       FROM scout_years
+      WHERE organization_id = $1 AND status = 'active'
+      LIMIT 1`,
+    [organizationId]
+  );
+  return result.rows[0] || null;
+}
+
+/**
+ * Get the active scout year, creating it if the organization has none.
+ *
+ * Used as a safety net so an organization that never ran a transition still has
+ * a year to attach data to.
+ *
+ * @param {Object} pool - Database pool or client
+ * @param {number} organizationId - Organization ID
+ * @returns {Promise<Object>} Active scout year row
+ */
+async function ensureActiveScoutYear(pool, organizationId) {
+  const existing = await getActiveScoutYear(pool, organizationId);
+  if (existing) {
+    return existing;
+  }
+
+  const bounds = await computeYearBounds(pool, organizationId);
+  const result = await pool.query(
+    `INSERT INTO scout_years (organization_id, label, start_date, end_date, status)
+     VALUES ($1, $2, $3, $4, 'active')
+     ON CONFLICT (organization_id, label) DO UPDATE SET status = 'active'
+     RETURNING id, organization_id, label, start_date, end_date, status`,
+    [organizationId, bounds.label, bounds.startDate, bounds.endDate]
+  );
+  return result.rows[0];
+}
+
+/**
+ * List an organization's scout years, most recent first.
+ *
+ * @param {Object} pool - Database pool or client
+ * @param {number} organizationId - Organization ID
+ * @returns {Promise<Array<Object>>} Scout years with participant counts
+ */
+async function listScoutYears(pool, organizationId) {
+  const result = await pool.query(
+    `SELECT sy.id, sy.label, sy.start_date, sy.end_date, sy.status,
+            sy.closed_at, sy.closed_by,
+            COUNT(pe.participant_id) FILTER (WHERE pe.status = 'active') AS active_participants,
+            COUNT(pe.participant_id) AS total_enrollments
+       FROM scout_years sy
+       LEFT JOIN participant_enrollments pe
+         ON pe.scout_year_id = sy.id AND pe.organization_id = sy.organization_id
+      WHERE sy.organization_id = $1
+      GROUP BY sy.id
+      ORDER BY sy.start_date DESC`,
+    [organizationId]
+  );
+  return result.rows;
+}
+
+/**
+ * Resolve which scout year a request is about.
+ *
+ * Falls back to the active year when no year is requested. A requested year that
+ * does not belong to the organization is rejected rather than silently ignored.
+ *
+ * @param {Object} pool - Database pool or client
+ * @param {number} organizationId - Organization ID
+ * @param {number|string|null} requestedYearId - Explicitly requested year, if any
+ * @returns {Promise<Object>} Scout year row
+ * @throws {Error} When the requested year does not belong to the organization
+ */
+async function resolveScoutYear(pool, organizationId, requestedYearId = null) {
+  if (requestedYearId === null || requestedYearId === undefined || requestedYearId === '') {
+    return ensureActiveScoutYear(pool, organizationId);
+  }
+
+  const parsed = parseInt(requestedYearId, 10);
+  if (Number.isNaN(parsed)) {
+    const invalid = new Error('Invalid scout year identifier');
+    invalid.code = 'INVALID_SCOUT_YEAR';
+    throw invalid;
+  }
+
+  const result = await pool.query(
+    `SELECT id, organization_id, label, start_date, end_date, status
+       FROM scout_years
+      WHERE id = $1 AND organization_id = $2`,
+    [parsed, organizationId]
+  );
+
+  if (result.rows.length === 0) {
+    const notFound = new Error('Scout year not found for this organization');
+    notFound.code = 'SCOUT_YEAR_NOT_FOUND';
+    throw notFound;
+  }
+
+  return result.rows[0];
+}
+
+/**
+ * Close the active year and open the next one.
+ *
+ * Boundary handling keeps the "active year contains today" invariant:
+ * - transition run **early** (before the nominal start): the new year starts
+ *   today and the closed year ends yesterday;
+ * - transition run **late** (after the nominal start): the new year keeps its
+ *   nominal start, and points already awarded since that date are re-stamped
+ *   from the closed year onto the new one.
+ *
+ * Does not move participants — that is the caller's job, inside the same
+ * transaction.
+ *
+ * @param {Object} client - Database client inside an open transaction
+ * @param {Object} options - Options
+ * @param {number} options.organizationId - Organization ID
+ * @param {string} options.userId - UUID of the user performing the transition
+ * @returns {Promise<{previousYear: Object|null, newYear: Object, restampedPoints: number}>} Result
+ */
+async function openNextScoutYear(client, { organizationId, userId }) {
+  const previousYear = await getActiveScoutYear(client, organizationId);
+  const now = today();
+
+  const nominalReference = previousYear
+    ? addDays(toUtcDate(previousYear.end_date), 1)
+    : now;
+  const nominal = await computeYearBounds(client, organizationId, nominalReference);
+
+  const nominalStart = toUtcDate(nominal.startDate);
+  const effectiveStart = nominalStart > now ? now : nominalStart;
+
+  if (previousYear && toUtcDate(previousYear.end_date) >= effectiveStart) {
+    await client.query(
+      `UPDATE scout_years SET end_date = $1, updated_at = now() WHERE id = $2`,
+      [toIsoDate(addDays(effectiveStart, -1)), previousYear.id]
+    );
+  }
+
+  if (previousYear) {
+    await client.query(
+      `UPDATE scout_years
+          SET status = 'closed', closed_at = now(), closed_by = $1, updated_at = now()
+        WHERE id = $2`,
+      [userId, previousYear.id]
+    );
+  }
+
+  const created = await client.query(
+    `INSERT INTO scout_years (organization_id, label, start_date, end_date, status)
+     VALUES ($1, $2, $3, $4, 'active')
+     ON CONFLICT (organization_id, label)
+     DO UPDATE SET status = 'active', start_date = EXCLUDED.start_date,
+                   end_date = EXCLUDED.end_date, updated_at = now()
+     RETURNING id, organization_id, label, start_date, end_date, status`,
+    [organizationId, nominal.label, toIsoDate(effectiveStart), nominal.endDate]
+  );
+  const newYear = created.rows[0];
+
+  // Late transition: points awarded since the nominal start belong to the new year.
+  let restampedPoints = 0;
+  if (previousYear && effectiveStart < now) {
+    const restamped = await client.query(
+      `UPDATE points
+          SET scout_year_id = $1
+        WHERE organization_id = $2
+          AND scout_year_id = $3
+          AND created_at::date >= $4`,
+      [newYear.id, organizationId, previousYear.id, toIsoDate(effectiveStart)]
+    );
+    restampedPoints = restamped.rowCount;
+  }
+
+  return { previousYear, newYear, restampedPoints };
+}
+
+/**
+ * List memberships whose linked participants are no longer enrolled.
+ *
+ * A user is considered linked to a participant either directly
+ * (`user_participants`) or through a guardian record (`guardian_users` ->
+ * `participant_guardians`). Memberships holding any role other than a parent
+ * role are never listed: a leader who is also a parent must keep their access.
+ *
+ * @param {Object} pool - Database pool or client
+ * @param {number} organizationId - Organization ID
+ * @param {number} scoutYearId - Scout year the enrollment check runs against
+ * @param {Array<string>} [parentRoleNames] - Role names considered "parent only"
+ * @returns {Promise<Array<Object>>} Candidate memberships
+ */
+async function listMembershipsWithoutEnrolledChild(
+  pool,
+  organizationId,
+  scoutYearId,
+  parentRoleNames = ['parent', 'guardian', 'demoparent']
+) {
+  const result = await pool.query(
+    `WITH membership_roles AS (
+       SELECT uo.id AS membership_id,
+              uo.user_id,
+              uo.status,
+              ARRAY_AGG(DISTINCT r.role_name::text) FILTER (WHERE r.role_name IS NOT NULL) AS role_names
+         FROM user_organizations uo
+         LEFT JOIN LATERAL jsonb_array_elements_text(uo.role_ids) AS role_id_text ON TRUE
+         LEFT JOIN roles r ON r.id = role_id_text::integer
+        WHERE uo.organization_id = $1
+        GROUP BY uo.id, uo.user_id, uo.status
+     ),
+     linked_participants AS (
+       SELECT up.user_id, up.participant_id
+         FROM user_participants up
+       UNION
+       SELECT gu.user_id, pg.participant_id
+         FROM guardian_users gu
+         JOIN participant_guardians pg ON pg.guardian_id = gu.guardian_id
+     )
+     SELECT mr.membership_id,
+            mr.user_id,
+            mr.status,
+            mr.role_names,
+            u.email,
+            u.full_name,
+            COALESCE(
+              ARRAY_AGG(DISTINCT p.first_name || ' ' || p.last_name)
+                FILTER (WHERE p.id IS NOT NULL),
+              ARRAY[]::text[]
+            ) AS past_children
+       FROM membership_roles mr
+       JOIN users u ON u.id = mr.user_id
+       LEFT JOIN linked_participants lp ON lp.user_id = mr.user_id
+       LEFT JOIN participants p ON p.id = lp.participant_id
+      WHERE mr.status = 'active'
+        AND mr.role_names IS NOT NULL
+        AND mr.role_names <@ $3::text[]
+        AND NOT EXISTS (
+          SELECT 1
+            FROM linked_participants lp2
+            JOIN participant_enrollments pe
+              ON pe.participant_id = lp2.participant_id
+             AND pe.organization_id = $1
+             AND pe.scout_year_id = $2
+             AND pe.status = 'active'
+           WHERE lp2.user_id = mr.user_id
+        )
+      GROUP BY mr.membership_id, mr.user_id, mr.status, mr.role_names, u.email, u.full_name
+      ORDER BY u.full_name NULLS LAST, u.email`,
+    [organizationId, scoutYearId, parentRoleNames]
+  );
+
+  return result.rows;
+}
+
+module.exports = {
+  DEFAULT_FISCAL_START_MONTH,
+  DEFAULT_FISCAL_START_DAY,
+  getFiscalYearStart,
+  computeYearBounds,
+  getActiveScoutYear,
+  ensureActiveScoutYear,
+  listScoutYears,
+  resolveScoutYear,
+  openNextScoutYear,
+  listMembershipsWithoutEnrolledChild
+};

--- a/test/routes-participants.test.js
+++ b/test/routes-participants.test.js
@@ -309,7 +309,19 @@ describe('POST /api/v1/participants', () => {
           }]
         });
       }
-      if (query.includes('INSERT INTO participant_organizations')) {
+      if (query.includes('FROM scout_years')) {
+        return Promise.resolve({
+          rows: [{
+            id: 1,
+            organization_id: 1,
+            label: '2025-2026',
+            start_date: '2025-09-01',
+            end_date: '2026-08-31',
+            status: 'active'
+          }]
+        });
+      }
+      if (query.includes('INSERT INTO participant_enrollments')) {
         return Promise.resolve({ rows: [{}] });
       }
       if (query.includes('permission_key')) {

--- a/test/routes-points.test.js
+++ b/test/routes-points.test.js
@@ -84,6 +84,18 @@ describe('GET /api/v1/points', () => {
       if (query.includes('role_name')) {
         return Promise.resolve({ rows: [{ role_name: 'admin', display_name: 'Admin' }] });
       }
+      if (query.includes('FROM scout_years')) {
+        return Promise.resolve({
+          rows: [{
+            id: 1,
+            organization_id: 1,
+            label: '2025-2026',
+            start_date: '2025-09-01',
+            end_date: '2026-08-31',
+            status: 'active'
+          }]
+        });
+      }
       if (query.includes('FROM groups g') && query.includes('member_points')) {
         groupQuery = query;
         return Promise.resolve({
@@ -120,6 +132,9 @@ describe('GET /api/v1/points', () => {
     });
     expect(groupQuery).toContain('participant_id IS NULL');
     expect(groupQuery).toContain('participant_id IS NOT NULL');
+    // Totals belong to a scout year, so opening a new year resets the score.
+    expect(groupQuery).toContain('scout_year_id');
+    expect(res.body.scout_year).toMatchObject({ label: '2025-2026', status: 'active' });
   });
 });
 

--- a/test/user-stories/backend-points.stories.test.js
+++ b/test/user-stories/backend-points.stories.test.js
@@ -48,12 +48,32 @@ function generateToken(overrides = {}) {
   }, TEST_SECRET);
 }
 
+/**
+ * Point totals are scoped to a scout year, so every points route resolves the
+ * active year first. Answer that lookup for all stories unless one overrides it.
+ */
+const ACTIVE_SCOUT_YEAR = {
+  id: 7,
+  organization_id: ORG_ID,
+  label: '2025-2026',
+  start_date: '2025-09-01',
+  end_date: '2026-08-31',
+  status: 'active'
+};
+
 function installHandler(storyHandler) {
   const { __mClient, __mPool } = require('pg');
   const recorded = [];
   mockQueryImplementation(__mClient, __mPool, (query, params) => {
     recorded.push({ query, params });
-    return storyHandler(query, params);
+    const storyResult = storyHandler(query, params);
+    if (storyResult !== undefined) {
+      return storyResult;
+    }
+    if (query.includes('FROM scout_years')) {
+      return { rows: [ACTIVE_SCOUT_YEAR] };
+    }
+    return undefined;
   });
   return recorded;
 }


### PR DESCRIPTION
L'année scoute devient une dimension de première classe : une transition de fin d'année ne supprime plus rien, elle change l'année de référence. Les points repartent à zéro parce qu'on change d'année, pas parce qu'on efface des lignes, et un jeune ou un parent parti reste consultable dans les archives.

Base de données (migrations/create_scout_years_and_enrollments.sql) :
- scout_years, une seule année active par organisation, contrainte d'exclusion contre le chevauchement ; historique amorcé depuis la plus ancienne trace d'activité de l'unité ;
- participant_organizations renommée participant_enrollments (annuelle), et recréée en VUE filtrée sur l'année active : les 85 jointures existantes fonctionnent sans modification ;
- points.scout_year_id + trigger d'estampillage couvrant les 8 sites d'écriture, les imports et le SQL manuel ; vue active_year_points ;
- user_organizations.status (active/inactive/alumni) ;
- scout_year_transitions, journal avec changeset pour une annulation future ; permissions scout_year.view et scout_year.manage.

La migration ne supprime jamais de ligne : une inscription impossible à rattacher à une année lève une exception et annule tout.

Backend :
- services/scoutYear.js et helpers getScoutYear/getScoutYearId ;
- statut de membership appliqué à la connexion, aux permissions et aux destinataires d'annonces ; un compte désactivé garde ses liens et son historique et reste réactivable ;
- routes/scoutYears.js : prévisualisation de la transition (étape de vérification, sans effet de bord), exécution transactionnelle avec exceptions nominatives, gestion manuelle des memberships ;
- DELETE participants ferme l'inscription au lieu de supprimer ;
- les agrégats de points lisent l'année active et les requêtes qui énumèrent une sixaine sont jointes à l'effectif.

Garde-fous dans le SQL et non seulement dans l'interface : un compte portant un rôle non-parent n'est jamais désactivé, et un jeune sans date de naissance n'est jamais sorti automatiquement.

Vérifié par une transition complète jouée bout en bout sur PostgreSQL 16 contre les vraies routes, migration ré-exécutée pour l'idempotence.

Interface, annulation, sélecteur d'année et renouvellement des fiches restent à faire : voir devdocs/GESTION_ANNEE_SCOUTE.md §9.