### PR TITLE
feat: run database migrations as part of deployment

### DIFF
--- a/.replit
+++ b/.replit
@@ -8,7 +8,7 @@ channel = "stable-22_11"
 
 [deployment]
 deploymentTarget = "autoscale"
-run = "npm run start:prod"
+run = "npm run deploy:start"
 build = "npm install && npm run build"
 
 [[ports]]

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "analyze": "ANALYZE=true vite build",
     "start": "node api.js",
     "start:prod": "NODE_ENV=production node api.js",
+    "db:migrate:deploy": "node scripts/deploy-migrate.js",
+    "deploy:start": "npm run db:migrate:deploy && npm run start:prod",
     "postinstall": "npm rebuild bcrypt --build-from-source",
     "test": "jest",
     "test:stories": "jest test/user-stories",

--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,25 @@ Database changes live in `migrations/` as SQL or JavaScript migrations. Use
 migrations must export `up(client, context)` and are useful for parameterized,
 data-driven catalog changes.
 
+### Migrations on deploy
+
+Deployments run migrations before the server starts. The deployment run command
+is `npm run deploy:start`, which is `npm run db:migrate:deploy` followed by
+`npm run start:prod`, so an instance never serves traffic against a schema older
+than the code it is running.
+
+`npm run db:migrate:deploy` is safe on the autoscale target, where the run
+command executes on every instance:
+
+* migrations are serialised by a transaction-scoped advisory lock, so instances
+  booting at the same time queue instead of racing each other;
+* the run is a single transaction, so a failing migration rolls back and leaves
+  the schema untouched;
+* a failure exits non-zero, which stops the instance from starting rather than
+  letting it serve requests against a half-migrated database.
+
+Re-running is a no-op once the schema is current.
+
 ## Common commands
 
 ```bash

--- a/scripts/deploy-migrate.js
+++ b/scripts/deploy-migrate.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * Deployment migration step.
+ *
+ * Runs before the server starts so a deploy can never serve traffic against a
+ * schema older than the code that was just shipped. That mismatch is not
+ * hypothetical: shipping code that referenced new columns before the migration
+ * had run took the fundraising campaigns screen down entirely.
+ *
+ * Designed for the autoscale deployment target, where the start command runs on
+ * every instance and several can boot simultaneously:
+ *
+ *   * migrations are serialised by a transaction-scoped advisory lock, so
+ *     concurrent instances queue rather than race;
+ *   * the whole run is one transaction — a failing migration rolls back and
+ *     leaves the schema untouched;
+ *   * a failure exits non-zero, so the instance does not start against a
+ *     half-migrated database. A loud failed deploy beats a quiet broken app.
+ *
+ * Usage: node scripts/deploy-migrate.js
+ */
+
+'use strict';
+
+require('dotenv').config();
+
+const { Pool } = require('pg');
+const { applyBaseMigrations } = require('./run-base-migrations');
+
+/**
+ * Apply every checked-in migration, then report what changed.
+ *
+ * @returns {Promise<void>} Resolves once migrations are committed
+ */
+async function migrateForDeploy() {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error('DATABASE_URL must be configured to run deployment migrations');
+  }
+
+  const pool = new Pool({
+    connectionString: databaseUrl,
+    ssl: databaseUrl.includes('sslmode=require') ? { rejectUnauthorized: false } : false,
+  });
+
+  const client = await pool.connect();
+  const startedAt = Date.now();
+
+  try {
+    await client.query('BEGIN');
+    const results = await applyBaseMigrations(client);
+    await client.query('COMMIT');
+
+    const applied = results.filter((result) => result.changed);
+    const elapsedMs = Date.now() - startedAt;
+
+    if (applied.length === 0) {
+      console.log(`[deploy-migrate] Schema already up to date (${results.length} migrations checked, ${elapsedMs}ms)`);
+      return;
+    }
+
+    console.log(`[deploy-migrate] Applied ${applied.length} migration(s) in ${elapsedMs}ms:`);
+    applied.forEach((result) => console.log(`[deploy-migrate]   + ${result.migrationFile}`));
+  } catch (error) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw error;
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+if (require.main === module) {
+  migrateForDeploy().catch((error) => {
+    // Fail the deploy rather than booting against an unmigrated schema.
+    console.error(`[deploy-migrate] FAILED: ${error.message}`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = { migrateForDeploy };

--- a/scripts/run-base-migrations.js
+++ b/scripts/run-base-migrations.js
@@ -10,8 +10,36 @@ const { applyMigration } = require('./run-migration');
 
 const migrationsDirectory = path.resolve(__dirname, '..', 'migrations');
 
-/** Apply all checked-in database migrations in filename order. */
+/**
+ * Advisory lock key serialising migration runs across processes.
+ *
+ * The deployment target is autoscale, so the start command runs on every
+ * instance and several can boot at once. Without this lock, concurrent runners
+ * each see a migration as unapplied and race to apply it: observed failures
+ * include `duplicate key value violates unique constraint
+ * "pg_type_typname_nsp_index"` from two transactions creating the same object,
+ * which would leave those instances unable to start.
+ *
+ * The lock is transaction scoped, so PostgreSQL releases it on COMMIT or
+ * ROLLBACK even if the process dies mid-migration. Latecomers block until the
+ * winner commits, then read the updated schema_migrations and no-op.
+ */
+const MIGRATION_ADVISORY_LOCK_KEY = 8264117;
+
+/**
+ * Apply all checked-in database migrations in filename order.
+ *
+ * Must be called inside a transaction; the caller owns BEGIN/COMMIT.
+ *
+ * @param {Object} client - Connected pg client already inside a transaction
+ * @param {Object} [context] - Extra context passed to JavaScript migrations
+ * @returns {Promise<Array<{migrationFile: string, changed: boolean}>>} Per-migration outcome
+ */
 async function applyBaseMigrations(client, context = {}) {
+  // Serialise concurrent runners before reading migration state, so the
+  // "has this been applied?" check and the apply cannot interleave.
+  await client.query('SELECT pg_advisory_xact_lock($1)', [MIGRATION_ADVISORY_LOCK_KEY]);
+
   const migrationFiles = fs.readdirSync(migrationsDirectory)
     .filter((fileName) => /\.(?:js|sql)$/.test(fileName))
     .sort();
@@ -54,4 +82,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { applyBaseMigrations };
+module.exports = { applyBaseMigrations, MIGRATION_ADVISORY_LOCK_KEY };


### PR DESCRIPTION
Answers the question "is there a deployment script that runs the migration?" — there was not, and this adds one.

## What was missing

`.replit` deployed with:

```
build = "npm install && npm run build"
run   = "npm run start:prod"
```

Neither touches the database. `npm run db:migrate:base` had to be remembered and run by hand, and the readme documented it purely as a manual step.

That gap is exactly what took the fundraising campaigns screen down: code referencing the new campaign columns shipped while the migration had not been applied, and every campaign query answered 500.

## What changes

Deployments now run `npm run deploy:start` = `npm run db:migrate:deploy && npm run start:prod`. An instance never serves traffic against a schema older than the code it is running.

## The autoscale problem, and why an advisory lock

The deployment target is `autoscale`, so the run command executes on **every instance** and several can boot simultaneously. Concurrent migration runs were genuinely unsafe — measured, not assumed:

**Before** — five simultaneous runners against a fresh database:

```
C: FAILED -> duplicate key value violates unique constraint "pg_type_typname_nsp_index"
A: FAILED -> duplicate key value violates unique constraint "pg_type_typname_nsp_index"
D: OK changed=true
B: OK changed=false
E: OK changed=false
```

Two of five crashed as separate transactions raced to create the same objects. On a real deploy those instances would fail to start.

`applyBaseMigrations` now takes a **transaction-scoped advisory lock** before reading migration state, so the "has this been applied?" check and the apply cannot interleave. Latecomers block until the winner commits, then read the updated `schema_migrations` and no-op.

**After** — same five-way test:

```
C: OK changed=true
A: OK changed=false
B: OK changed=false
D: OK changed=false
E: OK changed=false
```

The lock is transaction scoped, so PostgreSQL releases it on COMMIT or ROLLBACK even if a process dies mid-migration.

## Failure is deliberately loud

- The run is a single transaction: a failing migration rolls back and leaves the schema untouched.
- The script exits non-zero, so the instance does **not** start against a half-migrated database.

Verified exit codes:

| Scenario | Exit |
|---|---|
| No `DATABASE_URL` | 1 |
| Unreachable database | 1 |
| Healthy database | 0 |
| `deploy:start` chain with a failing migration | 1 (server never reached) |

**This is a behaviour change worth being explicit about:** a migration that fails will now fail the deploy instead of letting a broken app come up. That is the intent, but it does mean a bad migration blocks boot rather than degrading quietly.

## Verified end to end

Against a database built from the checked-in full schema (126 tables):

- first run applied all four migrations and added the campaign model columns;
- second run reported `Schema already up to date (4 migrations checked)`.

Full suite: **1398 passing**. All 9 lint scripts pass; production build succeeds.

## Files

- `scripts/deploy-migrate.js` — new deployment migration entry point
- `scripts/run-base-migrations.js` — advisory lock
- `package.json` — `db:migrate:deploy`, `deploy:start`
- `.replit` — deployment run command
- `readme.md` — documents the deploy step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116CrQ7QmL9SvKuGUcVyp8v

---
_Generated by [Claude Code](https://claude.ai/code/session_0116CrQ7QmL9SvKuGUcVyp8v)_