### PR TITLE
chore: rename the fundraising migration to 001_initial.sql

### DIFF
--- a/migrations/001_initial.sql
+++ b/migrations/001_initial.sql
@@ -1,4 +1,4 @@
--- 004_fundraiser_campaign_model.sql
+-- 001_initial.sql
 --
 -- Generalises fundraising campaigns beyond "unit count x fixed price".
 --

--- a/routes/fundraisers.js
+++ b/routes/fundraisers.js
@@ -307,7 +307,7 @@ module.exports = (pool, logger) => {
         // downgrading it.
         logger?.warn?.(
           `Campaign type "${values.campaign_type}" stored as "${DEFAULT_CAMPAIGN_TYPE}": ` +
-          'migration 004_fundraiser_campaign_model.sql has not been applied to this database.'
+          'migration 001_initial.sql has not been applied to this database.'
         );
       }
 

--- a/test/routes-fundraiser-campaigns.test.js
+++ b/test/routes-fundraiser-campaigns.test.js
@@ -548,7 +548,7 @@ describe('databases where migration 004 has not been applied', () => {
         campaign_type: 'hours_worked',
       });
 
-    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('004_fundraiser_campaign_model'));
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('001_initial.sql'));
   });
 
   test('a campaign can still be edited', async () => {


### PR DESCRIPTION
Renames `migrations/004_fundraiser_campaign_model.sql` to `migrations/001_initial.sql`, as requested, and updates the two places that name the file so the operator-facing message keeps pointing at a file that exists.

Git records this as a rename (99% similarity); the SQL itself is unchanged apart from its header comment.

## Two consequences, both verified against a real PostgreSQL database

**1. `migrations/` now holds two files numbered `001`.**

`001_seed_default_form_formats.js` already existed. The runner sorts by filename, so the order becomes:

```
001_initial.sql                     ← the fundraising migration
001_seed_default_form_formats.js
002_fix_parent_guardian_email_label.js
003_publish_standard_form_formats.js
```

Harmless in practice — `001_initial.sql` only touches the `fundraisers` and `fundraiser_entries` tables, so running it first changes nothing. But the number no longer identifies order on its own, which is worth knowing before the next migration is added.

**2. Databases that already applied the old filename will run it again.**

`applyMigration` tracks migrations by filename in `schema_migrations`, so a database holding `004_fundraiser_campaign_model.sql` sees `001_initial.sql` as new.

Verified on a database seeded to that exact state:

- the migration re-runs and **succeeds** — it is idempotent (`ADD COLUMN IF NOT EXISTS`, `DROP CONSTRAINT IF EXISTS`);
- `schema_migrations` ends up holding both names;
- the one visible effect is the backfill `UPDATE fundraiser_entries SET quantity = amount WHERE quantity IS NULL`, which repopulates any row whose `quantity` was deliberately cleared after the first run. Observed directly: a cleared `quantity` went back to `12.00` from the legacy `amount`.

That last point is narrow and non-destructive — it restores the legacy unit count rather than losing anything — but it is a real behaviour change on already-migrated databases, so it is recorded here rather than left to be discovered.

## Verification

- Migration applied cleanly on a fresh legacy schema: campaigns default to `fixed_price_sale`, `quantity` backfilled from the legacy count.
- Full suite: **1398 passing**, 0 failures.
- All 9 lint scripts pass; production build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116CrQ7QmL9SvKuGUcVyp8v

---
_Generated by [Claude Code](https://claude.ai/code/session_0116CrQ7QmL9SvKuGUcVyp8v)_