### PR TITLE
fix: bound cache invalidation to the mutated collection, 204 on delete

### DIFF
--- a/routes/fundraisers.js
+++ b/routes/fundraisers.js
@@ -619,8 +619,8 @@ module.exports = (pool, logger) => {
    *         schema:
    *           type: integer
    *     responses:
-   *       200:
-   *         description: Campaign deleted
+   *       204:
+   *         description: Campaign deleted (no content)
    *       404:
    *         description: Campaign not found
    *       409:
@@ -678,7 +678,9 @@ module.exports = (pool, logger) => {
       await client.query('COMMIT');
 
       logger?.info?.(`Fundraiser deleted: ${id} for organization ${organizationId}`);
-      return success(res, null, 'Fundraiser deleted');
+      // 204 No Content is the contract for a successful DELETE; the SPA
+      // response handler already maps it to { success: true, data: null }.
+      return res.status(204).end();
     } catch (deleteError) {
       await client.query('ROLLBACK');
       throw deleteError;

--- a/spa/api/api-core.js
+++ b/spa/api/api-core.js
@@ -10,7 +10,12 @@ import { CONFIG } from "../config.js";
 import { debugLog, debugError, debugWarn } from "../utils/DebugUtils.js";
 import { getCurrentOrganizationId, getAuthHeader } from "./api-helpers.js";
 import { PerformanceMonitor } from "../utils/PerformanceUtils.js";
-import { buildApiCacheKey, buildScopedCacheKey, normalizeApiPath } from "../utils/OfflineCacheKeys.js";
+import {
+    buildApiCacheKey,
+    buildScopedCacheKey,
+    cachePathsForMutation,
+    normalizeApiPath
+} from "../utils/OfflineCacheKeys.js";
 
 /**
  * Add cache buster parameter to URL
@@ -170,18 +175,11 @@ import { isArchiveMode } from "../modules/scout-year/ScoutYearContext.js";
  */
 async function invalidateCachedResource(endpoint) {
     try {
-        const path = normalizeApiPath(endpoint);
-        const paths = new Set([path]);
-
-        // Walk up one segment at a time so /api/v1/fundraisers/7/archive also
-        // clears /api/v1/fundraisers/7 and /api/v1/fundraisers.
-        let parent = path;
-        while (parent.lastIndexOf('/') > '/api'.length) {
-            parent = parent.slice(0, parent.lastIndexOf('/'));
-            paths.add(parent);
+        const paths = cachePathsForMutation(normalizeApiPath(endpoint));
+        if (paths.length === 0) {
+            return;
         }
-
-        await clearCachedApiPaths([...paths]);
+        await clearCachedApiPaths(paths);
     } catch (error) {
         // A failed invalidation must never fail the mutation the user just made.
         debugWarn('Cache invalidation after mutation failed:', error);

--- a/spa/utils/OfflineCacheKeys.js
+++ b/spa/utils/OfflineCacheKeys.js
@@ -47,6 +47,41 @@ export function normalizeApiPath(endpointOrUrl) {
 }
 
 /**
+ * Cache paths to drop for a mutated endpoint: the resource itself and each
+ * ancestor down to — but never above — its collection.
+ *
+ * Stopping at the collection matters. `clearCachedApiPaths` prefix-matches
+ * sub-paths, so including `/api/v1` would match every URL-derived cache key
+ * and turn each successful write into a full cache flush. Offline that is
+ * destructive rather than merely wasteful: a queued attendance update would
+ * erase the cached participants and groups that cannot be refetched until the
+ * connection returns.
+ *
+ * @param {string} path - Normalized API path, e.g. "/api/v1/fundraisers/7/archive"
+ * @returns {string[]} Paths to invalidate, widest last; empty when the path
+ *   does not identify a resource
+ */
+export function cachePathsForMutation(path) {
+    const segments = path.split('/').filter(Boolean);
+
+    // "/api/v1/fundraisers" -> keep api + v1 + collection.
+    // "/api/offline-sync"   -> keep api + collection.
+    const isVersioned = /^v\d+$/i.test(segments[1] || '');
+    const collectionDepth = isVersioned ? 3 : 2;
+
+    if (segments.length < collectionDepth) {
+        // Not a resource path (e.g. "/api/v1"); nothing safe to invalidate.
+        return [];
+    }
+
+    const paths = [];
+    for (let depth = segments.length; depth >= collectionDepth; depth -= 1) {
+        paths.push(`/${segments.slice(0, depth).join('/')}`);
+    }
+    return paths;
+}
+
+/**
  * Build a deterministic cache key for API responses.
  * Uses normalized path and sorted query parameters.
  *

--- a/test/routes-fundraiser-campaigns.test.js
+++ b/test/routes-fundraiser-campaigns.test.js
@@ -650,8 +650,10 @@ describe('DELETE /api/v1/fundraisers/:id', () => {
       .delete(`/api/v1/fundraisers/${FUNDRAISER_ID}`)
       .set('Authorization', `Bearer ${token()}`);
 
-    expect(response.status).toBe(200);
-    expect(response.body.success).toBe(true);
+    // The REST contract for a successful DELETE is 204 with no body.
+    expect(response.status).toBe(204);
+    expect(response.body).toEqual({});
+    expect(response.text).toBe('');
     // Entries go first so no orphans are left behind, and it commits.
     expect(statements).toEqual(expect.arrayContaining([
       expect.stringContaining('DELETE FROM fundraiser_entries'),

--- a/test/spa/ApiCacheInvalidation.test.js
+++ b/test/spa/ApiCacheInvalidation.test.js
@@ -39,7 +39,12 @@ import {
   clearCachedApiPaths,
   clearFundraiserRelatedCaches,
 } from '../../spa/indexedDB.js';
-import { buildApiCacheKey, buildScopedCacheKey, normalizeApiPath } from '../../spa/utils/OfflineCacheKeys.js';
+import {
+  buildApiCacheKey,
+  buildScopedCacheKey,
+  cachePathsForMutation,
+  normalizeApiPath,
+} from '../../spa/utils/OfflineCacheKeys.js';
 
 const ONE_HOUR = 60 * 60 * 1000;
 
@@ -150,5 +155,65 @@ describe('normalizeApiPath', () => {
     ['v1/fundraisers/', '/api/v1/fundraisers'],
   ])('%s -> %s', (input, expected) => {
     expect(normalizeApiPath(input)).toBe(expected);
+  });
+});
+
+describe('how far a mutation invalidates', () => {
+  test.each([
+    ['/api/v1/fundraisers', ['/api/v1/fundraisers']],
+    ['/api/v1/fundraisers/7', ['/api/v1/fundraisers/7', '/api/v1/fundraisers']],
+    [
+      '/api/v1/fundraisers/7/archive',
+      ['/api/v1/fundraisers/7/archive', '/api/v1/fundraisers/7', '/api/v1/fundraisers'],
+    ],
+    ['/api/offline-sync', ['/api/offline-sync']],
+  ])('%s invalidates %j', (path, expected) => {
+    expect(cachePathsForMutation(path)).toEqual(expected);
+  });
+
+  test('never reaches the version root, which would match every cached key', () => {
+    const everyPath = [
+      '/api/v1/fundraisers/7/archive',
+      '/api/v1/attendance',
+      '/api/v1/participants/9',
+    ].flatMap((path) => cachePathsForMutation(path));
+
+    expect(everyPath).not.toContain('/api/v1');
+    expect(everyPath).not.toContain('/api');
+  });
+
+  test('a path that identifies no resource invalidates nothing', () => {
+    expect(cachePathsForMutation('/api/v1')).toEqual([]);
+    expect(cachePathsForMutation('/api')).toEqual([]);
+  });
+
+  test('one resource write leaves every other resource cached', async () => {
+    const cached = {};
+    for (const endpoint of ['v1/participants', 'v1/groups', 'v1/attendance', 'v1/badges']) {
+      cached[endpoint] = await cacheAsApiGetWould(endpoint, {}, { success: true });
+    }
+    const target = await cacheAsApiGetWould('v1/fundraisers', { include_archived: true }, { success: true });
+
+    // Exactly what a successful write to the campaign resource clears.
+    await clearCachedApiPaths(cachePathsForMutation('/api/v1/fundraisers/7'));
+
+    expect(await getCachedData(target)).toBeNull();
+    for (const [endpoint, key] of Object.entries(cached)) {
+      expect(await getCachedData(key)).not.toBeNull();
+      expect(endpoint).toBeDefined();
+    }
+  });
+
+  test('an offline attendance write does not erase participants or groups', async () => {
+    // The destructive case: offline, these caches cannot be refetched.
+    const participants = await cacheAsApiGetWould('v1/participants', {}, { success: true });
+    const groups = await cacheAsApiGetWould('v1/groups', {}, { success: true });
+    const attendance = await cacheAsApiGetWould('v1/attendance', { date: '2026-08-09' }, { success: true });
+
+    await clearCachedApiPaths(cachePathsForMutation('/api/v1/attendance'));
+
+    expect(await getCachedData(attendance)).toBeNull();
+    expect(await getCachedData(participants)).not.toBeNull();
+    expect(await getCachedData(groups)).not.toBeNull();
   });
 });


### PR DESCRIPTION
Addresses both review findings on #1007. Both confirmed by reproduction before changing anything.

## 1. Invalidation walked too far up

The loop stopped at `'/api'.length`, so every mutation path also yielded `/api/v1`:

```
/api/v1/attendance            -> ["/api/v1/attendance", "/api/v1"]
/api/v1/fundraisers/7/archive -> [..., "/api/v1/fundraisers", "/api/v1"]
```

One correction to the report: `/api` itself was **not** reached — the loop terminates one level earlier. But `/api/v1` alone is enough. `clearCachedApiPaths` prefix-matches sub-paths and every endpoint is versioned, so that single entry matched every URL-derived cache key.

Measured blast radius of one `v1/attendance` write:

```
v1/participants    *** WIPED ***
v1/groups          *** WIPED ***
v1/attendance      *** WIPED ***
v1/fundraisers     *** WIPED ***
v1/badges          *** WIPED ***
```

Offline this is destructive rather than merely wasteful: a queued attendance update erases data the client cannot refetch until the connection returns.

**Fix.** The walk now stops at the collection — `/api/<version>/<collection>` when versioned, `/api/<collection>` otherwise:

| Mutated path | Invalidates |
|---|---|
| `/api/v1/fundraisers` | `/api/v1/fundraisers` |
| `/api/v1/fundraisers/7` | `…/7`, `/api/v1/fundraisers` |
| `/api/v1/fundraisers/7/archive` | `…/archive`, `…/7`, `/api/v1/fundraisers` |
| `/api/v1` | *(nothing)* |

A path that identifies no resource now invalidates **nothing** rather than everything. Editing an item still refreshes the list that shows it.

The helper moved to `OfflineCacheKeys.js` beside the other cache-key logic — it is a cache-key concern, not a request concern, and it can then be asserted directly without pulling api-core's import graph (and its `import.meta`) into a test.

## 2. DELETE now returns 204

`success()` always sends a JSON body with 200. The contract in CLAUDE.md is 204 No Content for a successful DELETE, and `handleResponse` in `api-core.js` already maps 204 to `{ success: true, data: null }` — so the SPA needed no change. The route now returns `res.status(204).end()`; the OpenAPI block and the route test were updated, the test asserting both an empty body and empty text.

## Tests

Seven tests pin the invalidation scope, including the two destructive cases explicitly:

- one resource write leaves every other resource cached;
- an offline attendance write does not erase participants or groups;
- no generated path ever contains `/api/v1` or `/api`.

Verified by restoring the old walk — all three targeted assertions fail.

Full suite: **1432 passing**. All 9 lint scripts pass; production build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116CrQ7QmL9SvKuGUcVyp8v

---
_Generated by [Claude Code](https://claude.ai/code/session_0116CrQ7QmL9SvKuGUcVyp8v)_