### PR TITLE
fix: serve campaigns whether or not migration 004 has been applied

### DIFF
--- a/routes/calendars.js
+++ b/routes/calendars.js
@@ -16,7 +16,13 @@ const {
   getOrganizationId,
 } = require('../middleware/auth');
 const { success, error, asyncHandler } = require('../middleware/response');
-const { entryAmountSql, toNullableNumber } = require('../services/fundraiserCampaigns');
+const {
+  campaignModelColumnsSql,
+  entryAmountSql,
+  entryMeasureColumnsSql,
+  hasCampaignModelColumns,
+  toNullableNumber,
+} = require('../services/fundraiserCampaigns');
 
 /**
  * Export route factory function
@@ -63,8 +69,10 @@ module.exports = (pool, logger) => {
         return error(res, 'fundraiser_id is required', 400);
       }
 
+      const extended = await hasCampaignModelColumns(pool);
+
       const fundraiserCheck = await pool.query(
-        `SELECT id, campaign_type, unit_price, unit_label
+        `SELECT id, ${campaignModelColumnsSql('fundraisers', extended)}
          FROM fundraisers WHERE id = $1 AND organization = $2`,
         [fundraiserId, organizationId]
       );
@@ -75,8 +83,8 @@ module.exports = (pool, logger) => {
 
       const result = await pool.query(
         `SELECT c.id, c.participant_id, c.amount as calendar_amount, c.amount_paid, c.paid, c.updated_at, c.fundraiser,
-                c.quantity, c.hours, c.amount_raised,
-                ${entryAmountSql()} as entry_amount,
+                ${entryMeasureColumnsSql('c', extended)},
+                ${entryAmountSql('c', 'f', extended)} as entry_amount,
                 p.first_name, p.last_name, g.name as group_name, pg.group_id
          FROM fundraiser_entries c
          JOIN fundraisers f ON c.fundraiser = f.id
@@ -154,6 +162,8 @@ module.exports = (pool, logger) => {
         return error(res, 'Invalid fundraiser entry data', 400, measureErrors);
       }
 
+      const extended = await hasCampaignModelColumns(pool);
+
       const verifyResult = await pool.query(
         `SELECT c.* FROM fundraiser_entries c
          JOIN fundraisers f ON c.fundraiser = f.id
@@ -176,28 +186,43 @@ module.exports = (pool, logger) => {
       // Each measure is guarded by its own "was it sent?" flag rather than
       // COALESCE, so clearing a field (sending null for an emptied input)
       // actually clears it instead of silently keeping the previous value.
-      const result = await pool.query(
-        `UPDATE fundraiser_entries
-         SET amount = CASE WHEN $1::boolean THEN $2::integer ELSE amount END,
-             amount_paid = CASE WHEN $3::boolean THEN $4::double precision ELSE amount_paid END,
-             paid = CASE WHEN $5::boolean THEN $6::boolean ELSE paid END,
-             quantity = CASE WHEN $7::boolean THEN $8::numeric ELSE quantity END,
-             hours = CASE WHEN $9::boolean THEN $10::numeric ELSE hours END,
-             amount_raised = CASE WHEN $11::boolean THEN $12::numeric ELSE amount_raised END,
-             updated_at = CURRENT_TIMESTAMP
-         WHERE id = $13
-         RETURNING *`,
-        [
-          // `amount` is NOT NULL, so it is only written when a value is known.
-          quantityProvided && legacyAmount !== null, legacyAmount,
-          amount_paid !== undefined, toNullableNumber(amount_paid),
-          paid !== undefined, paid === undefined ? null : Boolean(paid),
-          quantityProvided, nextQuantity,
-          hours !== undefined, toNullableNumber(hours),
-          amount_raised !== undefined, toNullableNumber(amount_raised),
-          id,
-        ]
-      );
+      // `amount` is NOT NULL, so it is only written when a value is known.
+      const legacyParams = [
+        quantityProvided && legacyAmount !== null, legacyAmount,
+        amount_paid !== undefined, toNullableNumber(amount_paid),
+        paid !== undefined, paid === undefined ? null : Boolean(paid),
+      ];
+
+      const result = extended
+        ? await pool.query(
+          `UPDATE fundraiser_entries
+           SET amount = CASE WHEN $1::boolean THEN $2::integer ELSE amount END,
+               amount_paid = CASE WHEN $3::boolean THEN $4::double precision ELSE amount_paid END,
+               paid = CASE WHEN $5::boolean THEN $6::boolean ELSE paid END,
+               quantity = CASE WHEN $7::boolean THEN $8::numeric ELSE quantity END,
+               hours = CASE WHEN $9::boolean THEN $10::numeric ELSE hours END,
+               amount_raised = CASE WHEN $11::boolean THEN $12::numeric ELSE amount_raised END,
+               updated_at = CURRENT_TIMESTAMP
+           WHERE id = $13
+           RETURNING *`,
+          [
+            ...legacyParams,
+            quantityProvided, nextQuantity,
+            hours !== undefined, toNullableNumber(hours),
+            amount_raised !== undefined, toNullableNumber(amount_raised),
+            id,
+          ]
+        )
+        : await pool.query(
+          `UPDATE fundraiser_entries
+           SET amount = CASE WHEN $1::boolean THEN $2::integer ELSE amount END,
+               amount_paid = CASE WHEN $3::boolean THEN $4::double precision ELSE amount_paid END,
+               paid = CASE WHEN $5::boolean THEN $6::boolean ELSE paid END,
+               updated_at = CURRENT_TIMESTAMP
+           WHERE id = $7
+           RETURNING *`,
+          [...legacyParams, id]
+        );
 
       return success(res, result.rows[0], 'Fundraiser entry updated');
     })
@@ -248,8 +273,10 @@ module.exports = (pool, logger) => {
         return error(res, 'Amount paid is required', 400);
       }
 
+      const extended = await hasCampaignModelColumns(pool);
+
       const currentResult = await pool.query(
-        `SELECT ${entryAmountSql()} as entry_amount
+        `SELECT ${entryAmountSql('c', 'f', extended)} as entry_amount
          FROM fundraiser_entries c
          JOIN fundraisers f ON c.fundraiser = f.id
          WHERE c.id = $1 AND f.organization = $2`,

--- a/routes/fundraisers.js
+++ b/routes/fundraisers.js
@@ -15,7 +15,11 @@ const { asyncHandler, success, error } = require('../middleware/response');
 const {
   CAMPAIGN_TYPE_KEYS,
   DEFAULT_CAMPAIGN_TYPE,
+  campaignModelColumnsSql,
   entryAmountSql,
+  entryHoursSql,
+  entryQuantitySql,
+  hasCampaignModelColumns,
   isValidCampaignType,
   toNullableNumber,
 } = require('../services/fundraiserCampaigns');
@@ -161,6 +165,7 @@ module.exports = (pool, logger) => {
   router.get('/', authenticate, requirePermission('fundraisers.view'), asyncHandler(async (req, res) => {
       const organizationId = await getOrganizationId(req, pool);
       const includeArchived = req.query.include_archived === 'true';
+      const extended = await hasCampaignModelColumns(pool);
 
       let query = `
         SELECT
@@ -172,13 +177,11 @@ module.exports = (pool, logger) => {
           f.result,
           f.archived,
           f.created_at,
-          f.campaign_type,
-          f.unit_price,
-          f.unit_label,
+          ${campaignModelColumnsSql('f', extended)},
           COUNT(DISTINCT c.id) as participant_count,
-          COALESCE(SUM(${entryAmountSql()}), 0) as total_amount,
-          COALESCE(SUM(c.quantity), 0) as total_quantity,
-          COALESCE(SUM(c.hours), 0) as total_hours,
+          COALESCE(SUM(${entryAmountSql('c', 'f', extended)}), 0) as total_amount,
+          COALESCE(SUM(${entryQuantitySql('c', extended)}), 0) as total_quantity,
+          COALESCE(SUM(${entryHoursSql('c', extended)}), 0) as total_hours,
           COALESCE(SUM(c.amount_paid), 0) as total_paid
         FROM fundraisers f
         LEFT JOIN fundraiser_entries c ON c.fundraiser = f.id
@@ -190,8 +193,8 @@ module.exports = (pool, logger) => {
       }
 
       query += `
-        GROUP BY f.id, f.name, f.start_date, f.end_date, f.objective, f.result, f.archived, f.created_at,
-                 f.campaign_type, f.unit_price, f.unit_label
+        GROUP BY f.id, f.name, f.start_date, f.end_date, f.objective, f.result, f.archived, f.created_at
+                 ${extended ? ', f.campaign_type, f.unit_price, f.unit_label' : ''}
         ORDER BY f.start_date DESC, f.created_at DESC
       `;
 
@@ -224,13 +227,17 @@ module.exports = (pool, logger) => {
   router.get('/:id', authenticate, requirePermission('fundraisers.view'), asyncHandler(async (req, res) => {
       const organizationId = await getOrganizationId(req, pool);
       const { id } = req.params;
+      const extended = await hasCampaignModelColumns(pool);
 
       const result = await pool.query(
         `SELECT f.*,
+                ${extended ? '' : `'${DEFAULT_CAMPAIGN_TYPE}'::text AS campaign_type,
+                NULL::numeric AS unit_price,
+                NULL::text AS unit_label,`}
                 COUNT(DISTINCT c.id) as participant_count,
-                COALESCE(SUM(${entryAmountSql()}), 0) as total_amount,
-                COALESCE(SUM(c.quantity), 0) as total_quantity,
-                COALESCE(SUM(c.hours), 0) as total_hours,
+                COALESCE(SUM(${entryAmountSql('c', 'f', extended)}), 0) as total_amount,
+                COALESCE(SUM(${entryQuantitySql('c', extended)}), 0) as total_quantity,
+                COALESCE(SUM(${entryHoursSql('c', extended)}), 0) as total_hours,
                 COALESCE(SUM(c.amount_paid), 0) as total_paid
          FROM fundraisers f
          LEFT JOIN fundraiser_entries c ON c.fundraiser = f.id
@@ -292,28 +299,56 @@ module.exports = (pool, logger) => {
         return error(res, 'Invalid campaign data', 400, validationErrors);
       }
 
+      const extended = await hasCampaignModelColumns(pool);
+
+      if (!extended && values.campaign_type !== DEFAULT_CAMPAIGN_TYPE) {
+        // The campaign is still created and usable, but its type cannot be
+        // stored yet. Make that visible to operators instead of silently
+        // downgrading it.
+        logger?.warn?.(
+          `Campaign type "${values.campaign_type}" stored as "${DEFAULT_CAMPAIGN_TYPE}": ` +
+          'migration 004_fundraiser_campaign_model.sql has not been applied to this database.'
+        );
+      }
+
       // Start a transaction
       const client = await pool.connect();
       try {
         await client.query('BEGIN');
 
-        // Create fundraiser
-        const fundraiserResult = await client.query(
-          `INSERT INTO fundraisers
-             (name, start_date, end_date, objective, organization, archived, campaign_type, unit_price, unit_label)
-           VALUES ($1, $2, $3, $4, $5, false, $6, $7, $8)
-           RETURNING *`,
-          [
-            values.name,
-            values.start_date,
-            values.end_date,
-            values.objective ?? null,
-            organizationId,
-            values.campaign_type,
-            values.unit_price ?? null,
-            values.unit_label ?? null,
-          ]
-        );
+        // Create fundraiser. The generalised columns are only written when
+        // they exist, so campaign creation keeps working on a database where
+        // migration 004 has not been applied yet.
+        const fundraiserResult = extended
+          ? await client.query(
+            `INSERT INTO fundraisers
+               (name, start_date, end_date, objective, organization, archived, campaign_type, unit_price, unit_label)
+             VALUES ($1, $2, $3, $4, $5, false, $6, $7, $8)
+             RETURNING *`,
+            [
+              values.name,
+              values.start_date,
+              values.end_date,
+              values.objective ?? null,
+              organizationId,
+              values.campaign_type,
+              values.unit_price ?? null,
+              values.unit_label ?? null,
+            ]
+          )
+          : await client.query(
+            `INSERT INTO fundraisers
+               (name, start_date, end_date, objective, organization, archived)
+             VALUES ($1, $2, $3, $4, $5, false)
+             RETURNING *`,
+            [
+              values.name,
+              values.start_date,
+              values.end_date,
+              values.objective ?? null,
+              organizationId,
+            ]
+          );
 
         const fundraiser = fundraiserResult.rows[0];
 
@@ -353,7 +388,15 @@ module.exports = (pool, logger) => {
 
         return success(
           res,
-          { fundraiser, participants_added: participantsResult.rows.length },
+          {
+            fundraiser: extended ? fundraiser : {
+              ...fundraiser,
+              campaign_type: DEFAULT_CAMPAIGN_TYPE,
+              unit_price: null,
+              unit_label: null,
+            },
+            participants_added: participantsResult.rows.length,
+          },
           'Fundraiser created',
           201
         );
@@ -420,6 +463,8 @@ module.exports = (pool, logger) => {
         return error(res, 'Invalid campaign data', 400, validationErrors);
       }
 
+      const extended = await hasCampaignModelColumns(pool);
+
       // A partial update needs both start and end dates to compare them, so
       // re-check the ordering against the stored row when only one was sent.
       if ((values.start_date && !values.end_date) || (values.end_date && !values.start_date)) {
@@ -440,31 +485,51 @@ module.exports = (pool, logger) => {
         }
       }
 
-      const updateResult = await pool.query(
-        `UPDATE fundraisers
-         SET name = COALESCE($1, name),
-             start_date = COALESCE($2, start_date),
-             end_date = COALESCE($3, end_date),
-             objective = COALESCE($4, objective),
-             result = COALESCE($5, result),
-             campaign_type = COALESCE($6, campaign_type),
-             unit_price = COALESCE($7, unit_price),
-             unit_label = COALESCE($8, unit_label)
-         WHERE id = $9 AND organization = $10
-         RETURNING *`,
-        [
-          values.name ?? null,
-          values.start_date ?? null,
-          values.end_date ?? null,
-          values.objective ?? null,
-          values.result ?? null,
-          values.campaign_type ?? null,
-          values.unit_price ?? null,
-          values.unit_label ?? null,
-          id,
-          organizationId,
-        ]
-      );
+      const updateResult = extended
+        ? await pool.query(
+          `UPDATE fundraisers
+           SET name = COALESCE($1, name),
+               start_date = COALESCE($2, start_date),
+               end_date = COALESCE($3, end_date),
+               objective = COALESCE($4, objective),
+               result = COALESCE($5, result),
+               campaign_type = COALESCE($6, campaign_type),
+               unit_price = COALESCE($7, unit_price),
+               unit_label = COALESCE($8, unit_label)
+           WHERE id = $9 AND organization = $10
+           RETURNING *`,
+          [
+            values.name ?? null,
+            values.start_date ?? null,
+            values.end_date ?? null,
+            values.objective ?? null,
+            values.result ?? null,
+            values.campaign_type ?? null,
+            values.unit_price ?? null,
+            values.unit_label ?? null,
+            id,
+            organizationId,
+          ]
+        )
+        : await pool.query(
+          `UPDATE fundraisers
+           SET name = COALESCE($1, name),
+               start_date = COALESCE($2, start_date),
+               end_date = COALESCE($3, end_date),
+               objective = COALESCE($4, objective),
+               result = COALESCE($5, result)
+           WHERE id = $6 AND organization = $7
+           RETURNING *`,
+          [
+            values.name ?? null,
+            values.start_date ?? null,
+            values.end_date ?? null,
+            values.objective ?? null,
+            values.result ?? null,
+            id,
+            organizationId,
+          ]
+        );
 
       if (updateResult.rows.length === 0) {
         return error(res, 'Fundraiser not found', 404);

--- a/services/fundraiserCampaigns.js
+++ b/services/fundraiserCampaigns.js
@@ -34,15 +34,88 @@ const CAMPAIGN_TYPE_KEYS = Object.freeze(Object.keys(CAMPAIGN_TYPES));
 /** Campaign type applied to campaigns created before the model was generalised. */
 const DEFAULT_CAMPAIGN_TYPE = 'fixed_price_sale';
 
+/** Columns migration 004 adds to `fundraisers`. */
+const CAMPAIGN_MODEL_COLUMNS = Object.freeze(['campaign_type', 'unit_price', 'unit_label']);
+
+/** Columns migration 004 adds to `fundraiser_entries`. */
+const ENTRY_MEASURE_COLUMNS = Object.freeze(['quantity', 'hours', 'amount_raised']);
+
+/**
+ * Cached "has migration 004 been applied?" answer, keyed by pool.
+ * @type {WeakMap<Object, Promise<boolean>>}
+ */
+const schemaSupportCache = new WeakMap();
+
+/**
+ * Whether the generalised campaign columns exist in this database.
+ *
+ * The API must serve campaigns whether or not migration 004 has run yet:
+ * a deploy that reaches the app before the migration would otherwise make
+ * every campaign query fail with "column f.campaign_type does not exist",
+ * taking the whole screen down. The answer is looked up once per pool.
+ *
+ * @param {Object} pool - Database connection pool
+ * @returns {Promise<boolean>} True when the campaign model columns are present
+ */
+function hasCampaignModelColumns(pool) {
+  const cached = schemaSupportCache.get(pool);
+  if (cached) {
+    return cached;
+  }
+
+  const lookup = pool.query(
+    `SELECT
+       COUNT(*) FILTER (
+         WHERE table_name = 'fundraisers' AND column_name = ANY($1::text[])
+       ) AS campaign_columns,
+       COUNT(*) FILTER (
+         WHERE table_name = 'fundraiser_entries' AND column_name = ANY($2::text[])
+       ) AS entry_columns
+     FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND table_name IN ('fundraisers', 'fundraiser_entries')`,
+    [[...CAMPAIGN_MODEL_COLUMNS], [...ENTRY_MEASURE_COLUMNS]]
+  ).then((result) => {
+    const row = result.rows[0] || {};
+    return Number(row.campaign_columns) === CAMPAIGN_MODEL_COLUMNS.length
+      && Number(row.entry_columns) === ENTRY_MEASURE_COLUMNS.length;
+  }).catch(() => {
+    // Never let schema detection itself break a request: fall back to the
+    // legacy shape, which every database has, and retry on the next call.
+    schemaSupportCache.delete(pool);
+    return false;
+  });
+
+  schemaSupportCache.set(pool, lookup);
+  return lookup;
+}
+
+/**
+ * Forget the cached schema answer (used by tests and after a migration run).
+ *
+ * @param {Object} [pool] - Pool to forget; omit to forget nothing in particular
+ * @returns {void}
+ */
+function resetCampaignModelSchemaCache(pool) {
+  if (pool) {
+    schemaSupportCache.delete(pool);
+  }
+}
+
 /**
  * SQL expression resolving the money raised by one fundraiser entry.
  * Written as a fragment so list, detail and report queries stay consistent.
  *
  * @param {string} [entryAlias='c'] - Alias of the fundraiser_entries table
  * @param {string} [campaignAlias='f'] - Alias of the fundraisers table
+ * @param {boolean} [extended=true] - Whether the campaign model columns exist
  * @returns {string} SQL expression yielding a numeric amount
  */
-function entryAmountSql(entryAlias = 'c', campaignAlias = 'f') {
+function entryAmountSql(entryAlias = 'c', campaignAlias = 'f', extended = true) {
+  if (!extended) {
+    // Pre-migration, the legacy amount column is the only measure there is.
+    return `${entryAlias}.amount`;
+  }
   return `COALESCE(
     ${entryAlias}.amount_raised,
     CASE
@@ -52,6 +125,64 @@ function entryAmountSql(entryAlias = 'c', campaignAlias = 'f') {
     END,
     ${entryAlias}.amount
   )`;
+}
+
+/**
+ * Campaign shape columns, or the legacy defaults when they do not exist yet,
+ * so the response shape is identical either way.
+ *
+ * @param {string} [campaignAlias='f'] - Alias of the fundraisers table
+ * @param {boolean} [extended=true] - Whether the campaign model columns exist
+ * @returns {string} Comma separated select list (no trailing comma)
+ */
+function campaignModelColumnsSql(campaignAlias = 'f', extended = true) {
+  if (!extended) {
+    return `'${DEFAULT_CAMPAIGN_TYPE}'::text AS campaign_type,
+            NULL::numeric AS unit_price,
+            NULL::text AS unit_label`;
+  }
+  return CAMPAIGN_MODEL_COLUMNS.map((column) => `${campaignAlias}.${column}`).join(',\n            ');
+}
+
+/**
+ * Per-entry measure columns, or the legacy defaults.
+ *
+ * The legacy `amount` column held a unit count, so it maps onto `quantity` —
+ * the same mapping migration 004 performs when it backfills.
+ *
+ * @param {string} [entryAlias='c'] - Alias of the fundraiser_entries table
+ * @param {boolean} [extended=true] - Whether the entry measure columns exist
+ * @returns {string} Comma separated select list (no trailing comma)
+ */
+function entryMeasureColumnsSql(entryAlias = 'c', extended = true) {
+  if (!extended) {
+    return `${entryAlias}.amount::numeric AS quantity,
+            NULL::numeric AS hours,
+            NULL::numeric AS amount_raised`;
+  }
+  return ENTRY_MEASURE_COLUMNS.map((column) => `${entryAlias}.${column}`).join(',\n            ');
+}
+
+/**
+ * Expression for a participant's unit count, whichever schema is in place.
+ *
+ * @param {string} [entryAlias='c'] - Alias of the fundraiser_entries table
+ * @param {boolean} [extended=true] - Whether the entry measure columns exist
+ * @returns {string} SQL expression yielding a numeric unit count
+ */
+function entryQuantitySql(entryAlias = 'c', extended = true) {
+  return extended ? `${entryAlias}.quantity` : `${entryAlias}.amount`;
+}
+
+/**
+ * Expression for a participant's worked hours, whichever schema is in place.
+ *
+ * @param {string} [entryAlias='c'] - Alias of the fundraiser_entries table
+ * @param {boolean} [extended=true] - Whether the entry measure columns exist
+ * @returns {string} SQL expression yielding numeric hours
+ */
+function entryHoursSql(entryAlias = 'c', extended = true) {
+  return extended ? `${entryAlias}.hours` : 'NULL::numeric';
 }
 
 /**
@@ -115,12 +246,20 @@ function resolveEntryAmount(entry = {}, campaign = {}) {
 }
 
 module.exports = {
+  CAMPAIGN_MODEL_COLUMNS,
   CAMPAIGN_TYPES,
   CAMPAIGN_TYPE_KEYS,
   DEFAULT_CAMPAIGN_TYPE,
+  ENTRY_MEASURE_COLUMNS,
+  campaignModelColumnsSql,
   campaignTypeCapabilities,
   entryAmountSql,
+  entryHoursSql,
+  entryMeasureColumnsSql,
+  entryQuantitySql,
+  hasCampaignModelColumns,
   isValidCampaignType,
+  resetCampaignModelSchemaCache,
   resolveEntryAmount,
   toNullableNumber,
 };

--- a/test/routes-fundraiser-campaigns.test.js
+++ b/test/routes-fundraiser-campaigns.test.js
@@ -34,6 +34,10 @@ function createFixture() {
   const insertedCampaigns = [];
 
   const respond = async (query, params = []) => {
+    if (query.includes('information_schema.columns')) {
+      // Migration 004 has been applied in this fixture.
+      return { rows: [{ campaign_columns: '3', entry_columns: '3' }] };
+    }
     if (query.includes('SELECT organization_id FROM user_organizations')) {
       return { rows: [{ organization_id: ORGANIZATION_ID }] };
     }
@@ -276,6 +280,10 @@ describe('PUT /api/v1/calendars/:id', () => {
 
     const pool = {
       query: jest.fn(async (query, params = []) => {
+        if (query.includes('information_schema.columns')) {
+          // Migration 004 has been applied in this fixture.
+          return { rows: [{ campaign_columns: '3', entry_columns: '3' }] };
+        }
         if (query.includes('SELECT organization_id FROM user_organizations')) {
           return { rows: [{ organization_id: ORGANIZATION_ID }] };
         }
@@ -399,5 +407,185 @@ describe('PUT /api/v1/calendars/:id', () => {
       expect.arrayContaining([expect.objectContaining({ field: 'quantity' })]),
     );
     expect(updates).toHaveLength(0);
+  });
+});
+
+describe('databases where migration 004 has not been applied', () => {
+  /**
+   * A pool whose schema lookup reports the legacy shape, and which throws the
+   * error PostgreSQL really raises if a query touches a missing column.
+   *
+   * @returns {{app: import('express').Express, queries: string[]}}
+   */
+  function createLegacyFixture() {
+    const queries = [];
+    const legacyColumns = ['campaign_type', 'unit_price', 'unit_label', 'quantity', 'hours', 'amount_raised'];
+
+    const guard = (query) => {
+      queries.push(query);
+      // Reject exactly what a pre-migration database rejects: a reference to
+      // one of the new columns qualified by a table alias.
+      const offending = legacyColumns.find((column) => new RegExp(`\\b[a-z]+\\.${column}\\b`).test(query));
+      if (offending) {
+        throw new Error(`column f.${offending} does not exist`);
+      }
+    };
+
+    const pool = {
+      query: jest.fn(async (query, params = []) => {
+        if (query.includes('information_schema.columns')) {
+          // Legacy database: none of the new columns are present.
+          return { rows: [{ campaign_columns: '0', entry_columns: '0' }] };
+        }
+        if (query.includes('SELECT organization_id FROM user_organizations')) {
+          return { rows: [{ organization_id: ORGANIZATION_ID }] };
+        }
+        if (query.includes("role_name IN ('demoadmin', 'demoparent')")) {
+          return { rows: [] };
+        }
+        if (query.includes('SELECT DISTINCT p.permission_key')) {
+          return {
+            rows: ['fundraisers.view', 'fundraisers.create', 'fundraisers.edit', 'finance.view', 'finance.manage']
+              .map((permission_key) => ({ permission_key })),
+          };
+        }
+        if (query.includes('SELECT DISTINCT r.role_name')) {
+          return { rows: [{ role_name: 'district', display_name: 'District' }] };
+        }
+
+        guard(query);
+
+        if (query.includes('FROM fundraisers f')) {
+          return {
+            rows: [{
+              id: FUNDRAISER_ID,
+              name: 'Calendriers 2025',
+              campaign_type: 'fixed_price_sale',
+              unit_price: null,
+              unit_label: null,
+              total_amount: '12',
+              total_quantity: '12',
+              total_hours: '0',
+              total_paid: '120',
+            }],
+          };
+        }
+        if (query.includes('UPDATE fundraisers')) {
+          return { rows: [{ id: FUNDRAISER_ID, name: 'Renommee' }] };
+        }
+        return { rows: [] };
+      }),
+      connect: jest.fn(async () => ({
+        query: jest.fn(async (query, params = []) => {
+          if (query === 'BEGIN' || query === 'COMMIT' || query === 'ROLLBACK') {
+            return { rows: [] };
+          }
+          guard(query);
+          if (query.includes('INSERT INTO fundraisers')) {
+            return { rows: [{ id: FUNDRAISER_ID, name: params[0] }] };
+          }
+          return { rows: [] };
+        }),
+        release: jest.fn(),
+      })),
+    };
+
+    const app = express();
+    app.locals.pool = pool;
+    app.use(express.json());
+    const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    app.use('/api/v1/fundraisers', require('../routes/fundraisers')(pool, logger));
+    app.use('/api/v1/calendars', require('../routes/calendars')(pool, logger));
+
+    return { app, queries, logger, pool };
+  }
+
+  test('the campaign list still loads', async () => {
+    const { app } = createLegacyFixture();
+
+    const response = await request(app)
+      .get('/api/v1/fundraisers')
+      .set('Authorization', `Bearer ${token()}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.data.fundraisers).toHaveLength(1);
+  });
+
+  test('the response keeps the same shape, using the legacy defaults', async () => {
+    const { app } = createLegacyFixture();
+
+    const response = await request(app)
+      .get('/api/v1/fundraisers')
+      .set('Authorization', `Bearer ${token()}`);
+
+    const [campaign] = response.body.data.fundraisers;
+    // The client renders these unconditionally; they must always be present.
+    expect(campaign).toHaveProperty('campaign_type');
+    expect(campaign).toHaveProperty('unit_price');
+    expect(campaign).toHaveProperty('total_quantity');
+  });
+
+  test('a campaign can still be created', async () => {
+    const { app } = createLegacyFixture();
+
+    const response = await request(app)
+      .post('/api/v1/fundraisers')
+      .set('Authorization', `Bearer ${token()}`)
+      .send({ name: 'Nouvelle campagne', start_date: '2026-09-01', end_date: '2026-10-31' });
+
+    expect(response.status).toBe(201);
+    expect(response.body.data.fundraiser.campaign_type).toBe('fixed_price_sale');
+  });
+
+  test('a campaign type that cannot be stored yet is reported, not swallowed', async () => {
+    const { app, logger } = createLegacyFixture();
+
+    await request(app)
+      .post('/api/v1/fundraisers')
+      .set('Authorization', `Bearer ${token()}`)
+      .send({
+        name: 'Heures', start_date: '2026-09-01', end_date: '2026-10-31',
+        campaign_type: 'hours_worked',
+      });
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('004_fundraiser_campaign_model'));
+  });
+
+  test('a campaign can still be edited', async () => {
+    const { app } = createLegacyFixture();
+
+    const response = await request(app)
+      .put(`/api/v1/fundraisers/${FUNDRAISER_ID}`)
+      .set('Authorization', `Bearer ${token()}`)
+      .send({ name: 'Renommee' });
+
+    expect(response.status).toBe(200);
+  });
+
+  test('validation still rejects bad input with field errors', async () => {
+    const { app } = createLegacyFixture();
+
+    const response = await request(app)
+      .post('/api/v1/fundraisers')
+      .set('Authorization', `Bearer ${token()}`)
+      .send({ start_date: '2026-09-01', end_date: '2026-10-31' });
+
+    expect(response.status).toBe(400);
+    expect(response.body.errors).toEqual(
+      expect.arrayContaining([expect.objectContaining({ field: 'name' })]),
+    );
+  });
+
+  test('the schema is looked up once, not on every request', async () => {
+    const { app, pool } = createLegacyFixture();
+    const auth = `Bearer ${token()}`;
+
+    await request(app).get('/api/v1/fundraisers').set('Authorization', auth);
+    await request(app).get('/api/v1/fundraisers').set('Authorization', auth);
+    await request(app).get('/api/v1/fundraisers').set('Authorization', auth);
+
+    const lookups = (pool?.query.mock.calls || [])
+      .filter(([query]) => query.includes('information_schema.columns'));
+    expect(lookups.length).toBeLessThanOrEqual(1);
   });
 });


### PR DESCRIPTION
Follow-up to #1000. That PR is merged and cannot carry this change, so this is a new pull request on the same branch, restarted from `main`.

## Problem

The campaigns screen stopped loading entirely after #1000 shipped.

#1000 rewrote every campaign query to reference the columns migration `004_fundraiser_campaign_model.sql` adds. On a database where that migration has not run yet, PostgreSQL rejects them:

```
column f.campaign_type does not exist
```

The route answered 500, the client caught the failure and fell back to an empty list, and the page rendered as if the organisation had no campaigns at all.

Reproduced against a real pre-migration schema before changing anything.

## Cause

Requiring the migration to land before the code is a deployment-ordering assumption the application should not make. Any environment that deploys the app before running migrations — or that simply has not run them yet — loses the whole screen.

## Fix

The API now detects **once per pool** whether the campaign model columns exist, and shapes its SQL accordingly:

- **Reads** select the real columns when present and the legacy defaults otherwise, so the response shape the client renders is identical either way. `campaign_type` defaults to `fixed_price_sale`, and the legacy `amount` column maps onto `quantity` — the same mapping the migration performs when it backfills.
- **Writes** only touch the new columns when they exist, so creating and editing campaigns keeps working on either schema.
- A campaign type that cannot be stored yet is **logged**, not silently downgraded.
- If the detection query itself fails, the legacy shape is assumed and the answer is **not** cached, so a transient error cannot pin the API to a degraded mode.

## Verification

Run end to end against two real PostgreSQL 16 databases holding identical data — one pre-migration, one post-migration. Every endpoint succeeds on both:

| Endpoint | Pre-migration | Post-migration |
|---|---|---|
| `GET /fundraisers` | 200 | 200 |
| `GET /fundraisers/:id` | 200 | 200 |
| `POST /fundraisers` | 201 | 201 |
| `POST` (invalid payload) | 400 + field errors | 400 + field errors |
| `PUT /fundraisers/:id` | 200 | 200 |
| `GET /calendars` | 200 | 200 |
| `PUT /calendars/:id` | 200 | 200 |
| `PUT /calendars/:id/payment` | 200 | 200 |

Also confirmed the migration itself stays additive: legacy totals are byte-identical before and after, re-running it is idempotent, and the check constraints reject unknown campaign types and negative measures.

- 7 new regression tests cover the pre-migration path, including one asserting the schema is looked up once rather than per request.
- Full suite: **1398 passing**, 0 failures.
- All 9 lint scripts pass; production build succeeds.

## Note on the migration

`npm run db:migrate:base` is still needed to actually use the new campaign types (hours worked, deposit-return containers, variable amounts). It is no longer required for the screen to work: without it, campaigns behave exactly as they did before #1000.

## Files changed

- `services/fundraiserCampaigns.js` — schema detection and the SQL fragments
- `routes/fundraisers.js`, `routes/calendars.js` — schema-aware reads and writes
- `test/routes-fundraiser-campaigns.test.js` — pre-migration regression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116CrQ7QmL9SvKuGUcVyp8v

---
_Generated by [Claude Code](https://claude.ai/code/session_0116CrQ7QmL9SvKuGUcVyp8v)_