### PR TITLE
fix: clear a campaign field's error once the user corrects it

### DIFF
--- a/spa/fundraisers.js
+++ b/spa/fundraisers.js
@@ -386,6 +386,13 @@ export class Fundraisers {
 			this.syncCampaignTypeFields();
 		});
 
+		// A validation message must not outlive the problem it describes: without
+		// this, correcting a field left "this field is required" sitting under a
+		// filled input, and aria-invalid stuck at true for screen readers.
+		const clearOnEdit = (event) => this.clearFieldError(event.target);
+		form.addEventListener('input', clearOnEdit);
+		form.addEventListener('change', clearOnEdit);
+
 		form.addEventListener('submit', async (e) => {
 			e.preventDefault();
 			await this.saveFundraiser();
@@ -493,6 +500,39 @@ export class Fundraisers {
 		form.querySelectorAll('[aria-invalid="true"]').forEach((node) => {
 			node.removeAttribute('aria-invalid');
 		});
+	}
+
+	/**
+	 * Clear the validation message for a single control.
+	 *
+	 * Called as the user edits, so a corrected field stops claiming to be
+	 * invalid, and the error summary disappears once nothing is flagged.
+	 *
+	 * @param {EventTarget|null} control - The edited form control
+	 * @returns {void}
+	 */
+	clearFieldError(control) {
+		const form = document.getElementById('fundraiser-form');
+		const fieldName = control instanceof HTMLElement ? control.getAttribute('name') : null;
+		if (!form || !fieldName) {
+			return;
+		}
+
+		const target = form.querySelector(`[data-field-error="${fieldName}"]`);
+		if (target) {
+			target.textContent = '';
+		}
+		control.removeAttribute('aria-invalid');
+
+		const stillInvalid = Array.from(form.querySelectorAll('[data-field-error]'))
+			.some((node) => node.textContent.trim() !== '');
+		if (!stillInvalid) {
+			const summary = document.getElementById('fundraiser-form-error');
+			if (summary) {
+				summary.textContent = '';
+				summary.hidden = true;
+			}
+		}
 	}
 
 	/**

--- a/test/spa/FundraiserCampaignForm.test.js
+++ b/test/spa/FundraiserCampaignForm.test.js
@@ -326,3 +326,102 @@ describe('finance terminology', () => {
     });
   });
 });
+
+describe('validation messages do not outlive the problem', () => {
+  /**
+   * The reported symptom: after a failed submit, the user corrects the field
+   * but "this field is required" stays under the now-filled input.
+   */
+  test('typing into a flagged field clears its message', async () => {
+    const { module } = setup();
+    fill({ name: '', campaign_type: 'container_deposit', start_date: '2026-08-09', end_date: '2026-08-10' });
+    await module.saveFundraiser();
+    expect(document.querySelector('[data-field-error="name"]').textContent).toBe('field_required');
+
+    const input = document.getElementById('fundraiser-name');
+    input.value = 'Test';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect(document.querySelector('[data-field-error="name"]').textContent).toBe('');
+    expect(input.hasAttribute('aria-invalid')).toBe(false);
+  });
+
+  test('correcting a select clears its message too', async () => {
+    const { module } = setup();
+    fill({ name: 'Test', campaign_type: 'container_deposit', start_date: '2026-08-10', end_date: '2026-08-09' });
+    await module.saveFundraiser();
+    expect(document.querySelector('[data-field-error="end_date"]').textContent)
+      .toBe('end_date_before_start_date');
+
+    const endDate = document.getElementById('fundraiser-end-date');
+    endDate.value = '2026-08-11';
+    endDate.dispatchEvent(new Event('change', { bubbles: true }));
+
+    expect(document.querySelector('[data-field-error="end_date"]').textContent).toBe('');
+  });
+
+  test('the summary disappears once nothing is flagged', async () => {
+    const { module } = setup();
+    fill({ name: '', campaign_type: 'container_deposit', start_date: '', end_date: '' });
+    await module.saveFundraiser();
+    const summary = document.getElementById('fundraiser-form-error');
+    expect(summary.hidden).toBe(false);
+
+    // Correct the fields one by one; the summary must survive until the last.
+    const name = document.getElementById('fundraiser-name');
+    name.value = 'Test';
+    name.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(summary.hidden).toBe(false);
+
+    const start = document.getElementById('fundraiser-start-date');
+    start.value = '2026-08-09';
+    start.dispatchEvent(new Event('change', { bubbles: true }));
+    const end = document.getElementById('fundraiser-end-date');
+    end.value = '2026-08-10';
+    end.dispatchEvent(new Event('change', { bubbles: true }));
+
+    expect(summary.hidden).toBe(true);
+    expect(summary.textContent).toBe('');
+  });
+
+  test('editing one field leaves other fields still flagged', async () => {
+    const { module } = setup();
+    fill({ name: '', campaign_type: 'container_deposit', start_date: '', end_date: '2026-08-10' });
+    await module.saveFundraiser();
+
+    const name = document.getElementById('fundraiser-name');
+    name.value = 'Test';
+    name.dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect(document.querySelector('[data-field-error="name"]').textContent).toBe('');
+    // start_date is still empty, so its message must remain.
+    expect(document.querySelector('[data-field-error="start_date"]').textContent)
+      .toBe('field_required');
+  });
+
+  test('the exact reported payload submits without a validation error', async () => {
+    const { module } = setup();
+    fill({
+      name: 'Test',
+      campaign_type: 'container_deposit',
+      start_date: '2026-08-09',
+      end_date: '2026-08-10',
+      unit_price: '.10',
+      unit_label: 'Canette',
+    });
+    module.syncCampaignTypeFields();
+
+    await module.saveFundraiser();
+
+    expect(mockCreateFundraiser).toHaveBeenCalledTimes(1);
+    expect(mockCreateFundraiser.mock.calls[0][0]).toEqual({
+      name: 'Test',
+      campaign_type: 'container_deposit',
+      start_date: '2026-08-09',
+      end_date: '2026-08-10',
+      objective: null,
+      unit_price: 0.1,
+      unit_label: 'Canette',
+    });
+  });
+});


### PR DESCRIPTION
The campaign form showed "Ce champ est obligatoire" under a field that visibly contained a value.

## What actually happens

The submit path is **not** broken. Reproduced with the exact data from the report — deposit-return containers, unit price `.10`, unit label `Canette` — the payload builds and sends correctly:

```json
{"name":"Test","campaign_type":"container_deposit","start_date":"2026-08-09",
 "end_date":"2026-08-10","objective":null,"unit_price":0.1,"unit_label":"Canette"}
```

The real fault is that a validation message outlives the problem it describes:

| Step | Message under the name field | `aria-invalid` |
|---|---|---|
| Submit with an empty name | `field_required` — correct | `true` |
| User types "Test" | `field_required` — **wrong** | `true` — **wrong** |

Nothing cleared the message until the next submit or until the modal was reopened, so the form kept accusing a field the user had already fixed. That is exactly the screenshot: a filled "nom" with a required-field error beneath it.

It is an accessibility defect too — `aria-invalid="true"` stuck on a valid field misreports its state to screen readers.

## Fix

Messages now clear as the field is edited. An `input` or `change` on a control drops that control's message and its `aria-invalid` flag, and the error summary is hidden once nothing is flagged. Fields that are still wrong keep their own messages — correcting one field does not hide the others.

## Tests

Five regression tests added, covering the reported sequence and its edges:

- typing into a flagged field clears its message and `aria-invalid`;
- correcting a date via `change` clears its message;
- the summary survives until the **last** flagged field is fixed, then disappears;
- fixing one field leaves the others still flagged;
- the exact reported payload submits with no validation error.

Full suite: **1403 passing**, 0 failures. All 9 lint scripts pass; production build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116CrQ7QmL9SvKuGUcVyp8v

---
_Generated by [Claude Code](https://claude.ai/code/session_0116CrQ7QmL9SvKuGUcVyp8v)_